### PR TITLE
feat(keeper): implement event-driven task registry discovery

### DIFF
--- a/keeper/.env.example
+++ b/keeper/.env.example
@@ -14,11 +14,8 @@ MAX_CONCURRENT_READS=10
 MAX_CONCURRENT_EXECUTIONS=3
 
 # Task Registry Configuration
-# Option 1: Check all tasks from 1 to MAX_TASK_ID
-MAX_TASK_ID=100
-
-# Option 2: Check specific task IDs (comma-separated)
-# TASK_IDS=1,2,3,5,8
+# Ledger to start scanning TaskRegistered events from (0 = auto-detect)
+START_LEDGER=0
 
 # Execution Configuration
 WAIT_FOR_CONFIRMATION=true

--- a/keeper/__tests__/registry.test.js
+++ b/keeper/__tests__/registry.test.js
@@ -1,0 +1,133 @@
+const fs = require('fs');
+const path = require('path');
+const { xdr } = require('@stellar/stellar-sdk');
+
+// Mock fs so we don't touch the real filesystem
+jest.mock('fs');
+
+const TaskRegistry = require('../src/registry');
+
+function makeTaskRegisteredEvent(taskId, ledger) {
+    // topic[0] = Symbol("TaskRegistered"), topic[1] = u64 task_id
+    const topic0 = xdr.ScVal.scvSymbol('TaskRegistered').toXDR('base64');
+    const topic1 = xdr.ScVal.scvU64(xdr.Uint64.fromString(String(taskId))).toXDR('base64');
+    return {
+        topic: [topic0, topic1],
+        ledger,
+    };
+}
+
+function mockServer(events = []) {
+    return {
+        getLatestLedger: jest.fn().mockResolvedValue({ sequence: 1000 }),
+        getEvents: jest.fn().mockResolvedValue({ events }),
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(false);
+    fs.mkdirSync.mockReturnValue(undefined);
+    fs.writeFileSync.mockReturnValue(undefined);
+});
+
+describe('TaskRegistry', () => {
+    test('discovers task IDs from events on init', async () => {
+        const events = [
+            makeTaskRegisteredEvent(1, 900),
+            makeTaskRegisteredEvent(2, 910),
+            makeTaskRegisteredEvent(3, 920),
+        ];
+        const server = mockServer(events);
+        const registry = new TaskRegistry(server, 'CABC123', { startLedger: 800 });
+
+        await registry.init();
+
+        expect(registry.getTaskIds()).toEqual([1, 2, 3]);
+        expect(server.getEvents).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns empty array when no events exist', async () => {
+        const server = mockServer([]);
+        const registry = new TaskRegistry(server, 'CABC123', { startLedger: 800 });
+
+        await registry.init();
+
+        expect(registry.getTaskIds()).toEqual([]);
+    });
+
+    test('deduplicates task IDs', async () => {
+        const events = [
+            makeTaskRegisteredEvent(1, 900),
+            makeTaskRegisteredEvent(1, 910),
+        ];
+        const server = mockServer(events);
+        const registry = new TaskRegistry(server, 'CABC123', { startLedger: 800 });
+
+        await registry.init();
+
+        expect(registry.getTaskIds()).toEqual([1]);
+    });
+
+    test('poll discovers new tasks', async () => {
+        const server = mockServer([makeTaskRegisteredEvent(1, 900)]);
+        const registry = new TaskRegistry(server, 'CABC123', { startLedger: 800 });
+        await registry.init();
+
+        // Simulate new events on next poll
+        server.getEvents.mockResolvedValueOnce({
+            events: [makeTaskRegisteredEvent(4, 950)],
+        });
+
+        await registry.poll();
+
+        expect(registry.getTaskIds()).toEqual([1, 4]);
+    });
+
+    test('persists task IDs to disk', async () => {
+        const server = mockServer([makeTaskRegisteredEvent(5, 900)]);
+        const registry = new TaskRegistry(server, 'CABC123', { startLedger: 800 });
+
+        await registry.init();
+
+        expect(fs.writeFileSync).toHaveBeenCalled();
+        const writtenData = JSON.parse(fs.writeFileSync.mock.calls[0][1]);
+        expect(writtenData.taskIds).toEqual([5]);
+        expect(writtenData.lastSeenLedger).toBe(900);
+    });
+
+    test('loads persisted state from disk', async () => {
+        fs.existsSync.mockReturnValue(true);
+        fs.readFileSync.mockReturnValue(JSON.stringify({
+            taskIds: [10, 20],
+            lastSeenLedger: 500,
+        }));
+
+        const server = mockServer([]);
+        const registry = new TaskRegistry(server, 'CABC123');
+
+        expect(registry.getTaskIds()).toEqual([10, 20]);
+    });
+
+    test('handles RPC errors gracefully', async () => {
+        const server = {
+            getLatestLedger: jest.fn().mockResolvedValue({ sequence: 1000 }),
+            getEvents: jest.fn().mockRejectedValue(new Error('RPC unavailable')),
+        };
+        const registry = new TaskRegistry(server, 'CABC123', { startLedger: 800 });
+
+        // Should not throw
+        await registry.init();
+
+        expect(registry.getTaskIds()).toEqual([]);
+    });
+
+    test('auto-detects start ledger when none provided', async () => {
+        const server = mockServer([]);
+        const registry = new TaskRegistry(server, 'CABC123');
+
+        await registry.init();
+
+        expect(server.getLatestLedger).toHaveBeenCalled();
+    });
+});

--- a/keeper/index.js
+++ b/keeper/index.js
@@ -6,6 +6,7 @@ const { loadConfig } = require('./src/config');
 const { initializeKeeperAccount } = require('./src/account');
 const { ExecutionQueue } = require('./src/queue');
 const TaskPoller = require('./src/poller');
+const TaskRegistry = require('./src/registry');
 
 async function main() {
     console.log("Starting SoroTask Keeper...");
@@ -97,22 +98,11 @@ async function main() {
         }
     };
 
-    // Get task registry - in production, this would query the contract for all registered task IDs
-    const getTaskRegistry = async () => {
-        // Option 1: Use environment variable for known task IDs
-        if (process.env.TASK_IDS) {
-            return process.env.TASK_IDS.split(',').map(id => parseInt(id.trim(), 10));
-        }
-
-        // Option 2: Default range (can be improved by querying events or contract counter)
-        try {
-            const maxTaskId = parseInt(process.env.MAX_TASK_ID || 10, 10);
-            return Array.from({ length: maxTaskId }, (_, i) => i + 1);
-        } catch (error) {
-            console.warn('[Registry] Could not determine task range');
-            return [];
-        }
-    };
+    // Initialize event-driven task registry
+    const registry = new TaskRegistry(server, config.contractId, {
+        startLedger: parseInt(process.env.START_LEDGER || '0', 10)
+    });
+    await registry.init();
 
     // Polling loop
     const pollingIntervalMs = config.pollIntervalMs;
@@ -122,8 +112,11 @@ async function main() {
         try {
             console.log('\n[Keeper] ===== Starting new polling cycle =====');
 
+            // Poll for new TaskRegistered events
+            await registry.poll();
+
             // Get list of all registered task IDs
-            const taskIds = await getTaskRegistry();
+            const taskIds = registry.getTaskIds();
             console.log(`[Keeper] Checking ${taskIds.length} tasks...`);
 
             // Poll for due tasks
@@ -159,7 +152,7 @@ async function main() {
     console.log('[Keeper] Running initial poll...');
     setTimeout(async () => {
         try {
-            const taskIds = await getTaskRegistry();
+            const taskIds = registry.getTaskIds();
             const dueTaskIds = await poller.pollDueTasks(taskIds);
             if (dueTaskIds.length > 0) {
                 await queue.enqueue(dueTaskIds, executeTask);

--- a/keeper/package-lock.json
+++ b/keeper/package-lock.json
@@ -2869,53 +2869,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bare-addon-resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
-      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-module-resolve": "^1.10.0",
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
-      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -5698,32 +5651,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sodium-native": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
-      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "require-addon": "^1.1.0"
-      }
-    },
-    "node_modules/soroban-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/soroban-client/-/soroban-client-1.0.1.tgz",
-      "integrity": "sha512-GdLgMuJ/riVnLvjEXFi7NqSwAZXsT6H55vITq5c+v15rTlbzGXvW2v/yA+K1zOXMFh0JAZ1IR+6S4CJMQXOcPA==",
-      "deprecated": "⚠️ This package is now deprecated: transition to @stellar/stellar-sdk@latest, instead! 🚚 All future updates and bug fixes will happen there. Please refer to the migration guide for details on porting your codebase: https://github.com/stellar/js-soroban-client/tree/main/docs/migration.md",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.6.0",
-        "bignumber.js": "^9.1.1",
-        "buffer": "^6.0.3",
-        "stellar-base": "10.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5763,25 +5690,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/stellar-base": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/stellar-base/-/stellar-base-10.0.0.tgz",
-      "integrity": "sha512-WQhxGXQLSwwmIxWbZqv0HcJtlSOiaUgv7yKCCEwP+OoYDHKBjPjQiZWyAkuEY+mRFX9L+hnejLaBorc3P2rk0g==",
-      "deprecated": "⚠️ This package has moved to @stellar/stellar-base! 🚚",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.0.1",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.0.1"
       }
     },
     "node_modules/string-length": {
@@ -5945,13 +5853,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
-    },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true,
-      "license": "Unlicense"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/keeper/src/registry.js
+++ b/keeper/src/registry.js
@@ -1,9 +1,180 @@
-export function createRegistry() {
-  const tasks = new Set();
+const fs = require('fs');
+const path = require('path');
+const { xdr } = require('@stellar/stellar-sdk');
 
-  return {
-    has: (id) => tasks.has(id),
-    add: (id) => tasks.add(id),
-    remove: (id) => tasks.delete(id),
-  };
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const TASKS_FILE = path.join(DATA_DIR, 'tasks.json');
+
+class TaskRegistry {
+    constructor(server, contractId, options = {}) {
+        this.server = server;
+        this.contractId = contractId;
+        this.taskIds = new Set();
+        this.lastSeenLedger = options.startLedger || 0;
+        this._ensureDataDir();
+        this._loadFromDisk();
+    }
+
+    /**
+     * Initialize the registry: load persisted state, then backfill any
+     * historical events we may have missed since the last run.
+     */
+    async init() {
+        console.log('[Registry] Initializing task registry...');
+        await this._fetchEvents();
+        console.log(`[Registry] Initialized with ${this.taskIds.size} task(s)`);
+    }
+
+    /**
+     * Poll for new TaskRegistered events since last seen ledger.
+     * Call this on every polling cycle.
+     */
+    async poll() {
+        await this._fetchEvents();
+    }
+
+    /**
+     * Return the current list of known task IDs.
+     * @returns {number[]}
+     */
+    getTaskIds() {
+        return Array.from(this.taskIds).sort((a, b) => a - b);
+    }
+
+    // ---- internal ----
+
+    async _fetchEvents() {
+        try {
+            // We need a valid startLedger. If we don't have one, grab the latest.
+            if (!this.lastSeenLedger) {
+                const info = await this.server.getLatestLedger();
+                // Look back a reasonable window (default ~1 hour on testnet ≈ 720 ledgers)
+                this.lastSeenLedger = Math.max(info.sequence - 720, 0);
+            }
+
+            const contractId = this.contractId;
+
+            // Fetch events page by page
+            let cursor = undefined;
+            let hasMore = true;
+
+            while (hasMore) {
+                const params = {
+                    startLedger: cursor ? undefined : this.lastSeenLedger,
+                    filters: [
+                        {
+                            type: 'contract',
+                            contractIds: [contractId],
+                            topics: [
+                                ['AAAADwAAAA9UYXNrUmVnaXN0ZXJlZAA=', '*']  // Symbol("TaskRegistered"), *
+                            ]
+                        }
+                    ],
+                    limit: 100,
+                };
+
+                if (cursor) {
+                    params.cursor = cursor;
+                    delete params.startLedger;
+                }
+
+                const response = await this.server.getEvents(params);
+
+                if (!response || !response.events || response.events.length === 0) {
+                    hasMore = false;
+                    break;
+                }
+
+                for (const event of response.events) {
+                    try {
+                        const taskId = this._extractTaskId(event);
+                        if (taskId !== null && !this.taskIds.has(taskId)) {
+                            this.taskIds.add(taskId);
+                            console.log(`[Registry] Discovered task ID: ${taskId}`);
+                        }
+                    } catch (err) {
+                        console.warn(`[Registry] Failed to decode event: ${err.message}`);
+                    }
+
+                    // Track the latest ledger we've processed
+                    if (event.ledger && event.ledger > this.lastSeenLedger) {
+                        this.lastSeenLedger = event.ledger;
+                    }
+                }
+
+                // If we got fewer events than the limit, we're done
+                if (response.events.length < 100) {
+                    hasMore = false;
+                } else {
+                    cursor = response.cursor || response.events[response.events.length - 1].pagingToken;
+                }
+            }
+
+            this._saveToDisk();
+        } catch (err) {
+            // Don't crash on transient RPC errors — just log and keep going
+            console.error(`[Registry] Error fetching events: ${err.message}`);
+        }
+    }
+
+    /**
+     * Extract the u64 task ID from the second topic of a TaskRegistered event.
+     */
+    _extractTaskId(event) {
+        // event.topic is an array of base64-encoded XDR ScVal values
+        // topic[0] = Symbol("TaskRegistered"), topic[1] = task_id (u64)
+        if (!event.topic || event.topic.length < 2) {
+            return null;
+        }
+
+        const taskIdXdr = event.topic[1];
+
+        // The topic values come as base64-encoded XDR
+        const scVal = xdr.ScVal.fromXDR(taskIdXdr, 'base64');
+
+        // Extract the u64 value
+        if (scVal.switch().name === 'scvU64') {
+            return Number(scVal.u64());
+        }
+
+        return null;
+    }
+
+    _ensureDataDir() {
+        if (!fs.existsSync(DATA_DIR)) {
+            fs.mkdirSync(DATA_DIR, { recursive: true });
+        }
+    }
+
+    _loadFromDisk() {
+        try {
+            if (fs.existsSync(TASKS_FILE)) {
+                const data = JSON.parse(fs.readFileSync(TASKS_FILE, 'utf-8'));
+                if (Array.isArray(data.taskIds)) {
+                    data.taskIds.forEach(id => this.taskIds.add(id));
+                }
+                if (data.lastSeenLedger && data.lastSeenLedger > this.lastSeenLedger) {
+                    this.lastSeenLedger = data.lastSeenLedger;
+                }
+                console.log(`[Registry] Loaded ${this.taskIds.size} task(s) from disk (ledger: ${this.lastSeenLedger})`);
+            }
+        } catch (err) {
+            console.warn(`[Registry] Could not load persisted tasks: ${err.message}`);
+        }
+    }
+
+    _saveToDisk() {
+        try {
+            const data = {
+                taskIds: Array.from(this.taskIds).sort((a, b) => a - b),
+                lastSeenLedger: this.lastSeenLedger,
+                updatedAt: new Date().toISOString()
+            };
+            fs.writeFileSync(TASKS_FILE, JSON.stringify(data, null, 2));
+        } catch (err) {
+            console.warn(`[Registry] Could not persist tasks: ${err.message}`);
+        }
+    }
 }
+
+module.exports = TaskRegistry;


### PR DESCRIPTION
## Summary

- Replace static task ID configuration with dynamic event-based discovery
- Add TaskRegistry class to scan TaskRegistered events from Stellar ledger
- Implement automatic ledger detection when START_LEDGER not configured
- Add persistence layer to cache discovered task IDs and last seen ledger
- Update .env.example to use START_LEDGER instead of MAX_TASK_ID/TASK_IDS
- Add comprehensive test suite for registry initialization, polling, and error handling
- Integrate registry into main keeper loop for continuous task discovery
- Remove legacy getTaskRegistry function that relied on static configuration

closes #34 