### PR TITLE
fix(#68): add GitHub issue templates for bug reports and feature requ…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a bug to help us improve SoroTask
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Screenshots / Logs
+
+If applicable, add screenshots or paste relevant log output to help explain the problem.
+
+## Environment
+
+- **Component**: (Contract / Keeper / Frontend)
+- **OS**: (e.g. Ubuntu 22.04, Windows 11)
+- **Node.js version**: (if applicable)
+- **Rust version**: (if applicable)
+- **Soroban SDK version**: (if applicable)
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for SoroTask
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear and concise description of the problem this feature would solve. E.g. "I'm always frustrated when..."
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A description of any alternative solutions or features you've considered.
+
+## Component
+
+Which part of SoroTask does this affect?
+
+- [ ] Smart Contract (`/contract`)
+- [ ] Keeper Bot (`/keeper`)
+- [ ] Frontend Dashboard (`/frontend`)
+- [ ] CI/CD / DevOps
+- [ ] Documentation
+- [ ] Other
+
+## Additional Context
+
+Add any other context, mockups, or references about the feature request here.


### PR DESCRIPTION
## Summary

Add standard GitHub issue templates for bug reports and feature requests. The repository was missing these templates, making it difficult for contributors to provide structured feedback.

## Related Issue

Closes #68 

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Documentation

## Changes Made

- Created `.github/ISSUE_TEMPLATE/bug_report.md` with sections for description, reproduction steps, expected/actual behavior, logs, and environment info
- Created `.github/ISSUE_TEMPLATE/feature_request.md` with sections for problem statement, proposed solution, alternatives, and component checklist

## Validation

- [ ] `cargo fmt --all` (if `contract` changed)
- [ ] `npm run lint` in `frontend` (if `frontend` changed)
- [x] Manual verification completed

## Screenshots (if UI changes)

N/A — no UI changes.

## Checklist

- [x] Scope is focused and avoids unrelated changes
- [x] Commit messages are clear
- [x] Documentation updated when needed
- [x] ETA was provided when requesting assignment for the linked issue

Closes #68 
