### PR TITLE
feat(frontend): add error boundaries to prevent full-app crashes

### DIFF
--- a/frontend/app/components/ErrorBoundary.tsx
+++ b/frontend/app/components/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  section?: string;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack: string }) {
+    const { section } = this.props;
+    // Log with context so it's easy to trace in dev tools / monitoring
+    console.error("[ErrorBoundary]", {
+      section: section ?? "unknown",
+      message: error.message,
+      // Avoid leaking full stack to any external sink; keep it local
+      componentStack: info.componentStack,
+    });
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (!error) return children;
+
+    if (fallback) return fallback;
+
+    return (
+      <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-6 text-sm text-red-400 space-y-3">
+        <p className="font-medium">Something went wrong in this section.</p>
+        <p className="text-neutral-500 text-xs font-mono">{error.message}</p>
+        <button
+          onClick={this.reset}
+          className="text-xs px-3 py-1.5 rounded-md bg-neutral-800 hover:bg-neutral-700 text-neutral-300 transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+}

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface Props {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: Props) {
+  useEffect(() => {
+    // Same pattern as ErrorBoundary — log locally, no sensitive data sent out
+    console.error("[GlobalError]", {
+      message: error.message,
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-neutral-900 text-neutral-100 flex items-center justify-center px-6">
+      <div className="max-w-md w-full space-y-6 text-center">
+        <div className="w-12 h-12 bg-red-500/10 border border-red-500/20 rounded-xl flex items-center justify-center mx-auto text-red-400 text-xl">
+          !
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-xl font-bold">Something went wrong</h1>
+          <p className="text-neutral-400 text-sm">
+            An unexpected error occurred. You can try again or navigate back to
+            the app.
+          </p>
+          {error.digest && (
+            <p className="text-neutral-600 text-xs font-mono">
+              ref: {error.digest}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-3 justify-center">
+          <button
+            onClick={reset}
+            className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors"
+          >
+            Try again
+          </button>
+          <a
+            href="/"
+            className="px-4 py-2 rounded-md bg-neutral-800 hover:bg-neutral-700 text-neutral-300 text-sm font-medium transition-colors"
+          >
+            Go home
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 
 export default function Home() {
   return (
@@ -19,43 +19,48 @@ export default function Home() {
       <main className="container mx-auto px-6 py-12">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
           {/* Create Task Section */}
-          <section className="space-y-6">
-            <h2 className="text-2xl font-bold">Create Automation Task</h2>
-            <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 space-y-4 shadow-xl">
-              <div>
-                <label className="block text-sm font-medium text-neutral-400 mb-1">Target Contract Address</label>
-                <input type="text" placeholder="C..." className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-neutral-400 mb-1">Function Name</label>
-                <input type="text" placeholder="harvest_yield" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+          <ErrorBoundary section="create-task">
+            <section className="space-y-6">
+              <h2 className="text-2xl font-bold">Create Automation Task</h2>
+              <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 space-y-4 shadow-xl">
                 <div>
-                  <label className="block text-sm font-medium text-neutral-400 mb-1">Interval (seconds)</label>
-                  <input type="number" placeholder="3600" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  <label className="block text-sm font-medium text-neutral-400 mb-1">Target Contract Address</label>
+                  <input type="text" placeholder="C..." className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-neutral-400 mb-1">Gas Balance (XLM)</label>
-                  <input type="number" placeholder="10" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  <label className="block text-sm font-medium text-neutral-400 mb-1">Function Name</label>
+                  <input type="text" placeholder="harvest_yield" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
                 </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-neutral-400 mb-1">Interval (seconds)</label>
+                    <input type="number" placeholder="3600" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-neutral-400 mb-1">Gas Balance (XLM)</label>
+                    <input type="number" placeholder="10" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  </div>
+                </div>
+                <button className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20">
+                  Register Task
+                </button>
               </div>
-              <button className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20">
-                Register Task
-              </button>
-            </div>
-          </section>
+            </section>
+          </ErrorBoundary>
 
           {/* Your Tasks Section */}
-          <section className="space-y-6">
-            <h2 className="text-2xl font-bold">Your Tasks</h2>
-            <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 min-h-[300px] flex flex-col items-center justify-center text-neutral-500 shadow-xl">
-              <p>No tasks registered yet.</p>
-            </div>
-          </section>
+          <ErrorBoundary section="task-list">
+            <section className="space-y-6">
+              <h2 className="text-2xl font-bold">Your Tasks</h2>
+              <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 min-h-[300px] flex flex-col items-center justify-center text-neutral-500 shadow-xl">
+                <p>No tasks registered yet.</p>
+              </div>
+            </section>
+          </ErrorBoundary>
         </div>
 
         {/* Execution Logs */}
+        <ErrorBoundary section="execution-logs">
         <section className="mt-16 space-y-6">
           <h2 className="text-2xl font-bold">Execution Logs</h2>
           <div className="overflow-hidden rounded-xl border border-neutral-700/50 shadow-xl">
@@ -86,6 +91,7 @@ export default function Home() {
             </table>
           </div>
         </section>
+        </ErrorBoundary>
       </main>
     </div>
   );


### PR DESCRIPTION
- Add reusable ErrorBoundary class component with section tagging, inline fallback UI, and a Try again reset button
- Add Next.js route-level error.tsx for uncaught root crashes with retry + go home recovery actions
- Wrap Create Task, Your Tasks, and Execution Logs sections independently so a crash in one doesn't take down the others
- Log error message, section name, and component stack locally; no sensitive data sent externally
- Use error.digest as opaque reference in the global fallback

## Summary

<!-- What does this PR change and why? -->

## Related Issue

<!-- Link issue: Closes #123 / Related #123 -->

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

## Changes Made

-

## Validation

<!-- Mark what you ran locally. -->

- [ ] `cargo fmt --all` (if `contract` changed)
- [ ] `npm run lint` in `frontend` (if `frontend` changed)
- [ ] Manual verification completed

## Screenshots (if UI changes)

<!-- Add before/after screenshots or short recording -->

## Checklist

- [ ] Scope is focused and avoids unrelated changes
- [ ] Commit messages are clear
- [ ] Documentation updated when needed
- [ ] ETA was provided when requesting assignment for the linked issue

closes #176