### PR TITLE
feat(frontend): add advanced search, filter, and saved views system

### DIFF
--- a/frontend/components/ActiveFilterSummary.tsx
+++ b/frontend/components/ActiveFilterSummary.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { ActiveFilter } from '@/types/search';
+
+interface ActiveFilterSummaryProps {
+  activeFilters: ActiveFilter[];
+  onRemoveFilter: (filterId: string) => void;
+  onClearAll: () => void;
+}
+
+export function ActiveFilterSummary({ activeFilters, onRemoveFilter, onClearAll }: ActiveFilterSummaryProps) {
+  if (activeFilters.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Active filters">
+      <span className="text-xs text-neutral-500 font-medium">Filters:</span>
+      {activeFilters.map((filter) => (
+        <span
+          key={filter.id}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-blue-500/10 border border-blue-500/20 rounded-full text-xs text-blue-300"
+        >
+          <span className="text-blue-400/70">{filter.label}:</span>
+          <span className="font-medium truncate max-w-[120px]" title={filter.displayValue}>
+            {filter.displayValue}
+          </span>
+          <button
+            type="button"
+            onClick={() => onRemoveFilter(filter.id)}
+            className="text-blue-400/60 hover:text-blue-300 transition-colors ml-0.5 flex-shrink-0"
+            aria-label={`Remove ${filter.label} filter`}
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </span>
+      ))}
+      {activeFilters.length > 1 && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="text-xs text-neutral-500 hover:text-neutral-300 transition-colors"
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/SavedViewsPanel.tsx
+++ b/frontend/components/SavedViewsPanel.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import type { SavedView } from '@/types/search';
+
+interface SavedViewsPanelProps {
+  savedViews: SavedView[];
+  activeViewId: string | null;
+  hasActiveFilters: boolean;
+  onSaveView: (name: string) => void;
+  onLoadView: (viewId: string) => void;
+  onDeleteView: (viewId: string) => void;
+  onUpdateView: (viewId: string, name: string) => void;
+  onCopyShareableUrl: () => void;
+}
+
+export function SavedViewsPanel({
+  savedViews,
+  activeViewId,
+  hasActiveFilters,
+  onSaveView,
+  onLoadView,
+  onDeleteView,
+  onUpdateView,
+  onCopyShareableUrl,
+}: SavedViewsPanelProps) {
+  const [showSaveForm, setShowSaveForm] = useState(false);
+  const [newViewName, setNewViewName] = useState('');
+  const [editingViewId, setEditingViewId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const saveInputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (showSaveForm) {
+      saveInputRef.current?.focus();
+    }
+  }, [showSaveForm]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpenId(null);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSave = () => {
+    const name = newViewName.trim();
+    if (!name) return;
+    onSaveView(name);
+    setNewViewName('');
+    setShowSaveForm(false);
+  };
+
+  const handleEditSave = (viewId: string) => {
+    const name = editingName.trim();
+    if (!name) return;
+    onUpdateView(viewId, name);
+    setEditingViewId(null);
+    setEditingName('');
+  };
+
+  const handleCopyUrl = () => {
+    onCopyShareableUrl();
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-medium text-neutral-400 uppercase tracking-wide">Saved Views</h3>
+        <div className="flex items-center gap-2">
+          {/* Share URL button */}
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={handleCopyUrl}
+              className={`text-xs flex items-center gap-1 transition-colors ${
+                copied ? 'text-green-400' : 'text-neutral-400 hover:text-neutral-200'
+              }`}
+              title="Copy shareable URL"
+            >
+              {copied ? (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  Copied
+                </>
+              ) : (
+                <>
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+                  </svg>
+                  Share
+                </>
+              )}
+            </button>
+          )}
+          {/* Save current view */}
+          {hasActiveFilters && !showSaveForm && (
+            <button
+              type="button"
+              onClick={() => setShowSaveForm(true)}
+              className="text-xs text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-1"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+              </svg>
+              Save view
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Save form */}
+      {showSaveForm && (
+        <div className="flex items-center gap-2">
+          <input
+            ref={saveInputRef}
+            type="text"
+            value={newViewName}
+            onChange={(e) => setNewViewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSave();
+              if (e.key === 'Escape') { setShowSaveForm(false); setNewViewName(''); }
+            }}
+            placeholder="View name..."
+            className="flex-1 bg-neutral-800 border border-neutral-700/50 rounded-lg px-3 py-1.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all"
+            aria-label="New view name"
+          />
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!newViewName.trim()}
+            className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => { setShowSaveForm(false); setNewViewName(''); }}
+            className="px-3 py-1.5 bg-neutral-700 text-neutral-300 text-sm rounded-lg hover:bg-neutral-600 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Views list */}
+      {savedViews.length === 0 ? (
+        <p className="text-xs text-neutral-600 italic">
+          {hasActiveFilters ? 'Save your current filters as a view.' : 'No saved views yet.'}
+        </p>
+      ) : (
+        <div className="space-y-1" role="list" aria-label="Saved views">
+          {savedViews.map((view) => (
+            <div
+              key={view.id}
+              role="listitem"
+              className={`flex items-center gap-2 px-3 py-2 rounded-lg group transition-colors ${
+                activeViewId === view.id
+                  ? 'bg-blue-500/10 border border-blue-500/20'
+                  : 'hover:bg-neutral-800/50 border border-transparent'
+              }`}
+            >
+              {editingViewId === view.id ? (
+                <input
+                  type="text"
+                  value={editingName}
+                  onChange={(e) => setEditingName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleEditSave(view.id);
+                    if (e.key === 'Escape') { setEditingViewId(null); setEditingName(''); }
+                  }}
+                  onBlur={() => handleEditSave(view.id)}
+                  className="flex-1 bg-neutral-700 border border-neutral-600 rounded px-2 py-0.5 text-sm outline-none focus:ring-1 focus:ring-blue-500"
+                  autoFocus
+                  aria-label="Edit view name"
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => onLoadView(view.id)}
+                  className="flex-1 text-left text-sm truncate"
+                >
+                  <span className={activeViewId === view.id ? 'text-blue-300 font-medium' : 'text-neutral-300'}>
+                    {view.name}
+                  </span>
+                </button>
+              )}
+
+              {/* View menu */}
+              <div className="relative flex-shrink-0" ref={menuOpenId === view.id ? menuRef : null}>
+                <button
+                  type="button"
+                  onClick={() => setMenuOpenId(menuOpenId === view.id ? null : view.id)}
+                  className="opacity-0 group-hover:opacity-100 text-neutral-500 hover:text-neutral-300 transition-all p-0.5 rounded"
+                  aria-label={`Options for ${view.name}`}
+                  aria-haspopup="true"
+                  aria-expanded={menuOpenId === view.id}
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z" />
+                  </svg>
+                </button>
+
+                {menuOpenId === view.id && (
+                  <div className="absolute right-0 top-full mt-1 z-20 bg-neutral-800 border border-neutral-700/50 rounded-lg shadow-xl py-1 min-w-[120px]">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEditingViewId(view.id);
+                        setEditingName(view.name);
+                        setMenuOpenId(null);
+                      }}
+                      className="w-full text-left px-3 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 transition-colors"
+                    >
+                      Rename
+                    </button>
+                    {activeViewId === view.id && hasActiveFilters && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onUpdateView(view.id, view.name);
+                          setMenuOpenId(null);
+                        }}
+                        className="w-full text-left px-3 py-1.5 text-sm text-neutral-300 hover:bg-neutral-700/50 transition-colors"
+                      >
+                        Update filters
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onDeleteView(view.id);
+                        setMenuOpenId(null);
+                      }}
+                      className="w-full text-left px-3 py-1.5 text-sm text-red-400 hover:bg-neutral-700/50 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/SearchFilterPanel.tsx
+++ b/frontend/components/SearchFilterPanel.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { TaskFilters, TaskStatus, TaskPriority } from '@/types/search';
+
+interface SearchFilterPanelProps {
+  filters: TaskFilters;
+  onFilterChange: <K extends keyof TaskFilters>(field: K, value: TaskFilters[K]) => void;
+  onClearAll: () => void;
+}
+
+const STATUS_OPTIONS: { value: TaskStatus; label: string; color: string }[] = [
+  { value: 'active', label: 'Active', color: 'text-green-400' },
+  { value: 'paused', label: 'Paused', color: 'text-yellow-400' },
+  { value: 'completed', label: 'Completed', color: 'text-blue-400' },
+  { value: 'failed', label: 'Failed', color: 'text-red-400' },
+];
+
+const PRIORITY_OPTIONS: { value: TaskPriority; label: string; color: string }[] = [
+  { value: 'critical', label: 'Critical', color: 'text-red-400' },
+  { value: 'high', label: 'High', color: 'text-orange-400' },
+  { value: 'medium', label: 'Medium', color: 'text-yellow-400' },
+  { value: 'low', label: 'Low', color: 'text-neutral-400' },
+];
+
+const LABEL_OPTIONS = ['automation', 'defi', 'yield', 'governance', 'maintenance', 'monitoring'];
+
+const ASSIGNEE_OPTIONS = ['alice.xlm', 'bob.xlm', 'carol.xlm', 'dave.xlm'];
+
+function MultiSelectDropdown<T extends string>({
+  label,
+  options,
+  selected,
+  onChange,
+  renderOption,
+}: {
+  label: string;
+  options: { value: T; label: string; color?: string }[];
+  selected: T[];
+  onChange: (values: T[]) => void;
+  renderOption?: (opt: { value: T; label: string; color?: string }) => React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const toggle = (value: T) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+          selected.length > 0
+            ? 'bg-blue-500/10 border-blue-500/40 text-blue-300'
+            : 'bg-neutral-800 border-neutral-700/50 text-neutral-300 hover:border-neutral-600'
+        }`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span>{label}</span>
+        {selected.length > 0 && (
+          <span className="bg-blue-500/20 text-blue-400 text-xs px-1.5 py-0.5 rounded-full font-medium">
+            {selected.length}
+          </span>
+        )}
+        <svg
+          className={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="absolute top-full left-0 mt-1 z-20 bg-neutral-800 border border-neutral-700/50 rounded-lg shadow-xl min-w-[160px] py-1"
+          role="listbox"
+          aria-multiselectable="true"
+        >
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              role="option"
+              aria-selected={selected.includes(opt.value)}
+              onClick={() => toggle(opt.value)}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-neutral-700/50 transition-colors text-left"
+            >
+              <span
+                className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 ${
+                  selected.includes(opt.value)
+                    ? 'bg-blue-500 border-blue-500'
+                    : 'border-neutral-600'
+                }`}
+              >
+                {selected.includes(opt.value) && (
+                  <svg className="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </span>
+              {renderOption ? renderOption(opt) : (
+                <span className={opt.color ?? 'text-neutral-200'}>{opt.label}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SearchFilterPanel({ filters, onFilterChange, onClearAll }: SearchFilterPanelProps) {
+  const [searchValue, setSearchValue] = useState(filters.query ?? '');
+  const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync external filter changes back to local input
+  useEffect(() => {
+    setSearchValue(filters.query ?? '');
+  }, [filters.query]);
+
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setSearchValue(val);
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    searchTimeout.current = setTimeout(() => {
+      onFilterChange('query', val || undefined);
+    }, 300);
+  }, [onFilterChange]);
+
+  const handleSearchClear = useCallback(() => {
+    setSearchValue('');
+    onFilterChange('query', undefined);
+  }, [onFilterChange]);
+
+  const hasAnyFilter =
+    !!filters.query ||
+    (filters.status?.length ?? 0) > 0 ||
+    (filters.assignee?.length ?? 0) > 0 ||
+    (filters.label?.length ?? 0) > 0 ||
+    (filters.priority?.length ?? 0) > 0 ||
+    !!filters.dueDateFrom ||
+    !!filters.dueDateTo;
+
+  return (
+    <div className="space-y-3">
+      {/* Search input */}
+      <div className="relative">
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        <input
+          type="search"
+          value={searchValue}
+          onChange={handleSearchChange}
+          placeholder="Search tasks..."
+          className="w-full bg-neutral-800 border border-neutral-700/50 rounded-lg pl-10 pr-10 py-2.5 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all placeholder:text-neutral-500"
+          aria-label="Search tasks"
+        />
+        {searchValue && (
+          <button
+            type="button"
+            onClick={handleSearchClear}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-neutral-300 transition-colors"
+            aria-label="Clear search"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Filter row */}
+      <div className="flex flex-wrap items-center gap-2">
+        <MultiSelectDropdown
+          label="Status"
+          options={STATUS_OPTIONS}
+          selected={filters.status ?? []}
+          onChange={(v) => onFilterChange('status', v.length ? v : undefined)}
+          renderOption={(opt) => (
+            <span className={opt.color}>{opt.label}</span>
+          )}
+        />
+
+        <MultiSelectDropdown
+          label="Priority"
+          options={PRIORITY_OPTIONS}
+          selected={filters.priority ?? []}
+          onChange={(v) => onFilterChange('priority', v.length ? v : undefined)}
+          renderOption={(opt) => (
+            <span className={opt.color}>{opt.label}</span>
+          )}
+        />
+
+        <MultiSelectDropdown
+          label="Assignee"
+          options={ASSIGNEE_OPTIONS.map((a) => ({ value: a, label: a }))}
+          selected={filters.assignee ?? []}
+          onChange={(v) => onFilterChange('assignee', v.length ? v : undefined)}
+        />
+
+        <MultiSelectDropdown
+          label="Label"
+          options={LABEL_OPTIONS.map((l) => ({ value: l, label: l }))}
+          selected={filters.label ?? []}
+          onChange={(v) => onFilterChange('label', v.length ? v : undefined)}
+        />
+
+        {/* Date range */}
+        <div className="flex items-center gap-1.5">
+          <div className="relative">
+            <input
+              type="date"
+              value={filters.dueDateFrom ?? ''}
+              onChange={(e) => onFilterChange('dueDateFrom', e.target.value || undefined)}
+              className={`px-3 py-1.5 rounded-lg text-sm border transition-colors bg-neutral-800 outline-none focus:ring-2 focus:ring-blue-500 ${
+                filters.dueDateFrom
+                  ? 'border-blue-500/40 text-blue-300'
+                  : 'border-neutral-700/50 text-neutral-300'
+              }`}
+              aria-label="Due date from"
+              title="Due date from"
+            />
+          </div>
+          {(filters.dueDateFrom || filters.dueDateTo) && (
+            <span className="text-neutral-500 text-xs">to</span>
+          )}
+          {filters.dueDateFrom && (
+            <div className="relative">
+              <input
+                type="date"
+                value={filters.dueDateTo ?? ''}
+                onChange={(e) => onFilterChange('dueDateTo', e.target.value || undefined)}
+                min={filters.dueDateFrom}
+                className={`px-3 py-1.5 rounded-lg text-sm border transition-colors bg-neutral-800 outline-none focus:ring-2 focus:ring-blue-500 ${
+                  filters.dueDateTo
+                    ? 'border-blue-500/40 text-blue-300'
+                    : 'border-neutral-700/50 text-neutral-300'
+                }`}
+                aria-label="Due date to"
+                title="Due date to"
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Clear all */}
+        {hasAnyFilter && (
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="ml-auto text-xs text-neutral-400 hover:text-neutral-200 transition-colors flex items-center gap-1"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Clear all
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/__tests__/ActiveFilterSummary.test.tsx
+++ b/frontend/components/__tests__/ActiveFilterSummary.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ActiveFilterSummary } from '@/components/ActiveFilterSummary';
+import type { ActiveFilter } from '@/types/search';
+
+describe('ActiveFilterSummary', () => {
+  const mockFilters: ActiveFilter[] = [
+    { id: 'filter-0', field: 'query', label: 'Search', displayValue: 'harvest' },
+    { id: 'filter-1', field: 'status', label: 'Status', displayValue: 'active, paused' },
+  ];
+
+  const mockOnRemove = jest.fn();
+  const mockOnClearAll = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render nothing when no active filters', () => {
+    const { container } = render(
+      <ActiveFilterSummary activeFilters={[]} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render filter chips', () => {
+    render(
+      <ActiveFilterSummary activeFilters={mockFilters} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    expect(screen.getByText('harvest')).toBeInTheDocument();
+    expect(screen.getByText('active, paused')).toBeInTheDocument();
+  });
+
+  it('should show filter labels', () => {
+    render(
+      <ActiveFilterSummary activeFilters={mockFilters} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    expect(screen.getByText('Search:')).toBeInTheDocument();
+    expect(screen.getByText('Status:')).toBeInTheDocument();
+  });
+
+  it('should call onRemoveFilter when remove button clicked', () => {
+    render(
+      <ActiveFilterSummary activeFilters={mockFilters} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    fireEvent.click(screen.getByLabelText('Remove Search filter'));
+    expect(mockOnRemove).toHaveBeenCalledWith('filter-0');
+  });
+
+  it('should show clear all button when multiple filters', () => {
+    render(
+      <ActiveFilterSummary activeFilters={mockFilters} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    expect(screen.getByText('Clear all')).toBeInTheDocument();
+  });
+
+  it('should not show clear all button for single filter', () => {
+    render(
+      <ActiveFilterSummary
+        activeFilters={[mockFilters[0]]}
+        onRemoveFilter={mockOnRemove}
+        onClearAll={mockOnClearAll}
+      />
+    );
+    expect(screen.queryByText('Clear all')).not.toBeInTheDocument();
+  });
+
+  it('should call onClearAll when clear all clicked', () => {
+    render(
+      <ActiveFilterSummary activeFilters={mockFilters} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    fireEvent.click(screen.getByText('Clear all'));
+    expect(mockOnClearAll).toHaveBeenCalled();
+  });
+
+  it('should have accessible group label', () => {
+    render(
+      <ActiveFilterSummary activeFilters={mockFilters} onRemoveFilter={mockOnRemove} onClearAll={mockOnClearAll} />
+    );
+    expect(screen.getByRole('group', { name: 'Active filters' })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/__tests__/SavedViewsPanel.test.tsx
+++ b/frontend/components/__tests__/SavedViewsPanel.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SavedViewsPanel } from '@/components/SavedViewsPanel';
+import type { SavedView } from '@/types/search';
+
+describe('SavedViewsPanel', () => {
+  const mockView: SavedView = {
+    id: 'view-1',
+    name: 'My View',
+    filters: { query: 'test', status: ['active'] },
+    createdAt: '2024-01-15T10:00:00Z',
+    updatedAt: '2024-01-15T10:00:00Z',
+  };
+
+  const defaultProps = {
+    savedViews: [],
+    activeViewId: null,
+    hasActiveFilters: false,
+    onSaveView: jest.fn(),
+    onLoadView: jest.fn(),
+    onDeleteView: jest.fn(),
+    onUpdateView: jest.fn(),
+    onCopyShareableUrl: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Empty state', () => {
+    it('should show empty message when no views', () => {
+      render(<SavedViewsPanel {...defaultProps} />);
+      expect(screen.getByText('No saved views yet.')).toBeInTheDocument();
+    });
+
+    it('should show save hint when filters are active but no views', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      expect(screen.getByText('Save your current filters as a view.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Save view', () => {
+    it('should show save button when filters are active', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      expect(screen.getByText('Save view')).toBeInTheDocument();
+    });
+
+    it('should not show save button when no active filters', () => {
+      render(<SavedViewsPanel {...defaultProps} />);
+      expect(screen.queryByText('Save view')).not.toBeInTheDocument();
+    });
+
+    it('should show save form when save button clicked', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      fireEvent.click(screen.getByText('Save view'));
+      expect(screen.getByPlaceholderText('View name...')).toBeInTheDocument();
+    });
+
+    it('should call onSaveView with name', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      fireEvent.click(screen.getByText('Save view'));
+      fireEvent.change(screen.getByPlaceholderText('View name...'), {
+        target: { value: 'My New View' },
+      });
+      fireEvent.click(screen.getByText('Save'));
+      expect(defaultProps.onSaveView).toHaveBeenCalledWith('My New View');
+    });
+
+    it('should save on Enter key', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      fireEvent.click(screen.getByText('Save view'));
+      const input = screen.getByPlaceholderText('View name...');
+      fireEvent.change(input, { target: { value: 'My View' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(defaultProps.onSaveView).toHaveBeenCalledWith('My View');
+    });
+
+    it('should cancel on Escape key', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      fireEvent.click(screen.getByText('Save view'));
+      const input = screen.getByPlaceholderText('View name...');
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(screen.queryByPlaceholderText('View name...')).not.toBeInTheDocument();
+    });
+
+    it('should disable save button when name is empty', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      fireEvent.click(screen.getByText('Save view'));
+      expect(screen.getByText('Save')).toBeDisabled();
+    });
+  });
+
+  describe('Views list', () => {
+    it('should render saved views', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      expect(screen.getByText('My View')).toBeInTheDocument();
+    });
+
+    it('should highlight active view', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} activeViewId="view-1" />);
+      // Active view button should have blue styling
+      const viewButton = screen.getByText('My View');
+      expect(viewButton).toHaveClass('text-blue-300');
+    });
+
+    it('should call onLoadView when view clicked', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      fireEvent.click(screen.getByText('My View'));
+      expect(defaultProps.onLoadView).toHaveBeenCalledWith('view-1');
+    });
+
+    it('should have accessible list', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      expect(screen.getByRole('list', { name: 'Saved views' })).toBeInTheDocument();
+    });
+  });
+
+  describe('View options menu', () => {
+    it('should show options button on hover', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      const optionsBtn = screen.getByLabelText('Options for My View');
+      expect(optionsBtn).toBeInTheDocument();
+    });
+
+    it('should show delete option in menu', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      fireEvent.click(screen.getByLabelText('Options for My View'));
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+    });
+
+    it('should call onDeleteView when delete clicked', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      fireEvent.click(screen.getByLabelText('Options for My View'));
+      fireEvent.click(screen.getByText('Delete'));
+      expect(defaultProps.onDeleteView).toHaveBeenCalledWith('view-1');
+    });
+
+    it('should show rename option in menu', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      fireEvent.click(screen.getByLabelText('Options for My View'));
+      expect(screen.getByText('Rename')).toBeInTheDocument();
+    });
+
+    it('should show edit input when rename clicked', () => {
+      render(<SavedViewsPanel {...defaultProps} savedViews={[mockView]} />);
+      fireEvent.click(screen.getByLabelText('Options for My View'));
+      fireEvent.click(screen.getByText('Rename'));
+      expect(screen.getByLabelText('Edit view name')).toBeInTheDocument();
+    });
+  });
+
+  describe('Share URL', () => {
+    it('should show share button when filters are active', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      expect(screen.getByTitle('Copy shareable URL')).toBeInTheDocument();
+    });
+
+    it('should not show share button when no active filters', () => {
+      render(<SavedViewsPanel {...defaultProps} />);
+      expect(screen.queryByTitle('Copy shareable URL')).not.toBeInTheDocument();
+    });
+
+    it('should call onCopyShareableUrl when share clicked', () => {
+      render(<SavedViewsPanel {...defaultProps} hasActiveFilters />);
+      fireEvent.click(screen.getByTitle('Copy shareable URL'));
+      expect(defaultProps.onCopyShareableUrl).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/components/__tests__/SearchFilterPanel.test.tsx
+++ b/frontend/components/__tests__/SearchFilterPanel.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { SearchFilterPanel } from '@/components/SearchFilterPanel';
+import type { TaskFilters } from '@/types/search';
+
+// Use fake timers for debounce
+jest.useFakeTimers();
+
+describe('SearchFilterPanel', () => {
+  const mockOnFilterChange = jest.fn();
+  const mockOnClearAll = jest.fn();
+
+  const defaultProps = {
+    filters: {} as TaskFilters,
+    onFilterChange: mockOnFilterChange,
+    onClearAll: mockOnClearAll,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe('Search input', () => {
+    it('should render search input', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByPlaceholderText('Search tasks...')).toBeInTheDocument();
+    });
+
+    it('should have accessible label', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByLabelText('Search tasks')).toBeInTheDocument();
+    });
+
+    it('should debounce search input', async () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      const input = screen.getByPlaceholderText('Search tasks...');
+      fireEvent.change(input, { target: { value: 'harvest' } });
+      expect(mockOnFilterChange).not.toHaveBeenCalled();
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+      expect(mockOnFilterChange).toHaveBeenCalledWith('query', 'harvest');
+    });
+
+    it('should show clear button when search has value', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ query: 'test' }} />);
+      expect(screen.getByLabelText('Clear search')).toBeInTheDocument();
+    });
+
+    it('should not show clear button when search is empty', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument();
+    });
+
+    it('should clear search when clear button clicked', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ query: 'test' }} />);
+      fireEvent.click(screen.getByLabelText('Clear search'));
+      expect(mockOnFilterChange).toHaveBeenCalledWith('query', undefined);
+    });
+  });
+
+  describe('Status filter', () => {
+    it('should render status dropdown', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+
+    it('should open status dropdown on click', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      fireEvent.click(screen.getByText('Status'));
+      expect(screen.getByText('Active')).toBeInTheDocument();
+      expect(screen.getByText('Paused')).toBeInTheDocument();
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+      expect(screen.getByText('Failed')).toBeInTheDocument();
+    });
+
+    it('should call onFilterChange when status selected', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      fireEvent.click(screen.getByText('Status'));
+      fireEvent.click(screen.getByText('Active'));
+      expect(mockOnFilterChange).toHaveBeenCalledWith('status', ['active']);
+    });
+
+    it('should show count badge when statuses selected', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ status: ['active', 'paused'] }} />);
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+  });
+
+  describe('Priority filter', () => {
+    it('should render priority dropdown', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByText('Priority')).toBeInTheDocument();
+    });
+
+    it('should open priority dropdown on click', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      fireEvent.click(screen.getByText('Priority'));
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+      expect(screen.getByText('High')).toBeInTheDocument();
+      expect(screen.getByText('Medium')).toBeInTheDocument();
+      expect(screen.getByText('Low')).toBeInTheDocument();
+    });
+  });
+
+  describe('Assignee filter', () => {
+    it('should render assignee dropdown', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByText('Assignee')).toBeInTheDocument();
+    });
+  });
+
+  describe('Label filter', () => {
+    it('should render label dropdown', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByText('Label')).toBeInTheDocument();
+    });
+  });
+
+  describe('Date range filter', () => {
+    it('should render date from input', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.getByLabelText('Due date from')).toBeInTheDocument();
+    });
+
+    it('should call onFilterChange when date from changes', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      fireEvent.change(screen.getByLabelText('Due date from'), {
+        target: { value: '2024-01-15' },
+      });
+      expect(mockOnFilterChange).toHaveBeenCalledWith('dueDateFrom', '2024-01-15');
+    });
+
+    it('should show date to input when date from is set', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ dueDateFrom: '2024-01-15' }} />);
+      expect(screen.getByLabelText('Due date to')).toBeInTheDocument();
+    });
+
+    it('should not show date to input when date from is not set', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.queryByLabelText('Due date to')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Clear all', () => {
+    it('should show clear all button when any filter is active', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ query: 'test' }} />);
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+      // The clear all button appears when hasAnyFilter is true
+      // Since query is set in filters prop, it should show
+      expect(screen.getByText('Clear all')).toBeInTheDocument();
+    });
+
+    it('should not show clear all button when no filters', () => {
+      render(<SearchFilterPanel {...defaultProps} />);
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument();
+    });
+
+    it('should call onClearAll when clear all clicked', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ status: ['active'] }} />);
+      fireEvent.click(screen.getByText('Clear all'));
+      expect(mockOnClearAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('Multi-select deselection', () => {
+    it('should deselect option when clicked again', () => {
+      render(<SearchFilterPanel {...defaultProps} filters={{ status: ['active'] }} />);
+      fireEvent.click(screen.getByText('Status'));
+      fireEvent.click(screen.getByText('Active'));
+      expect(mockOnFilterChange).toHaveBeenCalledWith('status', undefined);
+    });
+  });
+});

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,0 +1,3 @@
+export { SearchFilterPanel } from './SearchFilterPanel';
+export { ActiveFilterSummary } from './ActiveFilterSummary';
+export { SavedViewsPanel } from './SavedViewsPanel';

--- a/frontend/hooks/__tests__/useSearch.test.ts
+++ b/frontend/hooks/__tests__/useSearch.test.ts
@@ -1,0 +1,353 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSearch } from '@/hooks/useSearch';
+import type { TaskFilters } from '@/types/search';
+
+describe('useSearch', () => {
+  describe('Initial state', () => {
+    it('should start with empty filters', () => {
+      const { result } = renderHook(() => useSearch());
+      expect(result.current.filters).toEqual({});
+    });
+
+    it('should accept initial filters', () => {
+      const initial: TaskFilters = { query: 'harvest', status: ['active'] };
+      const { result } = renderHook(() => useSearch(initial));
+      expect(result.current.filters).toEqual(initial);
+    });
+
+    it('should have no active filters initially', () => {
+      const { result } = renderHook(() => useSearch());
+      expect(result.current.activeFilters).toHaveLength(0);
+      expect(result.current.hasActiveFilters).toBe(false);
+    });
+
+    it('should have no saved views initially', () => {
+      const { result } = renderHook(() => useSearch());
+      expect(result.current.savedViews).toHaveLength(0);
+    });
+
+    it('should have no active view initially', () => {
+      const { result } = renderHook(() => useSearch());
+      expect(result.current.activeViewId).toBeNull();
+    });
+  });
+
+  describe('setFilter', () => {
+    it('should set a text query filter', () => {
+      const { result } = renderHook(() => useSearch());
+      act(() => {
+        result.current.setFilter('query', 'harvest');
+      });
+      expect(result.current.filters.query).toBe('harvest');
+    });
+
+    it('should set status filter', () => {
+      const { result } = renderHook(() => useSearch());
+      act(() => {
+        result.current.setFilter('status', ['active', 'paused']);
+      });
+      expect(result.current.filters.status).toEqual(['active', 'paused']);
+    });
+
+    it('should set priority filter', () => {
+      const { result } = renderHook(() => useSearch());
+      act(() => {
+        result.current.setFilter('priority', ['high', 'critical']);
+      });
+      expect(result.current.filters.priority).toEqual(['high', 'critical']);
+    });
+
+    it('should remove filter when set to empty string', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.setFilter('query', '');
+      });
+      expect(result.current.filters.query).toBeUndefined();
+    });
+
+    it('should remove filter when set to empty array', () => {
+      const { result } = renderHook(() => useSearch({ status: ['active'] }));
+      act(() => {
+        result.current.setFilter('status', []);
+      });
+      expect(result.current.filters.status).toBeUndefined();
+    });
+
+    it('should remove filter when set to undefined', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.setFilter('query', undefined);
+      });
+      expect(result.current.filters.query).toBeUndefined();
+    });
+
+    it('should clear active view when filter changes', () => {
+      const { result } = renderHook(() => useSearch());
+      // Save a view first
+      act(() => {
+        result.current.setFilter('query', 'test');
+      });
+      act(() => {
+        result.current.saveView('My View');
+      });
+      expect(result.current.activeViewId).not.toBeNull();
+      // Change filter
+      act(() => {
+        result.current.setFilter('query', 'other');
+      });
+      expect(result.current.activeViewId).toBeNull();
+    });
+  });
+
+  describe('activeFilters', () => {
+    it('should generate active filter for query', () => {
+      const { result } = renderHook(() => useSearch({ query: 'harvest' }));
+      expect(result.current.activeFilters).toHaveLength(1);
+      expect(result.current.activeFilters[0].field).toBe('query');
+      expect(result.current.activeFilters[0].label).toBe('Search');
+      expect(result.current.activeFilters[0].displayValue).toBe('harvest');
+    });
+
+    it('should generate active filter for status', () => {
+      const { result } = renderHook(() => useSearch({ status: ['active', 'paused'] }));
+      expect(result.current.activeFilters).toHaveLength(1);
+      expect(result.current.activeFilters[0].field).toBe('status');
+      expect(result.current.activeFilters[0].displayValue).toBe('active, paused');
+    });
+
+    it('should generate multiple active filters', () => {
+      const { result } = renderHook(() => useSearch({
+        query: 'test',
+        status: ['active'],
+        priority: ['high'],
+      }));
+      expect(result.current.activeFilters).toHaveLength(3);
+    });
+
+    it('should have unique ids for each filter', () => {
+      const { result } = renderHook(() => useSearch({
+        query: 'test',
+        status: ['active'],
+      }));
+      const ids = result.current.activeFilters.map((f) => f.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+
+  describe('removeFilter', () => {
+    it('should remove a specific filter by id', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test', status: ['active'] }));
+      const filterId = result.current.activeFilters.find((f) => f.field === 'query')!.id;
+      act(() => {
+        result.current.removeFilter(filterId);
+      });
+      expect(result.current.filters.query).toBeUndefined();
+      expect(result.current.filters.status).toEqual(['active']);
+    });
+
+    it('should do nothing for unknown filter id', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.removeFilter('nonexistent-id');
+      });
+      expect(result.current.filters.query).toBe('test');
+    });
+  });
+
+  describe('clearAllFilters', () => {
+    it('should clear all filters', () => {
+      const { result } = renderHook(() => useSearch({
+        query: 'test',
+        status: ['active'],
+        priority: ['high'],
+      }));
+      act(() => {
+        result.current.clearAllFilters();
+      });
+      expect(result.current.filters).toEqual({});
+      expect(result.current.activeFilters).toHaveLength(0);
+    });
+
+    it('should clear active view', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.saveView('My View');
+      });
+      act(() => {
+        result.current.clearAllFilters();
+      });
+      expect(result.current.activeViewId).toBeNull();
+    });
+  });
+
+  describe('saveView', () => {
+    it('should save current filters as a view', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test', status: ['active'] }));
+      act(() => {
+        result.current.saveView('My View');
+      });
+      expect(result.current.savedViews).toHaveLength(1);
+      expect(result.current.savedViews[0].name).toBe('My View');
+      expect(result.current.savedViews[0].filters).toEqual({ query: 'test', status: ['active'] });
+    });
+
+    it('should set the new view as active', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.saveView('My View');
+      });
+      expect(result.current.activeViewId).toBe(result.current.savedViews[0].id);
+    });
+
+    it('should return the created view', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      let view: ReturnType<typeof result.current.saveView> | undefined;
+      act(() => {
+        view = result.current.saveView('My View');
+      });
+      expect(view).toBeDefined();
+      expect(view!.name).toBe('My View');
+      expect(view!.id).toBeTruthy();
+    });
+
+    it('should allow multiple saved views', () => {
+      const { result } = renderHook(() => useSearch());
+      act(() => {
+        result.current.setFilter('query', 'view1');
+        result.current.saveView('View 1');
+      });
+      act(() => {
+        result.current.setFilter('query', 'view2');
+        result.current.saveView('View 2');
+      });
+      expect(result.current.savedViews).toHaveLength(2);
+    });
+  });
+
+  describe('loadView', () => {
+    it('should load filters from a saved view', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      let viewId: string;
+      act(() => {
+        const view = result.current.saveView('My View');
+        viewId = view.id;
+      });
+      // Change filters
+      act(() => {
+        result.current.setFilter('query', 'changed');
+      });
+      // Load the saved view
+      act(() => {
+        result.current.loadView(viewId!);
+      });
+      expect(result.current.filters.query).toBe('test');
+      expect(result.current.activeViewId).toBe(viewId!);
+    });
+
+    it('should do nothing for unknown view id', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.loadView('nonexistent');
+      });
+      expect(result.current.filters.query).toBe('test');
+    });
+  });
+
+  describe('deleteView', () => {
+    it('should delete a saved view', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      let viewId: string;
+      act(() => {
+        const view = result.current.saveView('My View');
+        viewId = view.id;
+      });
+      act(() => {
+        result.current.deleteView(viewId!);
+      });
+      expect(result.current.savedViews).toHaveLength(0);
+    });
+
+    it('should clear active view if deleted view was active', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      let viewId: string;
+      act(() => {
+        const view = result.current.saveView('My View');
+        viewId = view.id;
+      });
+      act(() => {
+        result.current.deleteView(viewId!);
+      });
+      expect(result.current.activeViewId).toBeNull();
+    });
+  });
+
+  describe('updateView', () => {
+    it('should update view name and filters', () => {
+      const { result } = renderHook(() => useSearch({ query: 'original' }));
+      let viewId: string;
+      act(() => {
+        const view = result.current.saveView('Original Name');
+        viewId = view.id;
+      });
+      act(() => {
+        result.current.setFilter('query', 'updated');
+      });
+      act(() => {
+        result.current.updateView(viewId!, 'Updated Name');
+      });
+      const view = result.current.savedViews.find((v) => v.id === viewId);
+      expect(view?.name).toBe('Updated Name');
+      expect(view?.filters.query).toBe('updated');
+    });
+  });
+
+  describe('getShareableUrl', () => {
+    it('should return a URL with filter params', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test', status: ['active'] }));
+      const url = result.current.getShareableUrl();
+      expect(url).toContain('q=test');
+      expect(url).toContain('status=active');
+    });
+
+    it('should return empty string or base URL for no filters', () => {
+      const { result } = renderHook(() => useSearch());
+      const url = result.current.getShareableUrl();
+      // In jsdom, window.location.origin is 'http://localhost'
+      // With no filters, params are empty so URL is just origin + pathname
+      expect(url).not.toContain('q=');
+      expect(url).not.toContain('status=');
+    });
+  });
+
+  describe('loadFromUrl', () => {
+    it('should parse filters from URL search string', () => {
+      const { result } = renderHook(() => useSearch());
+      act(() => {
+        result.current.loadFromUrl('?q=harvest&status=active,paused&priority=high');
+      });
+      expect(result.current.filters.query).toBe('harvest');
+      expect(result.current.filters.status).toEqual(['active', 'paused']);
+      expect(result.current.filters.priority).toEqual(['high']);
+    });
+
+    it('should clear active view when loading from URL', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.saveView('My View');
+      });
+      act(() => {
+        result.current.loadFromUrl('?q=other');
+      });
+      expect(result.current.activeViewId).toBeNull();
+    });
+
+    it('should handle empty search string', () => {
+      const { result } = renderHook(() => useSearch({ query: 'test' }));
+      act(() => {
+        result.current.loadFromUrl('');
+      });
+      expect(result.current.filters).toEqual({});
+    });
+  });
+});

--- a/frontend/hooks/index.ts
+++ b/frontend/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSearch } from './useSearch';

--- a/frontend/hooks/useSearch.ts
+++ b/frontend/hooks/useSearch.ts
@@ -1,0 +1,244 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import type { TaskFilters, SavedView, ActiveFilter, TaskStatus, TaskPriority } from '@/types/search';
+
+const FILTER_LABELS: Record<keyof TaskFilters, string> = {
+  query: 'Search',
+  status: 'Status',
+  assignee: 'Assignee',
+  label: 'Label',
+  priority: 'Priority',
+  dueDateFrom: 'Due after',
+  dueDateTo: 'Due before',
+};
+
+function formatFilterDisplayValue(field: keyof TaskFilters, value: TaskFilters[keyof TaskFilters]): string {
+  if (!value) return '';
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  return String(value);
+}
+
+function filtersToUrlParams(filters: TaskFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.query) params.set('q', filters.query);
+  if (filters.status?.length) params.set('status', filters.status.join(','));
+  if (filters.assignee?.length) params.set('assignee', filters.assignee.join(','));
+  if (filters.label?.length) params.set('label', filters.label.join(','));
+  if (filters.priority?.length) params.set('priority', filters.priority.join(','));
+  if (filters.dueDateFrom) params.set('from', filters.dueDateFrom);
+  if (filters.dueDateTo) params.set('to', filters.dueDateTo);
+  return params;
+}
+
+function urlParamsToFilters(params: URLSearchParams): TaskFilters {
+  const filters: TaskFilters = {};
+  const q = params.get('q');
+  if (q) filters.query = q;
+  const status = params.get('status');
+  if (status) filters.status = status.split(',') as TaskStatus[];
+  const assignee = params.get('assignee');
+  if (assignee) filters.assignee = assignee.split(',');
+  const label = params.get('label');
+  if (label) filters.label = label.split(',');
+  const priority = params.get('priority');
+  if (priority) filters.priority = priority.split(',') as TaskPriority[];
+  const from = params.get('from');
+  if (from) filters.dueDateFrom = from;
+  const to = params.get('to');
+  if (to) filters.dueDateTo = to;
+  return filters;
+}
+
+interface UseSearchReturn {
+  filters: TaskFilters;
+  activeFilters: ActiveFilter[];
+  savedViews: SavedView[];
+  activeViewId: string | null;
+  hasActiveFilters: boolean;
+  setFilter: <K extends keyof TaskFilters>(field: K, value: TaskFilters[K]) => void;
+  removeFilter: (filterId: string) => void;
+  clearAllFilters: () => void;
+  saveView: (name: string) => SavedView;
+  loadView: (viewId: string) => void;
+  deleteView: (viewId: string) => void;
+  updateView: (viewId: string, name: string) => void;
+  getShareableUrl: () => string;
+  loadFromUrl: (search: string) => void;
+}
+
+export function useSearch(initialFilters: TaskFilters = {}): UseSearchReturn {
+  const [filters, setFilters] = useState<TaskFilters>(initialFilters);
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  const [activeViewId, setActiveViewId] = useState<string | null>(null);
+
+  // Derive active filters list for display
+  const activeFilters = useMemo<ActiveFilter[]>(() => {
+    const result: ActiveFilter[] = [];
+    let idCounter = 0;
+
+    if (filters.query) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'query',
+        label: FILTER_LABELS.query,
+        displayValue: filters.query,
+      });
+    }
+    if (filters.status?.length) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'status',
+        label: FILTER_LABELS.status,
+        displayValue: formatFilterDisplayValue('status', filters.status),
+      });
+    }
+    if (filters.assignee?.length) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'assignee',
+        label: FILTER_LABELS.assignee,
+        displayValue: formatFilterDisplayValue('assignee', filters.assignee),
+      });
+    }
+    if (filters.label?.length) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'label',
+        label: FILTER_LABELS.label,
+        displayValue: formatFilterDisplayValue('label', filters.label),
+      });
+    }
+    if (filters.priority?.length) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'priority',
+        label: FILTER_LABELS.priority,
+        displayValue: formatFilterDisplayValue('priority', filters.priority),
+      });
+    }
+    if (filters.dueDateFrom) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'dueDateFrom',
+        label: FILTER_LABELS.dueDateFrom,
+        displayValue: filters.dueDateFrom,
+      });
+    }
+    if (filters.dueDateTo) {
+      result.push({
+        id: `filter-${idCounter++}`,
+        field: 'dueDateTo',
+        label: FILTER_LABELS.dueDateTo,
+        displayValue: filters.dueDateTo,
+      });
+    }
+
+    return result;
+  }, [filters]);
+
+  const hasActiveFilters = activeFilters.length > 0;
+
+  const setFilter = useCallback(<K extends keyof TaskFilters>(field: K, value: TaskFilters[K]) => {
+    setFilters((prev) => {
+      // Clear value removes the filter
+      if (value === undefined || value === null || value === '' || (Array.isArray(value) && value.length === 0)) {
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      }
+      return { ...prev, [field]: value };
+    });
+    // Changing filters deactivates any saved view
+    setActiveViewId(null);
+  }, []);
+
+  const removeFilter = useCallback((filterId: string) => {
+    const filter = activeFilters.find((f) => f.id === filterId);
+    if (!filter) return;
+    setFilters((prev) => {
+      const next = { ...prev };
+      delete next[filter.field];
+      return next;
+    });
+    setActiveViewId(null);
+  }, [activeFilters]);
+
+  const clearAllFilters = useCallback(() => {
+    setFilters({});
+    setActiveViewId(null);
+  }, []);
+
+  const saveView = useCallback((name: string): SavedView => {
+    const now = new Date().toISOString();
+    const newView: SavedView = {
+      id: `view-${Date.now()}`,
+      name,
+      filters: { ...filters },
+      createdAt: now,
+      updatedAt: now,
+    };
+    setSavedViews((prev) => [...prev, newView]);
+    setActiveViewId(newView.id);
+    return newView;
+  }, [filters]);
+
+  const loadView = useCallback((viewId: string) => {
+    const view = savedViews.find((v) => v.id === viewId);
+    if (!view) return;
+    setFilters({ ...view.filters });
+    setActiveViewId(viewId);
+  }, [savedViews]);
+
+  const deleteView = useCallback((viewId: string) => {
+    setSavedViews((prev) => prev.filter((v) => v.id !== viewId));
+    if (activeViewId === viewId) {
+      setActiveViewId(null);
+    }
+  }, [activeViewId]);
+
+  const updateView = useCallback((viewId: string, name: string) => {
+    setSavedViews((prev) =>
+      prev.map((v) =>
+        v.id === viewId
+          ? { ...v, name, filters: { ...filters }, updatedAt: new Date().toISOString() }
+          : v
+      )
+    );
+  }, [filters]);
+
+  const getShareableUrl = useCallback((): string => {
+    const params = filtersToUrlParams(filters);
+    const paramStr = params.toString();
+    if (typeof window !== 'undefined') {
+      return `${window.location.origin}${window.location.pathname}${paramStr ? `?${paramStr}` : ''}`;
+    }
+    return paramStr ? `?${paramStr}` : '';
+  }, [filters]);
+
+  const loadFromUrl = useCallback((search: string) => {
+    const params = new URLSearchParams(search);
+    const parsed = urlParamsToFilters(params);
+    setFilters(parsed);
+    setActiveViewId(null);
+  }, []);
+
+  return {
+    filters,
+    activeFilters,
+    savedViews,
+    activeViewId,
+    hasActiveFilters,
+    setFilter,
+    removeFilter,
+    clearAllFilters,
+    saveView,
+    loadView,
+    deleteView,
+    updateView,
+    getShareableUrl,
+    loadFromUrl,
+  };
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -11,10 +11,12 @@ const createJestConfig = async () => {
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     collectCoverageFrom: [
       'src/**/*.{js,jsx,ts,tsx}',
-      '!src/**/*.d.ts',
+      'components/**/*.{js,jsx,ts,tsx}',
+      'hooks/**/*.{js,jsx,ts,tsx}',
+      '!**/*.d.ts',
       '!src/**/*.stories.{js,jsx,ts,tsx}',
-      '!src/**/__tests__/**',
-      '!src/**/__mocks__/**',
+      '!**/__tests__/**',
+      '!**/__mocks__/**',
     ],
     coveragePathIgnorePatterns: [
       '/node_modules/',
@@ -31,9 +33,13 @@ const createJestConfig = async () => {
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
       '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/components/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/components/**/*.{spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/hooks/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/hooks/**/*.{spec,test}.{js,jsx,ts,tsx}',
     ],
     moduleNameMapper: {
-      '^@/(.*)$': '<rootDir>/src/$1',
+      '^@/(.*)$': '<rootDir>/$1',
     },
   })
 }

--- a/frontend/types/search.ts
+++ b/frontend/types/search.ts
@@ -1,0 +1,52 @@
+// Search, filter, and saved views types
+
+export type TaskStatus = 'active' | 'paused' | 'completed' | 'failed';
+
+export type TaskPriority = 'low' | 'medium' | 'high' | 'critical';
+
+export type FilterOperator = 'is' | 'is_not' | 'contains' | 'not_contains' | 'before' | 'after' | 'between';
+
+export interface FilterValue {
+  operator: FilterOperator;
+  value: string | string[] | DateRange;
+}
+
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+export interface TaskFilters {
+  query?: string;
+  status?: TaskStatus[];
+  assignee?: string[];
+  label?: string[];
+  priority?: TaskPriority[];
+  dueDateFrom?: string;
+  dueDateTo?: string;
+}
+
+export interface ActiveFilter {
+  id: string;
+  field: keyof TaskFilters;
+  label: string;
+  displayValue: string;
+}
+
+export interface SavedView {
+  id: string;
+  name: string;
+  filters: TaskFilters;
+  createdAt: string;
+  updatedAt: string;
+  isDefault?: boolean;
+}
+
+export interface SearchState {
+  filters: TaskFilters;
+  savedViews: SavedView[];
+  activeViewId: string | null;
+}
+
+// URL serialization helpers
+export type SerializedFilters = Record<string, string>;


### PR DESCRIPTION
- Add SearchFilterPanel with text search, status, priority, assignee, label, and date range filters with multi-select dropdowns
- Add ActiveFilterSummary showing active filter chips with per-filter removal and clear-all
- Add SavedViewsPanel for creating, loading, renaming, and deleting saved filter presets
- Add useSearch hook managing filter state, active filter derivation, saved views, URL serialization, and shareable link generation
- Add TaskFilters, SavedView, ActiveFilter, and related types
- URL params sync enables shareable filtered views via getShareableUrl and loadFromUrl
- 85 tests covering all components and the hook

closes #166 
