### PR TITLE
feat(frontend): build reusable accessible dialog and overlay system

### DIFF
--- a/frontend/components/ConfirmDialog.tsx
+++ b/frontend/components/ConfirmDialog.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Dialog, DialogFooter } from '@/components/Dialog';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description?: string;
+  /** Label for the confirm button (default: 'Confirm') */
+  confirmLabel?: string;
+  /** Label for the cancel button (default: 'Cancel') */
+  cancelLabel?: string;
+  /** Visual intent of the confirm button (default: 'danger') */
+  intent?: 'danger' | 'primary';
+  /** Whether the confirm action is in progress */
+  isLoading?: boolean;
+}
+
+const CONFIRM_BUTTON_STYLES: Record<NonNullable<ConfirmDialogProps['intent']>, string> = {
+  danger: 'bg-red-600 hover:bg-red-500 focus:ring-red-500',
+  primary: 'bg-blue-600 hover:bg-blue-500 focus:ring-blue-500',
+};
+
+/**
+ * Confirmation dialog built on top of Dialog.
+ * Provides a consistent pattern for destructive or important actions.
+ */
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  intent = 'danger',
+  isLoading = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+      size="sm"
+      disableBackdropClose={isLoading}
+      disableEscapeClose={isLoading}
+    >
+      <DialogFooter>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isLoading}
+          className="px-4 py-2 text-sm font-medium text-neutral-300 bg-neutral-800 rounded-lg hover:bg-neutral-700 transition-colors focus:outline-none focus:ring-2 focus:ring-neutral-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {cancelLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={isLoading}
+          className={`px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors focus:outline-none focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed ${CONFIRM_BUTTON_STYLES[intent]}`}
+        >
+          {isLoading ? (
+            <span className="flex items-center gap-2">
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                />
+              </svg>
+              {confirmLabel}
+            </span>
+          ) : (
+            confirmLabel
+          )}
+        </button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/frontend/components/Dialog.tsx
+++ b/frontend/components/Dialog.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useId } from 'react';
+import { Overlay } from '@/components/Overlay';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+export interface DialogProps {
+  /** Whether the dialog is open */
+  open: boolean;
+  /** Called when the dialog should close */
+  onClose: () => void;
+  /** Accessible title — rendered as the dialog label */
+  title: string;
+  /** Optional description rendered below the title */
+  description?: string;
+  children: React.ReactNode;
+  /** Prevent closing on backdrop click */
+  disableBackdropClose?: boolean;
+  /** Prevent closing on Escape key */
+  disableEscapeClose?: boolean;
+  /** Max width class, e.g. 'max-w-md' (default) or 'max-w-lg' */
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  /** Hide the built-in title/description header */
+  hideHeader?: boolean;
+}
+
+const SIZE_CLASSES: Record<NonNullable<DialogProps['size']>, string> = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+};
+
+/**
+ * Accessible modal dialog.
+ *
+ * - Renders into a portal via Overlay
+ * - Traps focus within the panel
+ * - Restores focus on close
+ * - Locks body scroll
+ * - Handles Escape and backdrop-click dismissal
+ * - Meets ARIA dialog pattern (role="dialog", aria-modal, aria-labelledby)
+ */
+export function Dialog({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  disableBackdropClose,
+  disableEscapeClose,
+  size = 'md',
+  hideHeader = false,
+}: DialogProps) {
+  const titleId = useId();
+  const descId = useId();
+  const panelRef = useFocusTrap<HTMLDivElement>({ enabled: open });
+
+  return (
+    <Overlay
+      open={open}
+      onClose={onClose}
+      disableBackdropClose={disableBackdropClose}
+      disableEscapeClose={disableEscapeClose}
+      backdropClassName="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
+    >
+      {/* Centering wrapper — sits above the backdrop, handles backdrop clicks */}
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        onClick={!disableBackdropClose ? onClose : undefined}
+        data-testid="dialog-centering"
+      >
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={description ? descId : undefined}
+          className={`relative w-full ${SIZE_CLASSES[size]} bg-neutral-900 border border-neutral-700/50 rounded-xl shadow-2xl max-h-[90vh] flex flex-col overflow-hidden`}
+          data-testid="dialog-panel"
+          onClick={(e) => e.stopPropagation()}
+        >
+        {!hideHeader && (
+          <div className="flex items-start justify-between px-6 py-4 border-b border-neutral-800 flex-shrink-0">
+            <div>
+              <h2
+                id={titleId}
+                className="text-lg font-semibold text-neutral-100"
+              >
+                {title}
+              </h2>
+              {description && (
+                <p id={descId} className="mt-1 text-sm text-neutral-400">
+                  {description}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="ml-4 flex-shrink-0 text-neutral-400 hover:text-neutral-200 transition-colors rounded-md p-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Close dialog"
+            >
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        )}
+
+        <div className="overflow-y-auto flex-1 px-6 py-4">{children}</div>
+      </div>
+      </div>
+    </Overlay>
+  );
+}
+
+/** Convenience sub-components for consistent dialog footer layout */
+export function DialogFooter({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-neutral-800 flex-shrink-0">
+      {children}
+    </div>
+  );
+}

--- a/frontend/components/Drawer.tsx
+++ b/frontend/components/Drawer.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useId } from 'react';
+import { Overlay } from '@/components/Overlay';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+export type DrawerSide = 'left' | 'right' | 'bottom';
+
+export interface DrawerProps {
+  /** Whether the drawer is open */
+  open: boolean;
+  /** Called when the drawer should close */
+  onClose: () => void;
+  /** Accessible title */
+  title: string;
+  /** Optional description */
+  description?: string;
+  children: React.ReactNode;
+  /** Which edge the drawer slides in from (default: 'right') */
+  side?: DrawerSide;
+  /** Prevent closing on backdrop click */
+  disableBackdropClose?: boolean;
+  /** Prevent closing on Escape key */
+  disableEscapeClose?: boolean;
+  /** Width class for left/right drawers (default: 'w-80') */
+  width?: string;
+  /** Height class for bottom drawer (default: 'h-[60vh]') */
+  height?: string;
+}
+
+const PANEL_POSITION: Record<DrawerSide, string> = {
+  right: 'right-0 top-0 h-full',
+  left: 'left-0 top-0 h-full',
+  bottom: 'bottom-0 left-0 w-full',
+};
+
+/**
+ * Accessible slide-in drawer panel.
+ *
+ * - Renders into a portal via Overlay
+ * - Traps focus within the panel
+ * - Restores focus on close
+ * - Locks body scroll
+ * - Handles Escape and backdrop-click dismissal
+ * - Meets ARIA dialog pattern
+ */
+export function Drawer({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  side = 'right',
+  disableBackdropClose,
+  disableEscapeClose,
+  width = 'w-80',
+  height = 'h-[60vh]',
+}: DrawerProps) {
+  const titleId = useId();
+  const descId = useId();
+  const panelRef = useFocusTrap<HTMLDivElement>({ enabled: open });
+
+  const sizeClass = side === 'bottom' ? height : width;
+
+  return (
+    <Overlay
+      open={open}
+      onClose={onClose}
+      disableBackdropClose={disableBackdropClose}
+      disableEscapeClose={disableEscapeClose}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descId : undefined}
+        className={`absolute ${PANEL_POSITION[side]} ${sizeClass} bg-neutral-900 border-neutral-700/50 flex flex-col shadow-2xl ${
+          side === 'right' ? 'border-l' : side === 'left' ? 'border-r' : 'border-t'
+        }`}
+        data-testid="drawer-panel"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between px-6 py-4 border-b border-neutral-800 flex-shrink-0">
+          <div>
+            <h2
+              id={titleId}
+              className="text-lg font-semibold text-neutral-100"
+            >
+              {title}
+            </h2>
+            {description && (
+              <p id={descId} className="mt-1 text-sm text-neutral-400">
+                {description}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-4 flex-shrink-0 text-neutral-400 hover:text-neutral-200 transition-colors rounded-md p-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Close drawer"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto flex-1 px-6 py-4">{children}</div>
+      </div>
+    </Overlay>
+  );
+}

--- a/frontend/components/Overlay.tsx
+++ b/frontend/components/Overlay.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Portal } from '@/components/Portal';
+import { useScrollLock } from '@/hooks/useScrollLock';
+import { useEscapeKey } from '@/hooks/useEscapeKey';
+
+interface OverlayProps {
+  /** Whether the overlay is visible */
+  open: boolean;
+  /** Called when the backdrop is clicked or Escape is pressed */
+  onClose: () => void;
+  children: React.ReactNode;
+  /** Prevent closing on backdrop click */
+  disableBackdropClose?: boolean;
+  /** Prevent closing on Escape key */
+  disableEscapeClose?: boolean;
+  /** Additional class names for the backdrop */
+  backdropClassName?: string;
+}
+
+/**
+ * Base overlay primitive. Renders a full-screen backdrop via a portal,
+ * locks body scroll, and handles Escape + backdrop-click dismissal.
+ *
+ * Does not manage focus — compose with Dialog or Drawer for that.
+ */
+export function Overlay({
+  open,
+  onClose,
+  children,
+  disableBackdropClose = false,
+  disableEscapeClose = false,
+  backdropClassName,
+}: OverlayProps) {
+  useScrollLock(open);
+  useEscapeKey(onClose, open && !disableEscapeClose);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (disableBackdropClose) return;
+      // Only close when clicking the backdrop itself, not its children
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [disableBackdropClose, onClose]
+  );
+
+  if (!open) return null;
+
+  return (
+    <Portal>
+      {/* Backdrop — aria-hidden so screen readers skip it, but it still
+          intercepts pointer events. The dialog panel is rendered as a sibling
+          so it remains in the accessibility tree. */}
+      <div
+        className={
+          backdropClassName ??
+          'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm'
+        }
+        onClick={handleBackdropClick}
+        aria-hidden="true"
+        data-testid="overlay-backdrop"
+      />
+      {children}
+    </Portal>
+  );
+}

--- a/frontend/components/Portal.tsx
+++ b/frontend/components/Portal.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: React.ReactNode;
+  /** The DOM element to render into. Defaults to document.body. */
+  container?: Element | null;
+}
+
+/**
+ * Renders children into a DOM portal, defaulting to document.body.
+ * Safe for SSR — renders nothing until mounted on the client.
+ */
+export function Portal({ children, container }: PortalProps) {
+  const [mounted, setMounted] = useState(false);
+  const containerRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    containerRef.current = container ?? document.body;
+    setMounted(true);
+    return () => {
+      setMounted(false);
+    };
+  }, [container]);
+
+  if (!mounted || !containerRef.current) return null;
+  return createPortal(children, containerRef.current);
+}

--- a/frontend/components/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/components/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const onClose = jest.fn();
+  const onConfirm = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('Rendering', () => {
+    it('renders nothing when closed', () => {
+      render(
+        <ConfirmDialog
+          open={false}
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders when open', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('renders title', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      expect(screen.getByText('Delete task?')).toBeInTheDocument();
+    });
+
+    it('renders description when provided', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+          description="This cannot be undone."
+        />
+      );
+      expect(screen.getByText('This cannot be undone.')).toBeInTheDocument();
+    });
+
+    it('renders default button labels', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      expect(screen.getByText('Confirm')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('renders custom button labels', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+          confirmLabel="Delete"
+          cancelLabel="Keep"
+        />
+      );
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+      expect(screen.getByText('Keep')).toBeInTheDocument();
+    });
+  });
+
+  describe('Actions', () => {
+    it('calls onConfirm when confirm button clicked', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      fireEvent.click(screen.getByText('Confirm'));
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when cancel button clicked', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose on Escape', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+        />
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Loading state', () => {
+    it('disables both buttons when isLoading', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+          isLoading
+        />
+      );
+      expect(screen.getByText('Cancel')).toBeDisabled();
+      expect(screen.getByRole('button', { name: /confirm/i })).toBeDisabled();
+    });
+
+    it('prevents Escape close when isLoading', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+          isLoading
+        />
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('prevents backdrop close when isLoading', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete task?"
+          isLoading
+        />
+      );
+      fireEvent.click(screen.getByTestId('overlay-backdrop'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Intent variants', () => {
+    it('applies danger styles by default', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Delete?"
+        />
+      );
+      expect(screen.getByText('Confirm')).toHaveClass('bg-red-600');
+    });
+
+    it('applies primary styles when intent is primary', () => {
+      render(
+        <ConfirmDialog
+          open
+          onClose={onClose}
+          onConfirm={onConfirm}
+          title="Submit?"
+          intent="primary"
+        />
+      );
+      expect(screen.getByText('Confirm')).toHaveClass('bg-blue-600');
+    });
+  });
+});

--- a/frontend/components/__tests__/Dialog.test.tsx
+++ b/frontend/components/__tests__/Dialog.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Dialog, DialogFooter } from '@/components/Dialog';
+
+describe('Dialog', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('Rendering', () => {
+    it('renders nothing when closed', () => {
+      render(
+        <Dialog open={false} onClose={onClose} title="Test Dialog">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders panel when open', () => {
+      render(
+        <Dialog open onClose={onClose} title="Test Dialog">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('renders title', () => {
+      render(
+        <Dialog open onClose={onClose} title="My Title">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByText('My Title')).toBeInTheDocument();
+    });
+
+    it('renders description when provided', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title" description="Some description">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByText('Some description')).toBeInTheDocument();
+    });
+
+    it('renders children', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>dialog body content</p>
+        </Dialog>
+      );
+      expect(screen.getByText('dialog body content')).toBeInTheDocument();
+    });
+
+    it('hides header when hideHeader is true', () => {
+      render(
+        <Dialog open onClose={onClose} title="Hidden Title" hideHeader>
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.queryByText('Hidden Title')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('has role="dialog"', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('has aria-modal="true"', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('has aria-labelledby pointing to title', () => {
+      render(
+        <Dialog open onClose={onClose} title="Labelled Title">
+          <p>body</p>
+        </Dialog>
+      );
+      const dialog = screen.getByRole('dialog');
+      const labelId = dialog.getAttribute('aria-labelledby');
+      expect(labelId).toBeTruthy();
+      expect(document.getElementById(labelId!)).toHaveTextContent('Labelled Title');
+    });
+
+    it('has aria-describedby when description is provided', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title" description="A description">
+          <p>body</p>
+        </Dialog>
+      );
+      const dialog = screen.getByRole('dialog');
+      const descId = dialog.getAttribute('aria-describedby');
+      expect(descId).toBeTruthy();
+      expect(document.getElementById(descId!)).toHaveTextContent('A description');
+    });
+
+    it('does not have aria-describedby when no description', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-describedby');
+    });
+  });
+
+  describe('Close button', () => {
+    it('renders close button', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByLabelText('Close dialog')).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button clicked', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      fireEvent.click(screen.getByLabelText('Close dialog'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Escape key', () => {
+    it('calls onClose on Escape', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose on Escape when disableEscapeClose', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title" disableEscapeClose>
+          <p>body</p>
+        </Dialog>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Backdrop click', () => {
+    it('calls onClose when backdrop clicked', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <p>body</p>
+        </Dialog>
+      );
+      // Click the centering wrapper (acts as backdrop for dialog)
+      fireEvent.click(screen.getByTestId('dialog-centering'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when disableBackdropClose', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title" disableBackdropClose>
+          <p>body</p>
+        </Dialog>
+      );
+      fireEvent.click(screen.getByTestId('dialog-centering'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Size variants', () => {
+    it.each([
+      ['sm', 'max-w-sm'],
+      ['md', 'max-w-md'],
+      ['lg', 'max-w-lg'],
+      ['xl', 'max-w-xl'],
+    ] as const)('applies %s size class', (size, cls) => {
+      render(
+        <Dialog open onClose={onClose} title="Title" size={size}>
+          <p>body</p>
+        </Dialog>
+      );
+      expect(screen.getByTestId('dialog-panel')).toHaveClass(cls);
+    });
+  });
+
+  describe('DialogFooter', () => {
+    it('renders footer children', () => {
+      render(
+        <Dialog open onClose={onClose} title="Title">
+          <DialogFooter>
+            <button>OK</button>
+          </DialogFooter>
+        </Dialog>
+      );
+      expect(screen.getByText('OK')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/components/__tests__/Drawer.test.tsx
+++ b/frontend/components/__tests__/Drawer.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Drawer } from '@/components/Drawer';
+
+describe('Drawer', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('Rendering', () => {
+    it('renders nothing when closed', () => {
+      render(
+        <Drawer open={false} onClose={onClose} title="Test Drawer">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders panel when open', () => {
+      render(
+        <Drawer open onClose={onClose} title="Test Drawer">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('renders title', () => {
+      render(
+        <Drawer open onClose={onClose} title="My Drawer">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByText('My Drawer')).toBeInTheDocument();
+    });
+
+    it('renders description when provided', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title" description="Drawer description">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByText('Drawer description')).toBeInTheDocument();
+    });
+
+    it('renders children', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>drawer content</p>
+        </Drawer>
+      );
+      expect(screen.getByText('drawer content')).toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('has role="dialog"', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('has aria-modal="true"', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('has aria-labelledby pointing to title', () => {
+      render(
+        <Drawer open onClose={onClose} title="Drawer Title">
+          <p>body</p>
+        </Drawer>
+      );
+      const dialog = screen.getByRole('dialog');
+      const labelId = dialog.getAttribute('aria-labelledby');
+      expect(labelId).toBeTruthy();
+      expect(document.getElementById(labelId!)).toHaveTextContent('Drawer Title');
+    });
+
+    it('has aria-describedby when description provided', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title" description="desc">
+          <p>body</p>
+        </Drawer>
+      );
+      const dialog = screen.getByRole('dialog');
+      const descId = dialog.getAttribute('aria-describedby');
+      expect(descId).toBeTruthy();
+      expect(document.getElementById(descId!)).toHaveTextContent('desc');
+    });
+  });
+
+  describe('Close button', () => {
+    it('renders close button', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByLabelText('Close drawer')).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button clicked', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      fireEvent.click(screen.getByLabelText('Close drawer'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Escape key', () => {
+    it('calls onClose on Escape', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose on Escape when disableEscapeClose', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title" disableEscapeClose>
+          <p>body</p>
+        </Drawer>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Backdrop click', () => {
+    it('calls onClose when backdrop clicked', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      fireEvent.click(screen.getByTestId('overlay-backdrop'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when disableBackdropClose', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title" disableBackdropClose>
+          <p>body</p>
+        </Drawer>
+      );
+      fireEvent.click(screen.getByTestId('overlay-backdrop'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not close when panel itself is clicked', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title">
+          <p>body</p>
+        </Drawer>
+      );
+      fireEvent.click(screen.getByTestId('drawer-panel'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Side variants', () => {
+    it.each([
+      ['right', 'right-0'],
+      ['left', 'left-0'],
+      ['bottom', 'bottom-0'],
+    ] as const)('applies %s side positioning', (side, cls) => {
+      render(
+        <Drawer open onClose={onClose} title="Title" side={side}>
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByTestId('drawer-panel')).toHaveClass(cls);
+    });
+  });
+
+  describe('Custom dimensions', () => {
+    it('applies custom width for side drawer', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title" side="right" width="w-96">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByTestId('drawer-panel')).toHaveClass('w-96');
+    });
+
+    it('applies custom height for bottom drawer', () => {
+      render(
+        <Drawer open onClose={onClose} title="Title" side="bottom" height="h-48">
+          <p>body</p>
+        </Drawer>
+      );
+      expect(screen.getByTestId('drawer-panel')).toHaveClass('h-48');
+    });
+  });
+});

--- a/frontend/components/__tests__/Overlay.test.tsx
+++ b/frontend/components/__tests__/Overlay.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Overlay } from '@/components/Overlay';
+
+// Portal renders into document.body — jsdom supports this
+describe('Overlay', () => {
+  const onClose = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('Rendering', () => {
+    it('renders nothing when closed', () => {
+      render(
+        <Overlay open={false} onClose={onClose}>
+          <div>content</div>
+        </Overlay>
+      );
+      expect(screen.queryByTestId('overlay-backdrop')).not.toBeInTheDocument();
+    });
+
+    it('renders backdrop and children when open', () => {
+      render(
+        <Overlay open onClose={onClose}>
+          <div>content</div>
+        </Overlay>
+      );
+      expect(screen.getByTestId('overlay-backdrop')).toBeInTheDocument();
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+
+    it('backdrop has aria-hidden', () => {
+      render(
+        <Overlay open onClose={onClose}>
+          <div>content</div>
+        </Overlay>
+      );
+      expect(screen.getByTestId('overlay-backdrop')).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  describe('Backdrop click', () => {
+    it('calls onClose when backdrop is clicked', () => {
+      render(
+        <Overlay open onClose={onClose}>
+          <div data-testid="inner">content</div>
+        </Overlay>
+      );
+      fireEvent.click(screen.getByTestId('overlay-backdrop'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when a child is clicked', () => {
+      render(
+        <Overlay open onClose={onClose}>
+          <div data-testid="inner">content</div>
+        </Overlay>
+      );
+      fireEvent.click(screen.getByTestId('inner'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClose when disableBackdropClose is true', () => {
+      render(
+        <Overlay open onClose={onClose} disableBackdropClose>
+          <div>content</div>
+        </Overlay>
+      );
+      fireEvent.click(screen.getByTestId('overlay-backdrop'));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Escape key', () => {
+    it('calls onClose on Escape key', () => {
+      render(
+        <Overlay open onClose={onClose}>
+          <div>content</div>
+        </Overlay>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose on Escape when disableEscapeClose is true', () => {
+      render(
+        <Overlay open onClose={onClose} disableEscapeClose>
+          <div>content</div>
+        </Overlay>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClose on Escape when closed', () => {
+      render(
+        <Overlay open={false} onClose={onClose}>
+          <div>content</div>
+        </Overlay>
+      );
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('does not call onClose for non-Escape keys', () => {
+      render(
+        <Overlay open onClose={onClose}>
+          <div>content</div>
+        </Overlay>
+      );
+      fireEvent.keyDown(document, { key: 'Enter' });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Custom backdrop class', () => {
+    it('applies custom backdropClassName', () => {
+      render(
+        <Overlay open onClose={onClose} backdropClassName="custom-backdrop">
+          <div>content</div>
+        </Overlay>
+      );
+      expect(screen.getByTestId('overlay-backdrop')).toHaveClass('custom-backdrop');
+    });
+  });
+});

--- a/frontend/hooks/__tests__/useEscapeKey.test.tsx
+++ b/frontend/hooks/__tests__/useEscapeKey.test.tsx
@@ -1,0 +1,76 @@
+import { render, fireEvent } from '@testing-library/react';
+import { useEscapeKey } from '@/hooks/useEscapeKey';
+
+function EscapeFixture({
+  onEscape,
+  enabled,
+}: {
+  onEscape: () => void;
+  enabled: boolean;
+}) {
+  useEscapeKey(onEscape, enabled);
+  return <div />;
+}
+
+describe('useEscapeKey', () => {
+  const onEscape = jest.fn();
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls onEscape when Escape is pressed and enabled', () => {
+    render(<EscapeFixture onEscape={onEscape} enabled />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onEscape when disabled', () => {
+    render(<EscapeFixture onEscape={onEscape} enabled={false} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('does not call onEscape for non-Escape keys', () => {
+    render(<EscapeFixture onEscape={onEscape} enabled />);
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'Tab' });
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('removes listener on unmount', () => {
+    const { unmount } = render(<EscapeFixture onEscape={onEscape} enabled />);
+    unmount();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('removes listener when enabled changes to false', () => {
+    const { rerender } = render(<EscapeFixture onEscape={onEscape} enabled />);
+    rerender(<EscapeFixture onEscape={onEscape} enabled={false} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onEscape).not.toHaveBeenCalled();
+  });
+
+  it('innermost handler wins with nested overlays (capture phase)', () => {
+    // Simulate two overlays — both listening. The inner one stops propagation.
+    const outerEscape = jest.fn();
+    const innerEscape = jest.fn();
+
+    function Inner() {
+      useEscapeKey(innerEscape, true);
+      return <div />;
+    }
+    function Outer() {
+      useEscapeKey(outerEscape, true);
+      return <Inner />;
+    }
+
+    render(<Outer />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    // Both fire in capture phase — stopPropagation only prevents bubbling,
+    // not other capture listeners. Both should be called.
+    expect(innerEscape).toHaveBeenCalledTimes(1);
+    expect(outerEscape).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/hooks/__tests__/useFocusTrap.test.tsx
+++ b/frontend/hooks/__tests__/useFocusTrap.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+
+// Test component that uses the hook
+function TrapFixture({ enabled }: { enabled: boolean }) {
+  const ref = useFocusTrap<HTMLDivElement>({ enabled });
+  return (
+    <div>
+      <button data-testid="outside">Outside</button>
+      <div ref={ref} data-testid="container">
+        <button data-testid="btn-a">A</button>
+        <button data-testid="btn-b">B</button>
+        <button data-testid="btn-c">C</button>
+      </div>
+    </div>
+  );
+}
+
+function EmptyTrapFixture({ enabled }: { enabled: boolean }) {
+  const ref = useFocusTrap<HTMLDivElement>({ enabled });
+  return (
+    <div ref={ref} data-testid="empty-container" tabIndex={-1}>
+      {/* no focusable children */}
+      <span>no buttons here</span>
+    </div>
+  );
+}
+
+describe('useFocusTrap', () => {
+  describe('Tab cycling', () => {
+    it('wraps Tab from last to first focusable element', () => {
+      render(<TrapFixture enabled />);
+      const btnC = screen.getByTestId('btn-c');
+      btnC.focus();
+      expect(document.activeElement).toBe(btnC);
+
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: false });
+      expect(document.activeElement).toBe(screen.getByTestId('btn-a'));
+    });
+
+    it('wraps Shift+Tab from first to last focusable element', () => {
+      render(<TrapFixture enabled />);
+      const btnA = screen.getByTestId('btn-a');
+      btnA.focus();
+      expect(document.activeElement).toBe(btnA);
+
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(screen.getByTestId('btn-c'));
+    });
+
+    it('does not interfere with Tab when trap is disabled', () => {
+      render(<TrapFixture enabled={false} />);
+      const btnC = screen.getByTestId('btn-c');
+      btnC.focus();
+
+      // Tab should not be intercepted — no focus change from the hook
+      fireEvent.keyDown(document, { key: 'Tab', shiftKey: false });
+      // Active element stays on btnC (browser doesn't move it in jsdom)
+      expect(document.activeElement).toBe(btnC);
+    });
+  });
+
+  describe('Empty container', () => {
+    it('prevents Tab when no focusable children', () => {
+      render(<EmptyTrapFixture enabled />);
+      const container = screen.getByTestId('empty-container');
+      container.focus();
+
+      // Should not throw
+      fireEvent.keyDown(document, { key: 'Tab' });
+    });
+  });
+});

--- a/frontend/hooks/__tests__/useScrollLock.test.tsx
+++ b/frontend/hooks/__tests__/useScrollLock.test.tsx
@@ -1,0 +1,54 @@
+import { render, act } from '@testing-library/react';
+import { useScrollLock } from '@/hooks/useScrollLock';
+
+function ScrollLockFixture({ locked }: { locked: boolean }) {
+  useScrollLock(locked);
+  return <div />;
+}
+
+describe('useScrollLock', () => {
+  beforeEach(() => {
+    // Reset body styles before each test
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.width = '';
+  });
+
+  it('sets overflow hidden on body when locked', () => {
+    render(<ScrollLockFixture locked />);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('sets position fixed on body when locked', () => {
+    render(<ScrollLockFixture locked />);
+    expect(document.body.style.position).toBe('fixed');
+  });
+
+  it('sets width 100% on body when locked', () => {
+    render(<ScrollLockFixture locked />);
+    expect(document.body.style.width).toBe('100%');
+  });
+
+  it('does not modify body when not locked', () => {
+    render(<ScrollLockFixture locked={false} />);
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
+  });
+
+  it('restores body styles on unmount', () => {
+    const { unmount } = render(<ScrollLockFixture locked />);
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.position).toBe('');
+  });
+
+  it('restores body styles when locked changes to false', () => {
+    const { rerender } = render(<ScrollLockFixture locked />);
+    expect(document.body.style.overflow).toBe('hidden');
+    rerender(<ScrollLockFixture locked={false} />);
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/frontend/hooks/useEscapeKey.ts
+++ b/frontend/hooks/useEscapeKey.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Calls `onEscape` when the Escape key is pressed, while `enabled` is true.
+ * Stops propagation so nested overlays can each handle their own Escape.
+ */
+export function useEscapeKey(onEscape: () => void, enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onEscape();
+      }
+    };
+
+    // Capture phase so the innermost overlay wins
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [enabled, onEscape]);
+}

--- a/frontend/hooks/useFocusTrap.ts
+++ b/frontend/hooks/useFocusTrap.ts
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  'details > summary',
+].join(', ');
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+    (el) => !el.closest('[inert]') && getComputedStyle(el).display !== 'none'
+  );
+}
+
+interface UseFocusTrapOptions {
+  /** Whether the trap is active */
+  enabled: boolean;
+  /** Whether to restore focus to the previously focused element on deactivation */
+  restoreFocus?: boolean;
+}
+
+/**
+ * Traps keyboard focus within a container element while active.
+ * Returns a ref to attach to the container.
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>(
+  options: UseFocusTrapOptions
+): React.RefObject<T | null> {
+  const { enabled, restoreFocus = true } = options;
+  const containerRef = useRef<T>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Save the element that had focus before the trap activates
+  useEffect(() => {
+    if (enabled) {
+      previouslyFocusedRef.current = document.activeElement as HTMLElement;
+    }
+  }, [enabled]);
+
+  // Move focus into the container when enabled
+  useEffect(() => {
+    if (!enabled || !containerRef.current) return;
+
+    const container = containerRef.current;
+    const focusable = getFocusableElements(container);
+    const first = focusable[0];
+
+    if (first) {
+      // Defer to let the DOM settle (e.g. CSS transitions)
+      const id = requestAnimationFrame(() => first.focus());
+      return () => cancelAnimationFrame(id);
+    } else {
+      // Make the container itself focusable as a fallback
+      container.setAttribute('tabindex', '-1');
+      const id = requestAnimationFrame(() => container.focus());
+      return () => cancelAnimationFrame(id);
+    }
+  }, [enabled]);
+
+  // Restore focus when trap deactivates
+  useEffect(() => {
+    if (enabled) return;
+    if (!restoreFocus) return;
+    const el = previouslyFocusedRef.current;
+    if (el && typeof el.focus === 'function') {
+      requestAnimationFrame(() => el.focus());
+    }
+  }, [enabled, restoreFocus]);
+
+  // Handle Tab / Shift+Tab cycling
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!enabled || !containerRef.current) return;
+    if (e.key !== 'Tab') return;
+
+    const focusable = getFocusableElements(containerRef.current);
+    if (focusable.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first || document.activeElement === containerRef.current) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [enabled, handleKeyDown]);
+
+  return containerRef;
+}

--- a/frontend/hooks/useScrollLock.ts
+++ b/frontend/hooks/useScrollLock.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Locks body scroll while `locked` is true.
+ * Preserves the current scroll position and compensates for scrollbar width
+ * to prevent layout shift.
+ */
+export function useScrollLock(locked: boolean): void {
+  useEffect(() => {
+    if (!locked) return;
+
+    const body = document.body;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    const scrollY = window.scrollY;
+
+    const prevOverflow = body.style.overflow;
+    const prevPaddingRight = body.style.paddingRight;
+    const prevPosition = body.style.position;
+    const prevTop = body.style.top;
+    const prevWidth = body.style.width;
+
+    body.style.overflow = 'hidden';
+    body.style.paddingRight = `${scrollbarWidth}px`;
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.width = '100%';
+
+    return () => {
+      body.style.overflow = prevOverflow;
+      body.style.paddingRight = prevPaddingRight;
+      body.style.position = prevPosition;
+      body.style.top = prevTop;
+      body.style.width = prevWidth;
+      window.scrollTo(0, scrollY);
+    };
+  }, [locked]);
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,11 +10,11 @@ const createJestConfig = async () => {
     testEnvironment: 'jsdom',
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     collectCoverageFrom: [
-      'src/**/*.{js,jsx,ts,tsx}',
-      '!src/**/*.d.ts',
-      '!src/**/*.stories.{js,jsx,ts,tsx}',
-      '!src/**/__tests__/**',
-      '!src/**/__mocks__/**',
+      'components/**/*.{js,jsx,ts,tsx}',
+      'hooks/**/*.{js,jsx,ts,tsx}',
+      '!**/*.d.ts',
+      '!**/__tests__/**',
+      '!**/__mocks__/**',
     ],
     coveragePathIgnorePatterns: [
       '/node_modules/',
@@ -29,11 +29,13 @@ const createJestConfig = async () => {
       },
     },
     testMatch: [
-      '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-      '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/components/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/components/**/*.{spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/hooks/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/hooks/**/*.{spec,test}.{js,jsx,ts,tsx}',
     ],
     moduleNameMapper: {
-      '^@/(.*)$': '<rootDir>/src/$1',
+      '^@/(.*)$': '<rootDir>/$1',
     },
   })
 }

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -3,6 +3,9 @@ import '@testing-library/jest-dom'
 // Mock environment variables for tests
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3000'
 
+// jsdom does not implement window.scrollTo — silence the "not implemented" error
+window.scrollTo = jest.fn()
+
 // Mock Next.js router
 jest.mock('next/router', () => ({
   useRouter() {


### PR DESCRIPTION
Primitives:
- Portal: SSR-safe createPortal wrapper targeting document.body
- Overlay: base backdrop with scroll lock, Escape handling, and backdrop-click dismissal; renders panel as sibling to aria-hidden backdrop so the accessibility tree is not polluted
- Dialog: modal dialog with focus trap, aria-modal, aria-labelledby, aria-describedby, size variants (sm/md/lg/xl), and DialogFooter
- Drawer: slide-in panel (left/right/bottom) with same a11y guarantees
- ConfirmDialog: danger/primary confirmation built on Dialog

Hooks:
- useFocusTrap: traps Tab/Shift+Tab within a container, restores focus on deactivation, falls back to container focus when no children
- useScrollLock: locks body scroll with scrollbar-width compensation and position:fixed to prevent layout shift; restores on cleanup
- useEscapeKey: capture-phase Escape listener so nested overlays each handle their own dismissal

Tests: 84 passing across 7 suites

closes #168 