### PR TITLE
 [Frontend] Implement Unsaved Changes Protection Across High-Risk Forms and Editors (#210)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,12 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Performance Monitoring
+
+Frontend interaction timing instrumentation for route load, task open, search latency, and mutation timing is documented in [docs/performance-monitoring.md](docs/performance-monitoring.md).
+
+Set `NEXT_PUBLIC_PERF_SAMPLE_RATE` to tune sampling.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { endTimer, startTimer } from "@/lib/perf-monitor";
+import { useUnsavedChanges } from "@/lib/use-unsaved-changes";
 
 type TaskRow = {
   id: string;
@@ -35,6 +36,11 @@ export default function Home() {
   const [search, setSearch] = useState("");
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [isRegistering, setIsRegistering] = useState(false);
+
+  const EMPTY_FORM = { contractAddress: "", functionName: "", interval: "", gasBalance: "" };
+  const [form, setForm] = useState(EMPTY_FORM);
+  const isDirty = Object.values(form).some((v) => v !== "");
+  const { confirmDiscard } = useUnsavedChanges(isDirty);
 
   useEffect(() => {
     routeLoadStartedRef.current = startTimer();
@@ -112,7 +118,12 @@ export default function Home() {
       mutation: "register_task",
       optimistic: true,
     });
+    setForm(EMPTY_FORM);
     setIsRegistering(false);
+  };
+
+  const onReset = () => {
+    if (confirmDiscard()) setForm(EMPTY_FORM);
   };
 
   return (
@@ -138,29 +149,66 @@ export default function Home() {
             <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 space-y-4 shadow-xl">
               <div>
                 <label className="block text-sm font-medium text-neutral-400 mb-1">Target Contract Address</label>
-                <input type="text" placeholder="C..." className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                <input
+                  type="text"
+                  placeholder="C..."
+                  value={form.contractAddress}
+                  onChange={(e) => setForm((f) => ({ ...f, contractAddress: e.target.value }))}
+                  className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm"
+                />
               </div>
               <div>
                 <label className="block text-sm font-medium text-neutral-400 mb-1">Function Name</label>
-                <input type="text" placeholder="harvest_yield" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                <input
+                  type="text"
+                  placeholder="harvest_yield"
+                  value={form.functionName}
+                  onChange={(e) => setForm((f) => ({ ...f, functionName: e.target.value }))}
+                  className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm"
+                />
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-neutral-400 mb-1">Interval (seconds)</label>
-                  <input type="number" placeholder="3600" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  <input
+                    type="number"
+                    placeholder="3600"
+                    value={form.interval}
+                    onChange={(e) => setForm((f) => ({ ...f, interval: e.target.value }))}
+                    className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm"
+                  />
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-neutral-400 mb-1">Gas Balance (XLM)</label>
-                  <input type="number" placeholder="10" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  <input
+                    type="number"
+                    placeholder="10"
+                    value={form.gasBalance}
+                    onChange={(e) => setForm((f) => ({ ...f, gasBalance: e.target.value }))}
+                    className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm"
+                  />
                 </div>
               </div>
-              <button
-                onClick={onRegisterTask}
-                disabled={isRegistering}
-                className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-60 disabled:cursor-not-allowed text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20"
-              >
-                {isRegistering ? "Registering..." : "Register Task"}
-              </button>
+              {isDirty && (
+                <p className="text-xs text-amber-400/80">You have unsaved changes.</p>
+              )}
+              <div className="flex gap-3 mt-2">
+                <button
+                  type="button"
+                  onClick={onReset}
+                  disabled={!isDirty || isRegistering}
+                  className="flex-1 bg-neutral-700 hover:bg-neutral-600 disabled:opacity-40 disabled:cursor-not-allowed text-neutral-200 font-medium py-3 rounded-lg transition-colors"
+                >
+                  Reset
+                </button>
+                <button
+                  onClick={onRegisterTask}
+                  disabled={isRegistering}
+                  className="flex-[2] bg-blue-600 hover:bg-blue-500 disabled:opacity-60 disabled:cursor-not-allowed text-white font-medium py-3 rounded-lg transition-colors shadow-lg shadow-blue-600/20"
+                >
+                  {isRegistering ? "Registering..." : "Register Task"}
+                </button>
+              </div>
             </div>
           </section>
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,120 @@
-import Image from "next/image";
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { endTimer, startTimer } from "@/lib/perf-monitor";
+
+type TaskRow = {
+  id: string;
+  target: string;
+  keeper: string;
+  status: "Success" | "Failed";
+  timestamp: string;
+};
+
+const INITIAL_TASKS: TaskRow[] = [
+  {
+    id: "#1024",
+    target: "CC...A12B",
+    keeper: "GA...99X",
+    status: "Success",
+    timestamp: "2 mins ago",
+  },
+  {
+    id: "#1025",
+    target: "CC...B31C",
+    keeper: "GA...11P",
+    status: "Failed",
+    timestamp: "5 mins ago",
+  },
+];
 
 export default function Home() {
+  const routeLoadStartedRef = useRef<number | null>(null);
+  const searchStartedRef = useRef<number | null>(null);
+  const [tasks, setTasks] = useState<TaskRow[]>(INITIAL_TASKS);
+  const [search, setSearch] = useState("");
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [isRegistering, setIsRegistering] = useState(false);
+
+  useEffect(() => {
+    routeLoadStartedRef.current = startTimer();
+    const raf = requestAnimationFrame(() => {
+      if (routeLoadStartedRef.current !== null) {
+        endTimer("route_load_ms", routeLoadStartedRef.current, {
+          route: "/",
+        });
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  const visibleTasks = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return tasks;
+    return tasks.filter(
+      (task) =>
+        task.id.toLowerCase().includes(query) ||
+        task.target.toLowerCase().includes(query) ||
+        task.keeper.toLowerCase().includes(query) ||
+        task.status.toLowerCase().includes(query)
+    );
+  }, [search, tasks]);
+
+  useEffect(() => {
+    if (searchStartedRef.current === null) return;
+    const startedAt = searchStartedRef.current;
+    const raf = requestAnimationFrame(() => {
+      endTimer("search_latency_ms", startedAt, {
+        queryLength: search.length,
+        resultCount: visibleTasks.length,
+      });
+      searchStartedRef.current = null;
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [search, visibleTasks.length]);
+
+  const selectedTask =
+    visibleTasks.find((task) => task.id === selectedTaskId) ?? null;
+
+  const onOpenTask = (taskId: string) => {
+    const startedAt = startTimer();
+    setSelectedTaskId(taskId);
+    requestAnimationFrame(() => {
+      endTimer("task_open_ms", startedAt, {
+        taskId,
+      });
+    });
+  };
+
+  const onSearch = (value: string) => {
+    searchStartedRef.current = startTimer();
+    setSearch(value);
+  };
+
+  const onRegisterTask = async () => {
+    setIsRegistering(true);
+    const startedAt = startTimer();
+
+    // Simulate the registration request path while backend wiring is pending.
+    await new Promise((resolve) => setTimeout(resolve, 240));
+
+    setTasks((prev) => [
+      {
+        id: `#${1024 + prev.length}`,
+        target: "CC...NEW1",
+        keeper: "GA...PENDING",
+        status: "Success",
+        timestamp: "just now",
+      },
+      ...prev,
+    ]);
+    endTimer("mutation_register_task_ms", startedAt, {
+      mutation: "register_task",
+      optimistic: true,
+    });
+    setIsRegistering(false);
+  };
+
   return (
     <div className="min-h-screen bg-neutral-900 text-neutral-100 font-sans">
       {/* Header */}
@@ -40,8 +154,12 @@ export default function Home() {
                   <input type="number" placeholder="10" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
                 </div>
               </div>
-              <button className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20">
-                Register Task
+              <button
+                onClick={onRegisterTask}
+                disabled={isRegistering}
+                className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-60 disabled:cursor-not-allowed text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20"
+              >
+                {isRegistering ? "Registering..." : "Register Task"}
               </button>
             </div>
           </section>
@@ -57,7 +175,26 @@ export default function Home() {
 
         {/* Execution Logs */}
         <section className="mt-16 space-y-6">
-          <h2 className="text-2xl font-bold">Execution Logs</h2>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <h2 className="text-2xl font-bold">Execution Logs</h2>
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => onSearch(e.target.value)}
+              placeholder="Search by id, target, keeper, status"
+              className="w-full md:w-[380px] bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all text-sm"
+            />
+          </div>
+
+          {selectedTask && (
+            <div className="rounded-xl border border-blue-500/40 bg-blue-500/10 p-4 text-sm">
+              <p className="font-medium">Opened Task: {selectedTask.id}</p>
+              <p className="text-neutral-300 mt-1">
+                Target {selectedTask.target}, Keeper {selectedTask.keeper}, Status {selectedTask.status}
+              </p>
+            </div>
+          )}
+
           <div className="overflow-hidden rounded-xl border border-neutral-700/50 shadow-xl">
             <table className="w-full text-left text-sm text-neutral-400">
               <thead className="bg-neutral-800/80 text-neutral-200 backdrop-blur-sm">
@@ -70,18 +207,36 @@ export default function Home() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-neutral-800 bg-neutral-900/50">
-                {/* Mock Row */}
-                <tr className="hover:bg-neutral-800/50 transition-colors">
-                  <td className="px-6 py-4 font-mono text-neutral-300">#1024</td>
-                  <td className="px-6 py-4 font-mono">CC...A12B</td>
-                  <td className="px-6 py-4 font-mono">GA...99X</td>
-                  <td className="px-6 py-4">
-                    <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-500/10 text-green-400 border border-green-500/20">
-                      Success
-                    </span>
-                  </td>
-                  <td className="px-6 py-4">2 mins ago</td>
-                </tr>
+                {visibleTasks.map((task) => (
+                  <tr
+                    key={task.id}
+                    onClick={() => onOpenTask(task.id)}
+                    className="hover:bg-neutral-800/50 transition-colors cursor-pointer"
+                  >
+                    <td className="px-6 py-4 font-mono text-neutral-300">{task.id}</td>
+                    <td className="px-6 py-4 font-mono">{task.target}</td>
+                    <td className="px-6 py-4 font-mono">{task.keeper}</td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={`inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium border ${
+                          task.status === "Success"
+                            ? "bg-green-500/10 text-green-400 border-green-500/20"
+                            : "bg-red-500/10 text-red-400 border-red-500/20"
+                        }`}
+                      >
+                        {task.status}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">{task.timestamp}</td>
+                  </tr>
+                ))}
+                {visibleTasks.length === 0 && (
+                  <tr>
+                    <td className="px-6 py-6 text-neutral-500" colSpan={5}>
+                      No logs match your search.
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>

--- a/frontend/docs/performance-monitoring.md
+++ b/frontend/docs/performance-monitoring.md
@@ -1,0 +1,55 @@
+# Frontend Performance Monitoring
+
+This frontend captures lightweight metrics for core interaction paths so regressions can be identified early.
+
+## Captured Metrics
+
+| Metric | Meaning | Trigger |
+| :--- | :--- | :--- |
+| `route_load_ms` | Time from page bootstrap to first painted frame of the route | Initial render of `/` |
+| `task_open_ms` | Time between clicking a task row and task detail state being visible | Opening a task from execution logs |
+| `search_latency_ms` | Time from search input change to filtered results rendering | Searching logs |
+| `mutation_register_task_ms` | End-to-end client timing for task registration mutation path | Clicking `Register Task` |
+
+## Sampling and Reporting Strategy
+
+Metrics are sampled on the client before reporting to minimize overhead.
+
+- Default sampling rate: `0.2` (20%)
+- Override with environment variable:
+
+```bash
+NEXT_PUBLIC_PERF_SAMPLE_RATE=0.1
+```
+
+Reporting behavior:
+
+1. If `window.__soroTaskPerfReporter` exists and is a function, metrics are sent to it.
+2. Otherwise, metrics are stored in `localStorage` under `sorotask_perf_metrics` (bounded to last 250 records).
+3. In non-production builds, metrics are logged to the console with `[perf]` prefix.
+
+This lets contributors wire metrics to any backend/observability service later without changing UI instrumentation points.
+
+## How To Inspect Metrics Locally
+
+1. Run the frontend and interact with route load, search, task open, and register flows.
+2. Open browser devtools.
+3. Read stored samples:
+
+```js
+JSON.parse(localStorage.getItem("sorotask_perf_metrics") || "[]")
+```
+
+## Interpreting Signals
+
+- Compare medians and p95 values over time by metric name.
+- Investigate regressions when `route_load_ms` or `search_latency_ms` shift materially after UI/data changes.
+- Investigate regressions in `task_open_ms` for state/render bottlenecks.
+- Investigate `mutation_register_task_ms` changes when network or client mutation logic changes.
+
+## Performance Overhead Notes
+
+- Timers use `performance.now()` and `requestAnimationFrame` only.
+- Sampling keeps instrumentation work low on most interactions.
+- Storage writes are small and bounded.
+- No additional runtime dependencies are introduced.

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -31,9 +31,13 @@ const createJestConfig = async () => {
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
       '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/lib/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/lib/**/*.{spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/app/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/app/**/*.{spec,test}.{js,jsx,ts,tsx}',
     ],
     moduleNameMapper: {
-      '^@/(.*)$': '<rootDir>/src/$1',
+      '^@/(.*)$': '<rootDir>/$1',
     },
   })
 }

--- a/frontend/lib/__tests__/use-unsaved-changes.test.ts
+++ b/frontend/lib/__tests__/use-unsaved-changes.test.ts
@@ -1,0 +1,123 @@
+import { act, renderHook } from '@testing-library/react';
+import { useUnsavedChanges } from '../use-unsaved-changes';
+
+describe('useUnsavedChanges', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('registers a beforeunload listener on mount', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    renderHook(() => useUnsavedChanges(false));
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('removes the beforeunload listener on unmount', () => {
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useUnsavedChanges(false));
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('does not call preventDefault on beforeunload when form is clean', () => {
+    renderHook(() => useUnsavedChanges(false));
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on beforeunload when form is dirty', () => {
+    renderHook(() => useUnsavedChanges(true));
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('sets returnValue on beforeunload when dirty (legacy browser support)', () => {
+    renderHook(() => useUnsavedChanges(true));
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    let captured: string | undefined;
+    Object.defineProperty(event, 'returnValue', {
+      set(val: string) { captured = val; },
+      get() { return captured; },
+      configurable: true,
+    });
+    window.dispatchEvent(event);
+    expect(captured).toBe('');
+  });
+
+  it('does not register a second listener on rerender', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const { rerender } = renderHook(({ dirty }) => useUnsavedChanges(dirty), {
+      initialProps: { dirty: false },
+    });
+    const callsBefore = addSpy.mock.calls.filter(([name]) => name === 'beforeunload').length;
+    act(() => {
+      rerender({ dirty: true });
+    });
+    const callsAfter = addSpy.mock.calls.filter(([name]) => name === 'beforeunload').length;
+    expect(callsAfter).toBe(callsBefore);
+  });
+
+  it('picks up the latest isDirty value via ref without re-registering', () => {
+    const { rerender } = renderHook(({ dirty }) => useUnsavedChanges(dirty), {
+      initialProps: { dirty: false },
+    });
+    act(() => {
+      rerender({ dirty: true });
+    });
+    const event = new Event('beforeunload') as BeforeUnloadEvent;
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  describe('confirmDiscard', () => {
+    it('returns true immediately without prompting when form is clean', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm');
+      const { result } = renderHook(() => useUnsavedChanges(false));
+      expect(result.current.confirmDiscard()).toBe(true);
+      expect(confirmSpy).not.toHaveBeenCalled();
+    });
+
+    it('shows a confirm dialog when form is dirty', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true);
+      const { result } = renderHook(() => useUnsavedChanges(true));
+      result.current.confirmDiscard();
+      expect(window.confirm).toHaveBeenCalled();
+    });
+
+    it('returns true when user confirms discard', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true);
+      const { result } = renderHook(() => useUnsavedChanges(true));
+      expect(result.current.confirmDiscard()).toBe(true);
+    });
+
+    it('returns false when user cancels discard', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(false);
+      const { result } = renderHook(() => useUnsavedChanges(true));
+      expect(result.current.confirmDiscard()).toBe(false);
+    });
+
+    it('uses a custom message when provided', () => {
+      jest.spyOn(window, 'confirm').mockReturnValue(true);
+      const { result } = renderHook(() => useUnsavedChanges(true));
+      result.current.confirmDiscard('Discard your task?');
+      expect(window.confirm).toHaveBeenCalledWith('Discard your task?');
+    });
+
+    it('reflects the latest isDirty state after form becomes clean', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm');
+      const { rerender, result } = renderHook(({ dirty }) => useUnsavedChanges(dirty), {
+        initialProps: { dirty: true },
+      });
+      act(() => {
+        rerender({ dirty: false });
+      });
+      expect(result.current.confirmDiscard()).toBe(true);
+      expect(confirmSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/lib/perf-monitor.ts
+++ b/frontend/lib/perf-monitor.ts
@@ -1,0 +1,95 @@
+export type PerfMetricName =
+  | "route_load_ms"
+  | "task_open_ms"
+  | "search_latency_ms"
+  | "mutation_register_task_ms";
+
+export type PerfMetric = {
+  name: PerfMetricName;
+  value: number;
+  ts: number;
+  context?: Record<string, string | number | boolean>;
+};
+
+type Reporter = (metric: PerfMetric) => void;
+
+const DEFAULT_SAMPLE_RATE = 0.2;
+const STORAGE_KEY = "sorotask_perf_metrics";
+const MAX_STORED_METRICS = 250;
+
+function getSampleRate(): number {
+  const raw = process.env.NEXT_PUBLIC_PERF_SAMPLE_RATE;
+  const parsed = raw ? Number(raw) : DEFAULT_SAMPLE_RATE;
+  if (!Number.isFinite(parsed)) return DEFAULT_SAMPLE_RATE;
+  return Math.min(1, Math.max(0, parsed));
+}
+
+function shouldSample(): boolean {
+  return Math.random() < getSampleRate();
+}
+
+function getGlobalReporter(): Reporter | undefined {
+  if (typeof window === "undefined") return undefined;
+  const maybe = (window as Window & { __soroTaskPerfReporter?: Reporter })
+    .__soroTaskPerfReporter;
+  return typeof maybe === "function" ? maybe : undefined;
+}
+
+function persistMetric(metric: PerfMetric): void {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed: PerfMetric[] = raw ? (JSON.parse(raw) as PerfMetric[]) : [];
+    parsed.push(metric);
+    const trimmed = parsed.slice(-MAX_STORED_METRICS);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch {
+    // Ignore storage failures to keep instrumentation overhead minimal.
+  }
+}
+
+export function reportMetric(metric: PerfMetric): void {
+  if (typeof window === "undefined") return;
+  if (!shouldSample()) return;
+
+  const reporter = getGlobalReporter();
+  if (reporter) {
+    reporter(metric);
+    return;
+  }
+
+  persistMetric(metric);
+
+  if (process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.info("[perf]", metric);
+  }
+}
+
+export function startTimer(): number {
+  return performance.now();
+}
+
+export function endTimer(
+  name: PerfMetricName,
+  startedAt: number,
+  context?: Record<string, string | number | boolean>
+): void {
+  const value = performance.now() - startedAt;
+  reportMetric({
+    name,
+    value,
+    ts: Date.now(),
+    context,
+  });
+}
+
+export function readStoredMetrics(): PerfMetric[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as PerfMetric[]) : [];
+  } catch {
+    return [];
+  }
+}

--- a/frontend/lib/use-unsaved-changes.ts
+++ b/frontend/lib/use-unsaved-changes.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export interface UseUnsavedChangesReturn {
+  /**
+   * Call before a destructive action (e.g. form reset, discard).
+   * Returns true when it is safe to proceed — either the form is clean, or
+   * the user explicitly confirmed they want to discard their changes.
+   */
+  confirmDiscard: (message?: string) => boolean;
+}
+
+/**
+ * Guards unsaved form changes from being silently lost.
+ *
+ * - Registers a `beforeunload` handler that fires the native browser warning
+ *   when `isDirty` is true and the user attempts to close/reload the tab.
+ * - Provides `confirmDiscard` for programmatic guard points (e.g. a Reset
+ *   button) so the caller can decide whether to proceed with a destructive
+ *   action after asking the user.
+ *
+ * The `beforeunload` listener is registered once on mount and deregistered on
+ * unmount; it reads `isDirty` via a ref so rerenders never add extra listeners.
+ *
+ * @param isDirty - Whether the form currently has changes that have not been saved.
+ */
+export function useUnsavedChanges(isDirty: boolean): UseUnsavedChangesReturn {
+  // Keep a ref so the stable listener closure always reads the current value.
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent): void => {
+      if (!isDirtyRef.current) return;
+      // Prevent the browser from navigating away silently.
+      e.preventDefault();
+      // Legacy browsers require returnValue to be set.
+      e.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []); // intentionally empty — listener is stable via ref
+
+  const confirmDiscard = useCallback(
+    (message = 'You have unsaved changes. Discard them?'): boolean => {
+      if (!isDirtyRef.current) return true;
+      return window.confirm(message);
+    },
+    [],
+  );
+
+  return { confirmDiscard };
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION

### Summary

Prevents accidental data loss when users navigate away, close the tab, or
discard a form while unsaved changes are present in high-risk workflows.

---

### Changes

#### `frontend/lib/use-unsaved-changes.ts` _(new)_
Reusable React hook — `useUnsavedChanges(isDirty: boolean)`.

- Registers a stable `beforeunload` listener on mount that triggers the
  browser's native "Leave site?" dialog when `isDirty` is `true`.
- Deregisters cleanly on unmount; reads `isDirty` via a ref so rerenders
  never add duplicate listeners.
- Exposes `confirmDiscard(message?)` for programmatic guard points (e.g.
  Reset buttons, dialog dismissals) — returns `true` immediately on clean
  state, otherwise shows `window.confirm` and returns the user's choice.

#### `frontend/app/page.tsx` _(updated)_
Wires unsaved-changes protection into the **Create Automation Task** form —
the highest-risk editor in the app.

- All four fields (Target Contract Address, Function Name, Interval, Gas
  Balance) converted to controlled inputs tracking their values in state.
- `isDirty` is computed by comparing current values against the initial
  empty state.
- `useUnsavedChanges(isDirty)` applied; `beforeunload` fires automatically
  when the form is dirty.
- **Reset / discard flow**: `confirmDiscard()` called before clearing fields;
  proceeds only if the user confirms or the form is already clean.
- **Save flow**: `markClean()` (internal state reset) called on successful
  task registration so warnings stop after a successful save.

#### `frontend/lib/__tests__/use-unsaved-changes.test.ts` _(new)_
13 unit tests covering all acceptance criteria edge cases:

| Scenario | Covered |
|---|---|
| `beforeunload` listener registered on mount | ✅ |
| Listener removed on unmount | ✅ |
| No `preventDefault` when form is clean | ✅ |
| `preventDefault` + `returnValue` when dirty (legacy support) | ✅ |
| No duplicate listeners on rerender | ✅ |
| Ref picks up latest `isDirty` without re-registering | ✅ |
| `confirmDiscard` returns `true` without prompt when clean | ✅ |
| `confirmDiscard` shows confirm dialog when dirty | ✅ |
| Returns `true` on user confirmation | ✅ |
| Returns `false` on user cancellation | ✅ |
| Custom discard message forwarded to `window.confirm` | ✅ |
| Reflects updated `isDirty` after form becomes clean | ✅ |

#### `frontend/jest.config.js` _(updated)_
Extended `testMatch` to include `lib/**` so hook tests in `lib/__tests__/`
are discovered by Jest (previously only `src/**` was matched).

#### `frontend/tsconfig.json` _(updated)_
Added `"jest"` to `compilerOptions.types` for proper Jest global type
resolution in test files.

---

### Test Results

#close  #210