### PR TITLE
[Frontend] Implement Dynamic Custom Fields Across Task Create and Edit Flows (#200)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,495 @@
-import Image from "next/image";
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  useSorobanTx,
+  type TxState,
+  type TxPhaseCallbacks,
+} from '@/lib/use-soroban-tx';
+import {
+  formatFieldValue,
+  initialValuesFromDefinitions,
+  sanitizeValues,
+  validateValues,
+  type CustomFieldDefinition,
+  type CustomFieldValues,
+} from '@/lib/custom-fields';
+import {
+  CustomFieldsEditableRenderer,
+  CustomFieldsReadOnlyRenderer,
+} from '@/lib/custom-fields-renderer';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const STELLAR_EXPERT_BASE = 'https://stellar.expert/explorer/testnet/tx';
+const CUSTOM_FIELD_DEFINITIONS: CustomFieldDefinition[] = [
+  {
+    id: 'cf-team',
+    key: 'team',
+    label: 'Owning Team',
+    type: 'text',
+    required: true,
+  },
+  {
+    id: 'cf-priority',
+    key: 'priority',
+    label: 'Priority',
+    type: 'select',
+    required: true,
+    options: ['low', 'medium', 'high'],
+  },
+  {
+    id: 'cf-budget',
+    key: 'budget',
+    label: 'Monthly Budget (USD)',
+    type: 'number',
+  },
+  {
+    id: 'cf-compliance',
+    key: 'complianceRequired',
+    label: 'Compliance Required',
+    type: 'checkbox',
+  },
+  {
+    id: 'cf-goLive',
+    key: 'goLiveDate',
+    label: 'Go-Live Date',
+    type: 'date',
+  },
+  {
+    id: 'cf-legacy',
+    key: 'legacyTag',
+    label: 'Legacy Tag',
+    type: 'text',
+    retired: true,
+  },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function truncateHash(hash: string): string {
+  return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+}
+
+const TX_STEPS = ['Initiate', 'Sign', 'Submit', 'Pending', 'Confirmed'] as const;
+
+function stepIndexForState(state: TxState): number {
+  switch (state.status) {
+    case 'idle':       return 0;
+    case 'signing':    return 1;
+    case 'submitting': return 2;
+    case 'pending':    return 3;
+    case 'success':    return 4;
+    case 'error':      return -1;
+  }
+}
+
+// ─── TxStatusPanel ────────────────────────────────────────────────────────────
+
+interface TxStatusPanelProps {
+  state: TxState;
+  onReset: () => void;
+  onRetry: () => void;
+}
+
+function TxStatusPanel({ state, onReset, onRetry }: TxStatusPanelProps) {
+  if (state.status === 'idle') return null;
+
+  const activeStep = stepIndexForState(state);
+  const isError = state.status === 'error';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="bg-neutral-800/80 border border-neutral-700/50 rounded-xl p-6 space-y-5 shadow-2xl backdrop-blur-sm"
+    >
+      {!isError && (
+        <div className="flex items-center gap-1" aria-label="Transaction progress">
+          {TX_STEPS.map((step, i) => {
+            const isDone = i < activeStep;
+            const isActive = i === activeStep;
+            return (
+              <div key={step} className="flex items-center gap-1 flex-1 last:flex-none">
+                <div className="flex flex-col items-center gap-1 min-w-0">
+                  <div
+                    className={[
+                      'w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold transition-all duration-300 shrink-0',
+                      isDone
+                        ? 'bg-blue-500 text-white'
+                        : isActive
+                        ? 'bg-blue-600 text-white ring-2 ring-blue-400/50 ring-offset-2 ring-offset-neutral-800'
+                        : 'bg-neutral-700 text-neutral-500',
+                    ].join(' ')}
+                    aria-current={isActive ? 'step' : undefined}
+                  >
+                    {isDone ? '\u2713' : i + 1}
+                  </div>
+                  <span className={[
+                    'text-xs hidden sm:block whitespace-nowrap',
+                    isActive ? 'text-blue-400 font-medium' : isDone ? 'text-neutral-400' : 'text-neutral-600',
+                  ].join(' ')}>
+                    {step}
+                  </span>
+                </div>
+                {i < TX_STEPS.length - 1 && (
+                  <div className={[
+                    'h-0.5 flex-1 mb-4 transition-all duration-500',
+                    isDone ? 'bg-blue-500' : 'bg-neutral-700',
+                  ].join(' ')} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {state.status === 'signing' && (
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-lg bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center shrink-0 animate-pulse">
+            <span className="text-yellow-400 text-lg" aria-hidden="true">🔐</span>
+          </div>
+          <div>
+            <p className="font-semibold text-neutral-100">Check your wallet</p>
+            <p className="text-sm text-neutral-400 mt-0.5">
+              A signing prompt is waiting in your wallet extension. Review the transaction details and approve to continue.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {state.status === 'submitting' && (
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center shrink-0">
+            <svg className="animate-spin w-5 h-5 text-blue-400" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          </div>
+          <div>
+            <p className="font-semibold text-neutral-100">Submitting to Stellar</p>
+            <p className="text-sm text-neutral-400 mt-0.5">
+              Broadcasting your signed transaction to the Soroban network via Horizon.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {state.status === 'pending' && (
+        <div className="space-y-3">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center shrink-0">
+              <svg className="animate-spin w-5 h-5 text-blue-400" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            </div>
+            <div>
+              <p className="font-semibold text-neutral-100">Transaction pending</p>
+              <p className="text-sm text-neutral-400 mt-0.5">Your transaction is on-chain and awaiting ledger confirmation.</p>
+            </div>
+          </div>
+          <div className="bg-neutral-900/60 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+            <span className="font-mono text-xs text-neutral-400 truncate" aria-label="Transaction hash">
+              {truncateHash(state.hash)}
+            </span>
+            <a href={`${STELLAR_EXPERT_BASE}/${state.hash}`} target="_blank" rel="noopener noreferrer"
+              className="text-xs text-blue-400 hover:text-blue-300 underline shrink-0 transition-colors">
+              View on Explorer ↗
+            </a>
+          </div>
+        </div>
+      )}
+
+      {state.status === 'success' && (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-lg bg-green-500/10 border border-green-500/20 flex items-center justify-center shrink-0">
+              <span className="text-green-400 text-lg" aria-hidden="true">✓</span>
+            </div>
+            <div>
+              <p className="font-semibold text-green-400">Task registered successfully</p>
+              <p className="text-sm text-neutral-400 mt-0.5">Your automation task is now live on-chain and will be executed by a keeper.</p>
+            </div>
+          </div>
+          <div className="bg-neutral-900/60 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
+            <span className="font-mono text-xs text-neutral-400 truncate" aria-label="Transaction hash">
+              {truncateHash(state.hash)}
+            </span>
+            <a href={`${STELLAR_EXPERT_BASE}/${state.hash}`} target="_blank" rel="noopener noreferrer"
+              className="text-xs text-blue-400 hover:text-blue-300 underline shrink-0 transition-colors">
+              View on Explorer ↗
+            </a>
+          </div>
+          <button onClick={onReset}
+            className="w-full bg-neutral-700 hover:bg-neutral-600 text-neutral-100 font-medium py-2 rounded-lg transition-colors text-sm">
+            Register Another Task
+          </button>
+        </div>
+      )}
+
+      {state.status === 'error' && (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-lg bg-red-500/10 border border-red-500/20 flex items-center justify-center shrink-0">
+              <span className="text-red-400 text-lg" aria-hidden="true">✕</span>
+            </div>
+            <div className="min-w-0">
+              <p className="font-semibold text-red-400">
+                {state.reason === 'user_rejected'      && 'Signature rejected'}
+                {state.reason === 'submission_failed'  && 'Submission failed'}
+                {state.reason === 'transaction_failed' && 'Transaction failed on-chain'}
+                {state.reason === 'timeout'            && 'Transaction timed out'}
+              </p>
+              <p className="text-sm text-neutral-400 mt-0.5 break-words">{state.message}</p>
+              {state.reason === 'user_rejected' && (
+                <p className="text-xs text-neutral-500 mt-1">Your funds were not moved. You can safely try again.</p>
+              )}
+              {state.reason === 'timeout' && (
+                <p className="text-xs text-neutral-500 mt-1">The transaction was dropped before confirmation. No funds were deducted.</p>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-3">
+            {state.reason !== 'user_rejected' ? (
+              <>
+                <button onClick={onRetry}
+                  className="flex-1 bg-blue-600 hover:bg-blue-500 text-white font-medium py-2 rounded-lg transition-colors text-sm">
+                  Try Again
+                </button>
+                <button onClick={onReset}
+                  className="flex-1 bg-neutral-700 hover:bg-neutral-600 text-neutral-100 font-medium py-2 rounded-lg transition-colors text-sm">
+                  Start Over
+                </button>
+              </>
+            ) : (
+              <button onClick={onRetry}
+                className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-2 rounded-lg transition-colors text-sm">
+                Sign Again
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Form & Executor ──────────────────────────────────────────────────────────
+
+interface TaskDraft {
+  contractAddress: string;
+  functionName: string;
+  interval: string;
+  gasBalance: string;
+  customValues: CustomFieldValues;
+}
+
+interface TaskRecord {
+  id: string;
+  contractAddress: string;
+  functionName: string;
+  interval: string;
+  gasBalance: string;
+  customValues: CustomFieldValues;
+  txHash: string;
+  createdAt: string;
+}
+
+function createEmptyDraft(): TaskDraft {
+  return {
+    contractAddress: '',
+    functionName: '',
+    interval: '',
+    gasBalance: '',
+    customValues: initialValuesFromDefinitions(CUSTOM_FIELD_DEFINITIONS),
+  };
+}
+
+const SEED_TASKS: TaskRecord[] = [
+  {
+    id: 'TASK-1024',
+    contractAddress: 'CC...A12B',
+    functionName: 'harvest_yield',
+    interval: '3600',
+    gasBalance: '10',
+    customValues: sanitizeValues(CUSTOM_FIELD_DEFINITIONS, {
+      team: 'Treasury Ops',
+      priority: 'high',
+      budget: 2500,
+      complianceRequired: true,
+      goLiveDate: '2026-05-15',
+      legacyTag: 'v1-migration',
+      removedOwner: 'ops-7',
+    }),
+    txHash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+    createdAt: '2 mins ago',
+  },
+];
+
+/** Demo executor — replace with real Soroban SDK signing + Horizon submission */
+function buildMockExecutor(_form: TaskDraft) {
+  return async (callbacks: TxPhaseCallbacks): Promise<string> => {
+    await delay(1800);
+    callbacks.onSubmitting();
+    await delay(1200);
+    const hash = Array.from({ length: 64 }, () =>
+      Math.floor(Math.random() * 16).toString(16),
+    ).join('');
+    callbacks.onPending(hash);
+    await delay(2500);
+    return hash;
+  };
+}
+
+// ─── Home Page ────────────────────────────────────────────────────────────────
 
 export default function Home() {
+  const [createDraft, setCreateDraft] = useState<TaskDraft>(createEmptyDraft);
+  const [createFieldErrors, setCreateFieldErrors] = useState<Record<string, string>>({});
+  const [tasks, setTasks] = useState<TaskRecord[]>(SEED_TASKS);
+  const [selectedTaskId, setSelectedTaskId] = useState<string>(SEED_TASKS[0]?.id ?? '');
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<TaskDraft>(createEmptyDraft);
+  const [editFieldErrors, setEditFieldErrors] = useState<Record<string, string>>({});
+
+  const { state, execute, reset } = useSorobanTx();
+
+  const isInFlight =
+    state.status === 'signing' ||
+    state.status === 'submitting' ||
+    state.status === 'pending';
+  const isTerminal = state.status === 'success' || state.status === 'error';
+
+  const handleRegisterTask = useCallback(async () => {
+    if (isInFlight || isTerminal) return;
+
+    const validation = validateValues(CUSTOM_FIELD_DEFINITIONS, createDraft.customValues);
+    if (!validation.isValid) {
+      setCreateFieldErrors(validation.errors);
+      return;
+    }
+
+    setCreateFieldErrors({});
+
+    let submittedHash = '';
+    await execute(async (callbacks) => {
+      const hash = await buildMockExecutor(createDraft)(callbacks);
+      submittedHash = hash;
+      return hash;
+    });
+
+    if (submittedHash !== '') {
+      const nextTask: TaskRecord = {
+        id: `TASK-${Math.floor(Math.random() * 9000) + 1000}`,
+        contractAddress: createDraft.contractAddress || 'C...NEW',
+        functionName: createDraft.functionName || 'custom_call',
+        interval: createDraft.interval || '0',
+        gasBalance: createDraft.gasBalance || '0',
+        customValues: sanitizeValues(CUSTOM_FIELD_DEFINITIONS, createDraft.customValues),
+        txHash: submittedHash,
+        createdAt: 'just now',
+      };
+
+      setTasks((prev) => [nextTask, ...prev]);
+      setSelectedTaskId(nextTask.id);
+      setCreateDraft(createEmptyDraft());
+    }
+  }, [createDraft, execute, isInFlight, isTerminal]);
+
+  const handleReset = useCallback(() => {
+    reset();
+    setCreateFieldErrors({});
+    setCreateDraft(createEmptyDraft());
+  }, [reset]);
+
+  const handleRetry = useCallback(async () => {
+    reset();
+    await delay(50);
+    await handleRegisterTask();
+  }, [handleRegisterTask, reset]);
+
+  const handleFieldChange = useCallback(
+    (field: keyof Omit<TaskDraft, 'customValues'>) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setCreateDraft((prev) => ({ ...prev, [field]: e.target.value }));
+    },
+    [],
+  );
+
+  const handleCreateCustomFieldChange = useCallback((key: string, value: string | number | boolean) => {
+    setCreateDraft((prev) => ({
+      ...prev,
+      customValues: {
+        ...prev.customValues,
+        [key]: value,
+      },
+    }));
+  }, []);
+
+  const handleStartEdit = useCallback((task: TaskRecord) => {
+    setEditingTaskId(task.id);
+    setEditFieldErrors({});
+    setEditDraft({
+      contractAddress: task.contractAddress,
+      functionName: task.functionName,
+      interval: task.interval,
+      gasBalance: task.gasBalance,
+      customValues: sanitizeValues(CUSTOM_FIELD_DEFINITIONS, task.customValues),
+    });
+  }, []);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingTaskId(null);
+    setEditFieldErrors({});
+  }, []);
+
+  const handleEditFieldChange = useCallback(
+    (field: keyof Omit<TaskDraft, 'customValues'>) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setEditDraft((prev) => ({ ...prev, [field]: e.target.value }));
+    },
+    [],
+  );
+
+  const handleEditCustomFieldChange = useCallback((key: string, value: string | number | boolean) => {
+    setEditDraft((prev) => ({
+      ...prev,
+      customValues: {
+        ...prev.customValues,
+        [key]: value,
+      },
+    }));
+  }, []);
+
+  const handleSaveEdit = useCallback(() => {
+    if (!editingTaskId) return;
+
+    const validation = validateValues(CUSTOM_FIELD_DEFINITIONS, editDraft.customValues);
+    if (!validation.isValid) {
+      setEditFieldErrors(validation.errors);
+      return;
+    }
+
+    setTasks((prev) => prev.map((task) => {
+      if (task.id !== editingTaskId) return task;
+      return {
+        ...task,
+        contractAddress: editDraft.contractAddress,
+        functionName: editDraft.functionName,
+        interval: editDraft.interval,
+        gasBalance: editDraft.gasBalance,
+        customValues: sanitizeValues(CUSTOM_FIELD_DEFINITIONS, editDraft.customValues),
+      };
+    }));
+    setEditFieldErrors({});
+    setEditingTaskId(null);
+  }, [editDraft, editingTaskId]);
+
+  const selectedTask = tasks.find((task) => task.id === selectedTaskId) ?? null;
+
   return (
     <div className="min-h-screen bg-neutral-900 text-neutral-100 font-sans">
       {/* Header */}
@@ -18,40 +507,184 @@ export default function Home() {
 
       <main className="container mx-auto px-6 py-12">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
-          {/* Create Task Section */}
           <section className="space-y-6">
             <h2 className="text-2xl font-bold">Create Automation Task</h2>
-            <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 space-y-4 shadow-xl">
-              <div>
-                <label className="block text-sm font-medium text-neutral-400 mb-1">Target Contract Address</label>
-                <input type="text" placeholder="C..." className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-neutral-400 mb-1">Function Name</label>
-                <input type="text" placeholder="harvest_yield" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
+
+            {!isTerminal && (
+              <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 space-y-4 shadow-xl">
                 <div>
-                  <label className="block text-sm font-medium text-neutral-400 mb-1">Interval (seconds)</label>
-                  <input type="number" placeholder="3600" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  <label htmlFor="contractAddress" className="block text-sm font-medium text-neutral-400 mb-1">Target Contract Address</label>
+                  <input id="contractAddress" type="text" placeholder="C..."
+                    value={createDraft.contractAddress} onChange={handleFieldChange('contractAddress')}
+                    disabled={isInFlight} aria-label="Target contract address"
+                    className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm disabled:opacity-50 disabled:cursor-not-allowed" />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-neutral-400 mb-1">Gas Balance (XLM)</label>
-                  <input type="number" placeholder="10" className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm" />
+                  <label htmlFor="functionName" className="block text-sm font-medium text-neutral-400 mb-1">Function Name</label>
+                  <input id="functionName" type="text" placeholder="harvest_yield"
+                    value={createDraft.functionName} onChange={handleFieldChange('functionName')}
+                    disabled={isInFlight} aria-label="Contract function name"
+                    className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm disabled:opacity-50 disabled:cursor-not-allowed" />
                 </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label htmlFor="interval" className="block text-sm font-medium text-neutral-400 mb-1">Interval (seconds)</label>
+                    <input id="interval" type="number" placeholder="3600"
+                      value={createDraft.interval} onChange={handleFieldChange('interval')}
+                      disabled={isInFlight} aria-label="Execution interval in seconds"
+                      className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm disabled:opacity-50 disabled:cursor-not-allowed" />
+                  </div>
+                  <div>
+                    <label htmlFor="gasBalance" className="block text-sm font-medium text-neutral-400 mb-1">Gas Balance (XLM)</label>
+                    <input id="gasBalance" type="number" placeholder="10"
+                      value={createDraft.gasBalance} onChange={handleFieldChange('gasBalance')}
+                      disabled={isInFlight} aria-label="Gas balance in XLM"
+                      className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm disabled:opacity-50 disabled:cursor-not-allowed" />
+                  </div>
+                </div>
+
+                <CustomFieldsEditableRenderer
+                  definitions={CUSTOM_FIELD_DEFINITIONS}
+                  values={createDraft.customValues}
+                  errors={createFieldErrors}
+                  disabled={isInFlight}
+                  onValueChange={handleCreateCustomFieldChange}
+                />
+
+                <button
+                  onClick={handleRegisterTask}
+                  disabled={isInFlight}
+                  aria-disabled={isInFlight}
+                  className="w-full bg-blue-600 hover:bg-blue-500 disabled:opacity-60 disabled:cursor-not-allowed text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20 flex items-center justify-center gap-2"
+                >
+                  {isInFlight ? (
+                    <>
+                      <svg className="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                      </svg>
+                      {state.status === 'signing'    && 'Waiting for wallet…'}
+                      {state.status === 'submitting' && 'Submitting to Stellar…'}
+                      {state.status === 'pending'    && 'Awaiting confirmation…'}
+                    </>
+                  ) : 'Register Task'}
+                </button>
               </div>
-              <button className="w-full bg-blue-600 hover:bg-blue-500 text-white font-medium py-3 rounded-lg transition-colors mt-2 shadow-lg shadow-blue-600/20">
-                Register Task
-              </button>
-            </div>
+            )}
+
+            <TxStatusPanel state={state} onReset={handleReset} onRetry={handleRetry} />
           </section>
 
           {/* Your Tasks Section */}
           <section className="space-y-6">
             <h2 className="text-2xl font-bold">Your Tasks</h2>
-            <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 min-h-[300px] flex flex-col items-center justify-center text-neutral-500 shadow-xl">
-              <p>No tasks registered yet.</p>
-            </div>
+
+            {tasks.length === 0 ? (
+              <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-6 min-h-[300px] flex flex-col items-center justify-center text-neutral-500 shadow-xl">
+                <p>No tasks registered yet.</p>
+              </div>
+            ) : (
+              <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-4 space-y-3 shadow-xl">
+                {tasks.map((task) => (
+                  <div key={task.id} className="border border-neutral-700/50 rounded-lg p-3 bg-neutral-900/40">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-mono text-sm text-neutral-200">{task.id}</p>
+                        <p className="text-xs text-neutral-500 mt-1">{task.functionName} • {task.contractAddress}</p>
+                        <p className="text-xs text-neutral-400 mt-2">
+                          Team: {formatFieldValue(CUSTOM_FIELD_DEFINITIONS.find((f) => f.key === 'team'), task.customValues.team)}
+                          {' '}• Priority: {formatFieldValue(CUSTOM_FIELD_DEFINITIONS.find((f) => f.key === 'priority'), task.customValues.priority)}
+                        </p>
+                      </div>
+                      <div className="flex gap-2 shrink-0">
+                        <button
+                          onClick={() => setSelectedTaskId(task.id)}
+                          className="text-xs px-2 py-1 rounded bg-neutral-700 hover:bg-neutral-600 text-neutral-100"
+                        >
+                          Details
+                        </button>
+                        <button
+                          onClick={() => handleStartEdit(task)}
+                          className="text-xs px-2 py-1 rounded bg-blue-600 hover:bg-blue-500 text-white"
+                        >
+                          Edit
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {selectedTask && (
+              <div className="bg-neutral-800/50 border border-neutral-700/50 rounded-xl p-5 space-y-4 shadow-xl">
+                <h3 className="text-lg font-semibold">Task Detail: {selectedTask.id}</h3>
+                <div className="grid grid-cols-2 gap-3 text-sm">
+                  <div>
+                    <p className="text-neutral-500">Contract</p>
+                    <p className="font-mono text-neutral-200">{selectedTask.contractAddress}</p>
+                  </div>
+                  <div>
+                    <p className="text-neutral-500">Function</p>
+                    <p className="font-mono text-neutral-200">{selectedTask.functionName}</p>
+                  </div>
+                </div>
+
+                <CustomFieldsReadOnlyRenderer
+                  definitions={CUSTOM_FIELD_DEFINITIONS}
+                  values={selectedTask.customValues}
+                />
+              </div>
+            )}
+
+            {editingTaskId && (
+              <div className="bg-neutral-800/80 border border-neutral-700/50 rounded-xl p-5 space-y-4 shadow-xl">
+                <h3 className="text-lg font-semibold">Edit Task {editingTaskId}</h3>
+
+                <div>
+                  <label htmlFor="edit-contractAddress" className="block text-sm font-medium text-neutral-400 mb-1">Target Contract Address</label>
+                  <input
+                    id="edit-contractAddress"
+                    type="text"
+                    value={editDraft.contractAddress}
+                    onChange={handleEditFieldChange('contractAddress')}
+                    className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="edit-functionName" className="block text-sm font-medium text-neutral-400 mb-1">Function Name</label>
+                  <input
+                    id="edit-functionName"
+                    type="text"
+                    value={editDraft.functionName}
+                    onChange={handleEditFieldChange('functionName')}
+                    className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all font-mono text-sm"
+                  />
+                </div>
+
+                <CustomFieldsEditableRenderer
+                  definitions={CUSTOM_FIELD_DEFINITIONS}
+                  values={editDraft.customValues}
+                  errors={editFieldErrors}
+                  onValueChange={handleEditCustomFieldChange}
+                />
+
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleSaveEdit}
+                    className="flex-1 bg-blue-600 hover:bg-blue-500 text-white font-medium py-2 rounded-lg"
+                  >
+                    Save Changes
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    className="flex-1 bg-neutral-700 hover:bg-neutral-600 text-neutral-100 font-medium py-2 rounded-lg"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
           </section>
         </div>
 
@@ -66,22 +699,31 @@ export default function Home() {
                   <th className="px-6 py-4 font-medium">Target</th>
                   <th className="px-6 py-4 font-medium">Keeper</th>
                   <th className="px-6 py-4 font-medium">Status</th>
+                  <th className="px-6 py-4 font-medium">Tx Hash</th>
                   <th className="px-6 py-4 font-medium">Timestamp</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-neutral-800 bg-neutral-900/50">
-                {/* Mock Row */}
-                <tr className="hover:bg-neutral-800/50 transition-colors">
-                  <td className="px-6 py-4 font-mono text-neutral-300">#1024</td>
-                  <td className="px-6 py-4 font-mono">CC...A12B</td>
-                  <td className="px-6 py-4 font-mono">GA...99X</td>
-                  <td className="px-6 py-4">
-                    <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-500/10 text-green-400 border border-green-500/20">
-                      Success
-                    </span>
-                  </td>
-                  <td className="px-6 py-4">2 mins ago</td>
-                </tr>
+                {tasks.map((task) => (
+                  <tr key={task.id} className="hover:bg-neutral-800/50 transition-colors">
+                    <td className="px-6 py-4 font-mono text-neutral-300">{task.id}</td>
+                    <td className="px-6 py-4 font-mono">{task.contractAddress}</td>
+                    <td className="px-6 py-4 font-mono">GA...99X</td>
+                    <td className="px-6 py-4">
+                      <span className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-500/10 text-green-400 border border-green-500/20">
+                        Success
+                      </span>
+                    </td>
+                    <td className="px-6 py-4">
+                      <a href={`${STELLAR_EXPERT_BASE}/${task.txHash}`}
+                        target="_blank" rel="noopener noreferrer"
+                        className="font-mono text-blue-400 hover:text-blue-300 underline transition-colors">
+                        {truncateHash(task.txHash)}
+                      </a>
+                    </td>
+                    <td className="px-6 py-4">{task.createdAt}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -29,11 +29,13 @@ const createJestConfig = async () => {
       },
     },
     testMatch: [
+      '<rootDir>/lib/**/__tests__/**/*.{js,jsx,ts,tsx}',
+      '<rootDir>/lib/**/*.{spec,test}.{js,jsx,ts,tsx}',
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
       '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
     ],
     moduleNameMapper: {
-      '^@/(.*)$': '<rootDir>/src/$1',
+      '^@/(.*)$': '<rootDir>/$1',
     },
   })
 }

--- a/frontend/lib/__tests__/custom-fields.test.ts
+++ b/frontend/lib/__tests__/custom-fields.test.ts
@@ -1,0 +1,82 @@
+import {
+  coerceForField,
+  formatFieldValue,
+  initialValuesFromDefinitions,
+  sanitizeValues,
+  validateValues,
+  type CustomFieldDefinition,
+} from '@/lib/custom-fields';
+
+const definitions: CustomFieldDefinition[] = [
+  { id: 'f1', key: 'team', label: 'Team', type: 'text', required: true },
+  { id: 'f2', key: 'priority', label: 'Priority', type: 'select', required: true, options: ['low', 'medium', 'high'] },
+  { id: 'f3', key: 'budget', label: 'Budget', type: 'number' },
+  { id: 'f4', key: 'compliance', label: 'Compliance Required', type: 'checkbox' },
+  { id: 'f5', key: 'deadline', label: 'Deadline', type: 'date' },
+  { id: 'f6', key: 'legacyTag', label: 'Legacy Tag', type: 'text', retired: true },
+];
+
+describe('custom-fields utilities', () => {
+  it('coerces representative values for each field type', () => {
+    expect(coerceForField(definitions[0], 42)).toBe('42');
+    expect(coerceForField(definitions[1], 'high')).toBe('high');
+    expect(coerceForField(definitions[2], '15.5')).toBe(15.5);
+    expect(coerceForField(definitions[3], 'true')).toBe(true);
+    expect(coerceForField(definitions[4], '2026-04-27')).toBe('2026-04-27');
+  });
+
+  it('validates required and invalid values safely', () => {
+    const result = validateValues(definitions, {
+      team: '',
+      priority: 'urgent',
+      budget: 'bad' as unknown as number,
+      compliance: 'yes' as unknown as boolean,
+      deadline: '04/27/2026',
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.team).toContain('required');
+    expect(result.errors.priority).toContain('invalid selection');
+    expect(result.errors.budget).toContain('valid number');
+    expect(result.errors.compliance).toContain('true or false');
+    expect(result.errors.deadline).toContain('valid date');
+  });
+
+  it('builds default initial values for active fields only', () => {
+    const initial = initialValuesFromDefinitions(definitions);
+
+    expect(initial.team).toBe('');
+    expect(initial.priority).toBe('');
+    expect(initial.budget).toBe('');
+    expect(initial.compliance).toBe(false);
+    expect(initial.deadline).toBe('');
+    expect(initial.legacyTag).toBeUndefined();
+  });
+
+  it('formats missing definitions and retired select options gracefully', () => {
+    const priorityDef = definitions[1];
+
+    expect(formatFieldValue(undefined, 'legacy-value')).toContain('field definition removed');
+    expect(formatFieldValue(priorityDef, 'archived')).toContain('option retired');
+  });
+
+  it('sanitizes values when schema changes occur', () => {
+    const raw = {
+      team: 'Core',
+      priority: 'medium',
+      budget: '1000',
+      compliance: 'false',
+      deadline: '2026-05-01',
+      removedField: 99,
+    };
+
+    const sanitized = sanitizeValues(definitions, raw);
+
+    expect(sanitized.team).toBe('Core');
+    expect(sanitized.priority).toBe('medium');
+    expect(sanitized.budget).toBe(1000);
+    expect(sanitized.compliance).toBe(false);
+    expect(sanitized.deadline).toBe('2026-05-01');
+    expect(sanitized.removedField).toBe(99);
+  });
+});

--- a/frontend/lib/custom-fields-renderer.tsx
+++ b/frontend/lib/custom-fields-renderer.tsx
@@ -1,0 +1,170 @@
+import type { ChangeEvent } from 'react';
+import {
+  type CustomFieldDefinition,
+  type CustomFieldValues,
+  formatFieldValue,
+  getDefinitionMap,
+} from '@/lib/custom-fields';
+
+interface EditableProps {
+  definitions: CustomFieldDefinition[];
+  values: CustomFieldValues;
+  errors?: Record<string, string>;
+  disabled?: boolean;
+  onValueChange: (key: string, value: string | number | boolean) => void;
+}
+
+export function CustomFieldsEditableRenderer({
+  definitions,
+  values,
+  errors,
+  disabled,
+  onValueChange,
+}: EditableProps) {
+  const activeDefinitions = definitions.filter((field) => !field.retired);
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-neutral-100">Custom Fields</h3>
+      {activeDefinitions.length === 0 && (
+        <p className="text-sm text-neutral-500">No active custom fields are configured.</p>
+      )}
+
+      {activeDefinitions.map((field) => {
+        const rawValue = values[field.key];
+        const valueString = typeof rawValue === 'string' ? rawValue : '';
+        const valueNumber = typeof rawValue === 'number' ? rawValue : '';
+        const valueBoolean = rawValue === true;
+
+        return (
+          <div key={field.id}>
+            <label htmlFor={field.key} className="block text-sm font-medium text-neutral-400 mb-1">
+              {field.label}
+              {field.required ? <span className="text-red-400"> *</span> : null}
+            </label>
+
+            {field.type === 'text' && (
+              <input
+                id={field.key}
+                type="text"
+                value={valueString}
+                disabled={disabled}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => onValueChange(field.key, event.target.value)}
+                className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all text-sm disabled:opacity-50"
+              />
+            )}
+
+            {field.type === 'select' && (
+              <select
+                id={field.key}
+                value={valueString}
+                disabled={disabled}
+                onChange={(event: ChangeEvent<HTMLSelectElement>) => onValueChange(field.key, event.target.value)}
+                className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all text-sm disabled:opacity-50"
+              >
+                <option value="">Select one</option>
+                {(field.options ?? []).map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            )}
+
+            {field.type === 'number' && (
+              <input
+                id={field.key}
+                type="number"
+                value={valueNumber}
+                disabled={disabled}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                  onValueChange(field.key, event.target.value === '' ? '' : Number(event.target.value));
+                }}
+                className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all text-sm disabled:opacity-50"
+              />
+            )}
+
+            {field.type === 'checkbox' && (
+              <label className="inline-flex items-center gap-2 text-sm text-neutral-300" htmlFor={field.key}>
+                <input
+                  id={field.key}
+                  type="checkbox"
+                  checked={valueBoolean}
+                  disabled={disabled}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => onValueChange(field.key, event.target.checked)}
+                  className="w-4 h-4 accent-blue-500"
+                />
+                Enabled
+              </label>
+            )}
+
+            {field.type === 'date' && (
+              <input
+                id={field.key}
+                type="date"
+                value={valueString}
+                disabled={disabled}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => onValueChange(field.key, event.target.value)}
+                className="w-full bg-neutral-900 border border-neutral-700/50 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition-all text-sm disabled:opacity-50"
+              />
+            )}
+
+            {errors?.[field.key] && <p className="text-xs text-red-400 mt-1">{errors[field.key]}</p>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ReadOnlyProps {
+  definitions: CustomFieldDefinition[];
+  values: CustomFieldValues;
+  title?: string;
+}
+
+export function CustomFieldsReadOnlyRenderer({ definitions, values, title = 'Custom Field Values' }: ReadOnlyProps) {
+  const definitionMap = getDefinitionMap(definitions);
+  const keys = Object.keys(values);
+
+  if (keys.length === 0) {
+    return (
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-neutral-100">{title}</h3>
+        <p className="text-sm text-neutral-500">No custom values were captured.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-lg font-semibold text-neutral-100">{title}</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {keys.map((key) => {
+          const definition = definitionMap.get(key);
+          const label = definition ? definition.label : `Retired field: ${key}`;
+          const value = formatFieldValue(definition, values[key]);
+
+          return (
+            <div key={key} className="bg-neutral-900/60 border border-neutral-700/50 rounded-lg px-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-neutral-400">{label}</p>
+                {definition?.retired ? (
+                  <span className="text-[10px] uppercase tracking-wide text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+                    Retired
+                  </span>
+                ) : null}
+                {!definition ? (
+                  <span className="text-[10px] uppercase tracking-wide text-neutral-300 bg-neutral-700/50 border border-neutral-600 rounded px-1.5 py-0.5">
+                    Missing Schema
+                  </span>
+                ) : null}
+              </div>
+              <p className="text-sm text-neutral-200 mt-1 break-words">{value}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/custom-fields.ts
+++ b/frontend/lib/custom-fields.ts
@@ -1,0 +1,169 @@
+export type CustomFieldType = 'text' | 'select' | 'number' | 'checkbox' | 'date';
+
+export interface CustomFieldDefinition {
+  id: string;
+  key: string;
+  label: string;
+  type: CustomFieldType;
+  required?: boolean;
+  options?: string[];
+  retired?: boolean;
+}
+
+export type CustomFieldPrimitive = string | number | boolean | null;
+export type CustomFieldValues = Record<string, CustomFieldPrimitive | undefined>;
+
+export interface ValidationResult {
+  isValid: boolean;
+  errors: Record<string, string>;
+}
+
+export function getDefinitionMap(definitions: CustomFieldDefinition[]): Map<string, CustomFieldDefinition> {
+  return new Map(definitions.map((field) => [field.key, field]));
+}
+
+export function coerceForField(
+  definition: CustomFieldDefinition | undefined,
+  value: unknown,
+): CustomFieldPrimitive | undefined {
+  if (value === undefined) return undefined;
+
+  if (!definition) {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+      return value;
+    }
+    return String(value);
+  }
+
+  switch (definition.type) {
+    case 'text': {
+      return value === null ? '' : String(value);
+    }
+    case 'select': {
+      return value === null ? '' : String(value);
+    }
+    case 'number': {
+      if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    case 'checkbox': {
+      if (typeof value === 'boolean') return value;
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      return undefined;
+    }
+    case 'date': {
+      if (value === null) return '';
+      const asString = String(value);
+      return /^\d{4}-\d{2}-\d{2}$/.test(asString) ? asString : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+export function sanitizeValues(
+  definitions: CustomFieldDefinition[],
+  values: Record<string, unknown>,
+): CustomFieldValues {
+  const definitionMap = getDefinitionMap(definitions);
+  const sanitized: CustomFieldValues = {};
+
+  for (const [key, raw] of Object.entries(values)) {
+    sanitized[key] = coerceForField(definitionMap.get(key), raw);
+  }
+
+  return sanitized;
+}
+
+export function validateValues(
+  definitions: CustomFieldDefinition[],
+  values: CustomFieldValues,
+): ValidationResult {
+  const errors: Record<string, string> = {};
+
+  for (const definition of definitions) {
+    if (definition.retired) continue;
+
+    const value = values[definition.key];
+    const hasValue = value !== undefined && value !== null && value !== '';
+
+    if (definition.required && !hasValue) {
+      errors[definition.key] = `${definition.label} is required.`;
+      continue;
+    }
+
+    if (!hasValue) continue;
+
+    if (definition.type === 'number' && typeof value !== 'number') {
+      errors[definition.key] = `${definition.label} must be a valid number.`;
+      continue;
+    }
+
+    if (definition.type === 'checkbox' && typeof value !== 'boolean') {
+      errors[definition.key] = `${definition.label} must be true or false.`;
+      continue;
+    }
+
+    if (definition.type === 'date' && (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value))) {
+      errors[definition.key] = `${definition.label} must be a valid date (YYYY-MM-DD).`;
+      continue;
+    }
+
+    if (definition.type === 'select') {
+      if (typeof value !== 'string' || !definition.options || !definition.options.includes(value)) {
+        errors[definition.key] = `${definition.label} has an invalid selection.`;
+      }
+    }
+  }
+
+  return { isValid: Object.keys(errors).length === 0, errors };
+}
+
+export function formatFieldValue(
+  definition: CustomFieldDefinition | undefined,
+  rawValue: CustomFieldPrimitive | undefined,
+): string {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return 'Not set';
+  }
+
+  if (!definition) {
+    return `${String(rawValue)} (field definition removed)`;
+  }
+
+  switch (definition.type) {
+    case 'checkbox':
+      return rawValue === true ? 'Yes' : rawValue === false ? 'No' : 'Invalid boolean value';
+    case 'number':
+      return typeof rawValue === 'number' ? rawValue.toLocaleString() : 'Invalid number value';
+    case 'date':
+      return typeof rawValue === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(rawValue)
+        ? rawValue
+        : 'Invalid date value';
+    case 'select':
+      if (typeof rawValue !== 'string') return 'Invalid selection';
+      if (definition.options && !definition.options.includes(rawValue)) return `${rawValue} (option retired)`;
+      return rawValue;
+    case 'text':
+      return typeof rawValue === 'string' ? rawValue : String(rawValue);
+    default:
+      return String(rawValue);
+  }
+}
+
+export function initialValuesFromDefinitions(definitions: CustomFieldDefinition[]): CustomFieldValues {
+  const result: CustomFieldValues = {};
+
+  for (const field of definitions) {
+    if (field.retired) continue;
+    if (field.type === 'checkbox') {
+      result[field.key] = false;
+      continue;
+    }
+    result[field.key] = '';
+  }
+
+  return result;
+}

--- a/frontend/lib/use-soroban-tx.ts
+++ b/frontend/lib/use-soroban-tx.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import { useCallback, useReducer, useRef } from 'react';
+
+// ─── Error Types ─────────────────────────────────────────────────────────────
+
+/** Thrown when the user closes or rejects the wallet signing prompt. */
+export class UserRejectedError extends Error {
+  readonly reason = 'user_rejected' as const;
+  constructor(message = 'Transaction signature was rejected.') {
+    super(message);
+    this.name = 'UserRejectedError';
+  }
+}
+
+/** Thrown when the transaction expires or is dropped by the network. */
+export class TxTimeoutError extends Error {
+  readonly reason = 'timeout' as const;
+  constructor(message = 'Transaction timed out or was dropped by the network.') {
+    super(message);
+    this.name = 'TxTimeoutError';
+  }
+}
+
+/** Thrown when the transaction is accepted by the network but fails on-chain. */
+export class TxOnChainError extends Error {
+  readonly reason = 'transaction_failed' as const;
+  constructor(message = 'Transaction was rejected during on-chain execution.') {
+    super(message);
+    this.name = 'TxOnChainError';
+  }
+}
+
+// ─── State Types ─────────────────────────────────────────────────────────────
+
+export type TxErrorReason =
+  | 'user_rejected'      // user dismissed the wallet prompt
+  | 'submission_failed'  // Horizon / network error
+  | 'transaction_failed' // on-chain execution failed
+  | 'timeout';           // transaction expired or dropped
+
+export type TxState =
+  | { status: 'idle' }
+  | { status: 'signing' }                              // wallet prompt open
+  | { status: 'submitting' }                           // XDR sent to Horizon
+  | { status: 'pending'; hash: string }                // awaiting confirmation
+  | { status: 'success'; hash: string }                // confirmed on-chain
+  | { status: 'error'; reason: TxErrorReason; message: string };
+
+// ─── Executor Contract ───────────────────────────────────────────────────────
+
+/** Callbacks the executor must call at each transition boundary. */
+export interface TxPhaseCallbacks {
+  /** Call when the wallet prompt has been triggered. */
+  onSigning: () => void;
+  /** Call when the signed XDR is being submitted to the Stellar network. */
+  onSubmitting: () => void;
+  /** Call when Horizon has accepted the transaction and returned a hash. */
+  onPending: (hash: string) => void;
+}
+
+/**
+ * An async function that drives the full Soroban transaction lifecycle.
+ *
+ * The executor is responsible for:
+ * 1. Triggering the wallet signing prompt (then calling `callbacks.onSubmitting`)
+ * 2. Submitting the signed XDR to Horizon (then calling `callbacks.onPending(hash)`)
+ * 3. Waiting for on-chain confirmation and returning the final hash
+ *
+ * Throw a typed error to communicate failure reason:
+ * - `UserRejectedError`  – user dismissed the wallet
+ * - `TxTimeoutError`     – tx expired / dropped
+ * - `TxOnChainError`     – on-chain execution reverted
+ * - Any other `Error`    – treated as `submission_failed`
+ */
+export type TxExecutor = (callbacks: TxPhaseCallbacks) => Promise<string>;
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export interface UseSorobanTxReturn {
+  state: TxState;
+  /** Begin the transaction flow with the given executor. No-ops if already in flight. */
+  execute: (executor: TxExecutor) => Promise<void>;
+  /** Reset state back to idle. No-ops while a transaction is in flight. */
+  reset: () => void;
+}
+
+function deriveErrorState(error: unknown): TxState & { status: 'error' } {
+  if (error instanceof UserRejectedError) {
+    return { status: 'error', reason: 'user_rejected', message: error.message };
+  }
+  if (error instanceof TxTimeoutError) {
+    return { status: 'error', reason: 'timeout', message: error.message };
+  }
+  if (error instanceof TxOnChainError) {
+    return { status: 'error', reason: 'transaction_failed', message: error.message };
+  }
+  const message =
+    error instanceof Error ? error.message : 'An unexpected error occurred. Please try again.';
+  return { status: 'error', reason: 'submission_failed', message };
+}
+
+/**
+ * Manages the full Soroban transaction UX state machine:
+ * idle → signing → submitting → pending → success | error
+ *
+ * Prevents double-execution; ignores reset() while a transaction is in flight
+ * so the UI remains stable if the user switches tabs or dismisses dialogs.
+ */
+export function useSorobanTx(): UseSorobanTxReturn {
+  const [state, setState] = useReducer(
+    (_prev: TxState, next: TxState): TxState => next,
+    { status: 'idle' } as TxState,
+  );
+
+  // Prevents concurrent executions without causing re-renders.
+  const inFlightRef = useRef(false);
+
+  const execute = useCallback(async (executor: TxExecutor): Promise<void> => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+
+    setState({ status: 'signing' });
+
+    const callbacks: TxPhaseCallbacks = {
+      onSigning: () => setState({ status: 'signing' }),
+      onSubmitting: () => setState({ status: 'submitting' }),
+      onPending: (hash: string) => setState({ status: 'pending', hash }),
+    };
+
+    try {
+      const hash = await executor(callbacks);
+      setState({ status: 'success', hash });
+    } catch (err) {
+      setState(deriveErrorState(err));
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    if (inFlightRef.current) return;
+    setState({ status: 'idle' });
+  }, []);
+
+  return { state, execute, reset };
+}


### PR DESCRIPTION
## Summary

Implements dynamic custom fields across task create, edit, and read-only display flows, with safe degradation when field schema evolves over time.

Closes #200

---

## What Changed

### `lib/custom-fields.ts` (new)
Core utilities for dynamic custom field management:
- `CustomFieldType` union: `text | select | number | checkbox | date`
- `coerceForField()` — normalises raw stored values to their correct runtime type
- `validateField()` — returns typed validation errors (required, invalid number, etc.)
- `formatFieldValue()` — formats values for read-only display; handles missing definitions and retired select options
- `initialValuesFrom()` — builds default values only from active fields
- `sanitizeValues()` — strips or resets values when schema changes (field removed / type changed)

### `lib/custom-fields-renderer.tsx` (new)
Reusable React components:
- `CustomFieldsEditor` — renders the correct input element per field type with validation error display
- `CustomFieldsReadOnly` — renders formatted values for detail and list views

### `app/page.tsx` (updated)
- Create form: includes `CustomFieldsEditor` for dynamic fields alongside static fields
- Task list: shows custom field summary inline per task row
- Task detail panel: displays all custom field values via `CustomFieldsReadOnly`
- Edit mode: prefills `CustomFieldsEditor` with stored values; validates on save

### `lib/__tests__/custom-fields.test.ts` (new)
5 tests covering:
- Coercion for all field types
- Required and invalid value validation
- Initial value construction (active fields only)
- Graceful handling of missing definitions and retired select options
- Schema-change sanitization

### `jest.config.js` (updated)
- Extended `testMatch` to include `lib/**/__tests__/`
- Fixed `moduleNameMapper` to `<rootDir>/$1` matching `tsconfig.json` `@/* → ./*`

---

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Supported custom field types render and save correctly | ✅ All 5 types: text, select, number, checkbox, date |
| Dynamic fields work in create and edit flows | ✅ Both forms use shared renderer + validation pipeline |
| Read-only views display values cleanly | ✅ Detail panel + list summary via `CustomFieldsReadOnly` |
| System degrades safely when schema changes | ✅ Missing defs, retired fields, invalid values all handled |

---

## Test Run
