### PR TITLE
Implement persistent retry scheduling for failed keeper jobs

### DIFF
--- a/keeper/.env.example
+++ b/keeper/.env.example
@@ -25,6 +25,12 @@ MAX_RETRIES=3
 RETRY_BASE_DELAY_MS=1000
 MAX_RETRY_DELAY_MS=30000
 
+# Persistent Retry Scheduler Configuration
+RETRY_RETENTION_DAYS=7
+RETRY_STORAGE_PATH=./data/retries.json
+MAX_RETRY_QUEUE_SIZE=100
+MAX_RETRIES_PER_CYCLE=2
+
 # Logging Configuration
 LOG_LEVEL=info
 NODE_ENV=production

--- a/keeper/__tests__/retryScheduler.test.js
+++ b/keeper/__tests__/retryScheduler.test.js
@@ -1,0 +1,342 @@
+const { RetryScheduler } = require('../src/retryScheduler');
+const fs = require('fs').promises;
+
+describe('RetryScheduler', () => {
+  let scheduler;
+  const testStoragePath = './data/test-retries.json';
+
+  beforeEach(async () => {
+    // Clean up test storage
+    try {
+      await fs.unlink(testStoragePath);
+    } catch (e) {
+      // Ignore if file doesn't exist
+    }
+
+    scheduler = new RetryScheduler({
+      storagePath: testStoragePath,
+      maxRetries: 3,
+      baseDelayMs: 100,
+      maxDelayMs: 1000,
+      retryRetentionDays: 1,
+      maxRetryQueueSize: 10,
+    });
+    await scheduler.initialize();
+  });
+
+  afterEach(async () => {
+    // Clean up test storage
+    try {
+      await fs.unlink(testStoragePath);
+    } catch (e) {
+      // Ignore
+    }
+  });
+
+  describe('scheduleRetry', () => {
+    test('should schedule a retry for retryable error', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      const result = await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+        taskConfig: { target: 'C...', function_name: 'test' },
+      });
+
+      expect(result.scheduled).toBe(true);
+      expect(result.nextAttemptTime).toBeDefined();
+      expect(result.attemptNumber).toBe(1);
+    });
+
+    test('should not schedule retry for non-retryable error', async () => {
+      const error = new Error('Invalid arguments');
+      error.code = 'INVALID_ARGS';
+
+      const result = await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      expect(result.scheduled).toBe(false);
+      expect(result.reason).toBe('Error classification: non_retryable');
+    });
+
+    test('should not schedule retry if max retries exceeded', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      const result = await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 3, // Already at max
+      });
+
+      expect(result.scheduled).toBe(false);
+      expect(result.reason).toBe('Max retries exceeded');
+    });
+
+    test('should not schedule duplicate retry', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      const result = await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      expect(result.scheduled).toBe(false);
+      expect(result.reason).toBe('Already scheduled for retry');
+    });
+
+    test('should not schedule if queue is full', async () => {
+      scheduler.config.maxRetryQueueSize = 2;
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      // Fill the queue
+      await scheduler.scheduleRetry({ taskId: 1, error, currentAttempt: 0 });
+      await scheduler.scheduleRetry({ taskId: 2, error, currentAttempt: 0 });
+
+      // Try to add one more
+      const result = await scheduler.scheduleRetry({
+        taskId: 3,
+        error,
+        currentAttempt: 0,
+      });
+
+      expect(result.scheduled).toBe(false);
+      expect(result.reason).toBe('Retry queue full');
+    });
+  });
+
+  describe('getReadyRetries', () => {
+    test('should return retries ready for execution', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      // Set a very short delay for testing before scheduling
+      scheduler.config.baseDelayMs = 10;
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      await scheduler.scheduleRetry({
+        taskId: 2,
+        error,
+        currentAttempt: 0,
+      });
+
+      // Wait for delay to pass
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      const readyRetries = scheduler.getReadyRetries();
+
+      expect(readyRetries.length).toBe(2);
+      expect(readyRetries[0].taskId).toBeDefined();
+    });
+
+    test('should not return retries not yet due', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      // Don't wait - should not be ready yet
+      const readyRetries = scheduler.getReadyRetries();
+
+      expect(readyRetries.length).toBe(0);
+    });
+  });
+
+  describe('completeRetry', () => {
+    test('should remove successful retry from queue', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      const result = await scheduler.completeRetry(1, true);
+
+      expect(result.removed).toBe(true);
+      expect(result.reason).toBe('Retry succeeded');
+      expect(scheduler.retryQueue.has(1)).toBe(false);
+    });
+
+    test('should reschedule failed retry if not at max', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      const result = await scheduler.completeRetry(1, false);
+
+      expect(result.removed).toBe(false);
+      expect(result.rescheduled).toBe(true);
+      expect(result.attemptNumber).toBe(2);
+    });
+
+    test('should remove retry if max retries exceeded', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      // Manually set a retry at max attempts
+      scheduler.retryQueue.set(1, {
+        taskId: 1,
+        currentAttempt: 3,
+        maxRetries: 3,
+        nextAttemptTime: Date.now(),
+        createdAt: Date.now(),
+      });
+
+      const result = await scheduler.completeRetry(1, false);
+
+      expect(result.removed).toBe(true);
+      expect(result.reason).toBe('Max retries exceeded');
+    });
+  });
+
+  describe('persistence', () => {
+    test('should persist retries to disk', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+        taskConfig: { target: 'C...', function_name: 'test' },
+      });
+
+      // Verify file exists
+      const data = await fs.readFile(testStoragePath, 'utf8');
+      const retries = JSON.parse(data);
+
+      expect(retries).toHaveLength(1);
+      expect(retries[0].taskId).toBe(1);
+      expect(retries[0].failureReason).toBeDefined();
+    });
+
+    test('should load retries from disk on initialization', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      // Create new scheduler instance
+      const newScheduler = new RetryScheduler({
+        storagePath: testStoragePath,
+        maxRetries: 3,
+      });
+      await newScheduler.initialize();
+
+      expect(newScheduler.retryQueue.size).toBe(1);
+      expect(newScheduler.retryQueue.has(1)).toBe(true);
+    });
+
+    test('should filter expired retries on load', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      // Manually set createdAt to old date
+      const retry = scheduler.retryQueue.get(1);
+      retry.createdAt = Date.now() - (2 * 24 * 60 * 60 * 1000); // 2 days ago
+
+      await scheduler.persistRetries();
+
+      // Create new scheduler with 1 day retention
+      const newScheduler = new RetryScheduler({
+        storagePath: testStoragePath,
+        retryRetentionDays: 1,
+      });
+      await newScheduler.initialize();
+
+      expect(newScheduler.retryQueue.size).toBe(0);
+    });
+  });
+
+  describe('getStatistics', () => {
+    test('should return accurate statistics', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      // Set a longer delay to ensure retries are pending, not overdue
+      scheduler.config.baseDelayMs = 10000;
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      await scheduler.scheduleRetry({
+        taskId: 2,
+        error,
+        currentAttempt: 0,
+      });
+
+      const stats = scheduler.getStatistics();
+
+      expect(stats.total).toBe(2);
+      expect(stats.pending).toBe(2);
+      expect(stats.overdue).toBe(0);
+      expect(stats.expired).toBe(0);
+    });
+  });
+
+  describe('cleanupExpired', () => {
+    test('should remove expired retries', async () => {
+      const error = new Error('Network timeout');
+      error.code = 'TIMEOUT';
+
+      await scheduler.scheduleRetry({
+        taskId: 1,
+        error,
+        currentAttempt: 0,
+      });
+
+      // Manually set createdAt to old date
+      const retry = scheduler.retryQueue.get(1);
+      retry.createdAt = Date.now() - (2 * 24 * 60 * 60 * 1000); // 2 days ago
+
+      const removed = await scheduler.cleanupExpired();
+
+      expect(removed).toBe(1);
+      expect(scheduler.retryQueue.size).toBe(0);
+    });
+  });
+});

--- a/keeper/docs/RETRY_SCHEDULING.md
+++ b/keeper/docs/RETRY_SCHEDULING.md
@@ -1,0 +1,327 @@
+# Persistent Retry Scheduling
+
+## Overview
+
+The retry scheduler provides durable, persistent retry scheduling for failed keeper jobs. It ensures that retryable failures survive process restarts and are retried intentionally with proper backoff and fairness guarantees.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Retry Scheduler                          │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  Persistent Storage (JSON File)                     │   │
+│  │  • taskId                                           │   │
+│  │  • nextAttemptTime (timestamp)                      │   │
+│  │  • currentAttempt (counter)                          │   │
+│  │  • maxRetries                                        │   │
+│  │  • failureReason (error details)                     │   │
+│  │  • taskConfig (target, function, interval)           │   │
+│  │  • createdAt (for retention)                         │   │
+│  │  • lastUpdated                                       │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                            │                                │
+│                            ▼                                │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  In-Memory Queue (Map)                              │   │
+│  │  • Fast access for scheduling decisions            │   │
+│  │  • Synced to disk on changes                         │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Configuration
+
+Environment variables control retry behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_RETRIES` | 3 | Maximum number of retry attempts per task |
+| `RETRY_BASE_DELAY_MS` | 1000 | Base delay for exponential backoff (ms) |
+| `MAX_RETRY_DELAY_MS` | 30000 | Maximum delay cap (ms) |
+| `RETRY_RETENTION_DAYS` | 7 | Days to retain retry metadata |
+| `RETRY_STORAGE_PATH` | `./data/retries.json` | Path to retry storage file |
+| `MAX_RETRY_QUEUE_SIZE` | 100 | Maximum number of retries in queue |
+
+## Operational Behavior
+
+### Retry Scheduling
+
+When a task fails:
+
+1. **Error Classification**: The error is classified as `retryable`, `non_retryable`, or `duplicate`
+2. **Retry Check**: If retryable and under max retries, schedule retry
+3. **Backoff Calculation**: Calculate next attempt time with exponential backoff + jitter
+4. **Persistence**: Store retry metadata to disk
+5. **Queue Check**: Ensure queue size limit not exceeded
+6. **Duplicate Prevention**: Check if already scheduled for retry
+
+### Exponential Backoff with Jitter
+
+```
+delay = min(baseDelay * 2^attempt, maxDelay) + random(0, baseDelay)
+```
+
+This prevents thundering herd problems on shared RPC nodes.
+
+Example with baseDelay=1000ms, maxDelay=30000ms:
+- Attempt 0: 1000-2000ms
+- Attempt 1: 2000-3000ms
+- Attempt 2: 4000-5000ms
+- Attempt 3+: Capped at 30000-31000ms
+
+### Fair Scheduling
+
+Retries are processed separately from normal due tasks to ensure fairness:
+
+1. **Per-Cycle Limit**: Maximum 2 retries per polling cycle (configurable)
+2. **Priority**: Normal due tasks processed first
+3. **Separate Queue**: Retries have their own execution queue
+4. **Prevention**: Tasks being retried are excluded from normal task queue
+
+### Restart Recovery
+
+On keeper restart:
+
+1. **Load Retries**: Read persisted retry metadata from disk
+2. **Filter Expired**: Remove entries older than retention period
+3. **Resume Scheduling**: Ready retries are picked up in next cycle
+4. **No Data Loss**: All retryable failures survive restarts
+
+## Retention Rules
+
+### Automatic Cleanup
+
+- **Retention Period**: 7 days (configurable via `RETRY_RETENTION_DAYS`)
+- **Cleanup Trigger**: On scheduler initialization
+- **Cleanup Scope**: Only removes expired entries, not active retries
+
+### Entry Lifecycle
+
+```
+Created → Scheduled → Executing → Complete/Expire
+   ↓          ↓           ↓            ↓
+  Now      Ready      Success     Removed
+            ↓           ↓
+         Overdue     Failure
+            ↓           ↓
+         Ready    Reschedule
+```
+
+### When Entries Are Removed
+
+- **Success**: Task succeeded, retry no longer needed
+- **Max Retries Exceeded**: Failed too many times, give up
+- **Expired**: Older than retention period
+- **Manual**: Explicit removal via API
+
+## Retry Metadata Structure
+
+```javascript
+{
+  taskId: 1,
+  nextAttemptTime: 1714321234567,
+  currentAttempt: 2,
+  maxRetries: 3,
+  delayMs: 4000,
+  failureReason: {
+    message: "Network timeout",
+    code: "TIMEOUT",
+    classification: "retryable"
+  },
+  taskConfig: {
+    target: "C...",
+    functionName: "harvest_yield",
+    interval: 3600
+  },
+  createdAt: 1714321194567,
+  lastUpdated: 1714321194567
+}
+```
+
+## Monitoring & Observability
+
+### Metrics
+
+The retry scheduler emits the following metrics:
+
+- `retriesScheduledTotal`: Total retries scheduled
+- `retriesExecutedTotal`: Total retry executions attempted
+- `retriesFailedTotal`: Total retry failures
+- `lastRetryCycleDurationMs`: Duration of last retry cycle
+
+### Statistics
+
+Get retry queue statistics via `getRetryStatistics()`:
+
+```javascript
+{
+  total: 5,           // Total retries in queue
+  pending: 3,         // Waiting for next attempt time
+  overdue: 2,         // Ready to execute now
+  expired: 0,         // Past retention period
+  maxRetries: 3,      // Configured max retries
+  queueSize: 5,        // Current queue size
+  maxQueueSize: 100    // Configured max queue size
+}
+```
+
+### Events
+
+The execution queue emits retry-specific events:
+
+- `retry:started(taskId, retryMetadata)` - Retry execution started
+- `retry:success(taskId, retryMetadata)` - Retry succeeded
+- `retry:failed(taskId, error, retryMetadata, completeResult)` - Retry failed
+- `retry:cycle:complete(stats)` - Retry cycle completed
+
+## Error Classifications
+
+### Retryable Errors
+
+These errors trigger automatic retry scheduling:
+
+- `TIMEOUT` - Request timeout
+- `NETWORK_ERROR` - Network connectivity issues
+- `RATE_LIMITED` - Rate limiting from RPC
+- `SERVER_ERROR` - Transient server errors
+- `SERVICE_UNAVAILABLE` - Service temporarily unavailable
+- Generic network errors (timeout, econnrefused, etc.)
+
+### Non-Retryable Errors
+
+These errors do not trigger retries:
+
+- `INVALID_ARGS` - Invalid arguments to contract
+- `INSUFFICIENT_GAS` - Not enough gas for execution
+- `CONTRACT_PANIC` - Contract execution panic
+- `INVALID_TRANSACTION` - Malformed transaction
+- `TX_INSUFFICIENT_FEE` - Fee too low
+- `TX_BAD_AUTH` - Bad authorization
+- `TX_TOO_EARLY` / `TX_TOO_LATE` - Timing issues
+- `TX_NOT_SUPPORTED` - Operation not supported
+
+### Duplicate Errors
+
+These are treated as success (transaction already accepted):
+
+- `DUPLICATE_TRANSACTION`
+- `TX_ALREADY_IN_LEDGER`
+- `TX_DUPLICATE`
+
+## Best Practices
+
+### 1. Monitoring
+
+Monitor retry queue size and backlog:
+
+```javascript
+const stats = retryScheduler.getStatistics();
+if (stats.overdue > 10) {
+  // Alert: High retry backlog
+}
+```
+
+### 2. Retention
+
+Set appropriate retention based on your use case:
+
+- **Short-lived tasks**: 1-3 days
+- **Long-running tasks**: 7-14 days
+- **Critical tasks**: 30+ days
+
+### 3. Queue Size
+
+Set `MAX_RETRY_QUEUE_SIZE` based on your capacity:
+
+- **Small keepers**: 10-50
+- **Medium keepers**: 50-100
+- **Large keepers**: 100-500
+
+### 4. Backoff Tuning
+
+Adjust backoff parameters for your RPC provider:
+
+- **Fast RPC**: Lower baseDelay (500ms)
+- **Rate-limited RPC**: Higher baseDelay (2000ms)
+- **Unstable RPC**: Higher maxDelay (60000ms)
+
+## Troubleshooting
+
+### High Retry Backlog
+
+**Symptoms**: Many overdue retries, queue near capacity
+
+**Solutions**:
+1. Check RPC provider health
+2. Increase `MAX_RETRY_QUEUE_SIZE`
+3. Reduce `RETRY_BASE_DELAY_MS` to process faster
+4. Scale keeper instances
+
+### Retries Not Persisting
+
+**Symptoms**: Retries lost on restart
+
+**Solutions**:
+1. Check `RETRY_STORAGE_PATH` is writable
+2. Verify disk space available
+3. Check file permissions
+
+### Retries Not Executing
+
+**Symptoms**: Retries scheduled but never executed
+
+**Solutions**:
+1. Check `MAX_RETRIES_PER_CYCLE` in poller
+2. Verify retry scheduler is initialized
+3. Check logs for retry-related errors
+
+## Integration Example
+
+```javascript
+const { RetryScheduler } = require('./src/retryScheduler');
+const { ExecutionQueue } = require('./src/queue');
+
+// Initialize retry scheduler
+const retryScheduler = new RetryScheduler({
+  storagePath: './data/retries.json',
+  maxRetries: 3,
+});
+
+// Initialize queue with retry scheduler
+const queue = new ExecutionQueue(3, metricsServer, retryScheduler);
+
+// Initialize on startup
+await queue.initialize();
+
+// In polling cycle:
+const dueTaskIds = await pollDueTasks(taskIds);
+await queue.enqueue(dueTaskIds, executeTask, taskConfigMap);
+
+// Process retries (fair scheduling)
+const readyRetries = queue.getReadyRetries(2); // Max 2 per cycle
+await queue.enqueueRetries(readyRetries, executeTask);
+
+// On shutdown
+await queue.shutdown();
+```
+
+## Security Considerations
+
+- **File Permissions**: Ensure retry storage file has restricted permissions
+- **Path Validation**: Validate `RETRY_STORAGE_PATH` to prevent path traversal
+- **Data Sanitization**: Error messages are stored, ensure no sensitive data leaks
+- **Disk Space**: Monitor disk usage to prevent space exhaustion
+
+## Future Enhancements
+
+Potential improvements for future versions:
+
+1. **Database Backend**: Replace JSON file with SQLite/PostgreSQL
+2. **Priority Queues**: Different retry priorities for different error types
+3. **Retry Policies**: Custom retry policies per task type
+4. **Dead Letter Queue**: Permanently failed tasks for manual review
+5. **Retry Analytics**: Dashboard for retry patterns and failure analysis

--- a/keeper/index.js
+++ b/keeper/index.js
@@ -5,6 +5,7 @@ const { Server } = rpc;
 const { loadConfig } = require('./src/config');
 const { initializeKeeperAccount } = require('./src/account');
 const { ExecutionQueue } = require('./src/queue');
+const { RetryScheduler } = require('./src/retryScheduler');
 const TaskPoller = require('./src/poller');
 const TaskRegistry = require('./src/registry');
 const { createLogger } = require('./src/logger');
@@ -52,14 +53,57 @@ async function main() {
         logger: createLogger('poller')
     });
     logger.info('Poller initialized', { contractId: config.contractId });
+rtry scheduler
+    const retryScheduler = new RetryScheduler();
+    await retryScheduler.initialize();
+    logger.info('Retry scheduler initialized', { 
+        retentionDays: process.env.RETRY_RETENTION_DAYS || 7,
+        maRtries: proess.env.MAX_RETRIES || 3
+    });
 
-    // Initialize execution queue
+    // Initialize exec with retry scheduler
+    // Initialize execution queuenull, null, retryScheduler
+    await queue.initialize();
     const queue = new ExecutionQueue();
     const queueLogger = createLogger('queue');
 
     queue.on('task:started', (taskId) => queueLogger.info('Started execution', { taskId }));
-    queue.on('task:success', (taskId) => queueLogger.info('Task executed successfully', { taskId }));
-    queue.on('task:failed', (taskId, err) => queueLogger.error('Task failed', { taskId, error: err.message }));
+    queue.on('task:success', (taskId) =>, scheduleResult queu{
+        eLogger.info('Task executed success
+            fully', 
+            { taskId }));,
+           retryScheduled: scheduleResult?.scheduled || false
+        ;
+        if (scheduleResult?.scheduled {
+            queueLogger.info('Retry scheduled', { 
+                taskId, 
+                nextAttempt: new Date(scheduleResult.nextAttemptTime).toISOString(),
+                attempt: scheduleResult.attemptNumber
+            })
+        }
+    });
+    queue.on('task:failed', (taskId, err) => queueLogger.erroycle complete', stats));
+    
+    // Retry-specific events
+    queue.on('retry:started', (taskId, retryMetadata) => {
+        queueLogger.info('Retry started', { 
+            taskId, 
+            attempt: retryMetadata.currentAttempt,
+            failureReason: retryMetadata.failureReason.message
+        });
+    });
+    queue.on('retry:success', (taskId, retryMetadata) => {
+        queueLogger.info('Retry succeeded', { taskId, attempt: retryMetadata.currentAttempt });
+    });
+    queue.on('retry:failed', (taskId, err, retryMetadata, completeResult) => {
+        queueLogger.error('Retry failed', { 
+            taskId, 
+            attempt: retryMetadata.currentAttempt,
+            error: err.message,
+            rescheduled: completeResult?.rescheduled || false
+        });
+    });
+    queue.on('retry:cycle:complete', (stats) => queueLogger.info('Retry cr('Task failed', { taskId, error: err.message }));
     queue.on('cycle:complete', (stats) => queueLogger.info('Cycle complete', stats));
 
     // Task executor function - calls contract.execute(keeper, task_id)
@@ -110,12 +154,37 @@ async function main() {
                 let attempts = 0;
                 const maxAttempts = 10;
 
-                while (status.status === 'PENDING' && attempts < maxAttempts) {
+            // Fetch task conf gs  or retry scheduling
+            const taskConfigMap = {};
+            for  const taskIw of dhile (sta) {
+                try {
+                    const taskConfig = await pollertgetTaskConfig(taskId);
+                    taskConfigMap[taskId] = taskConfig;
+                } catch (err) {
+                    queueLogger.warn('Failed to fetch task config', { taskId, error: err.message });
+                }
+            }
+
+            if (dueTaskIds.us.status === 'PENDING' && attempts < maxAttempts) {
                     await new Promise(resolve => setTimeout(resolve, 1000));
-                    status = await server.getTransaction(response.hash);
+                    status = await server.getTransaction(re, taskConfigMapsponse.hash);
                     attempts++;
                 }
 
+
+            // Process ready retries (fair scheduling - max 2 per cycle)
+        await queue.shutdown(); // Persist retries
+            const maxRetriesPerCycle = parseInt(process.env.MAX_RETRIES_PER_CYCLE || '2', 10);
+            const readyRetries = queue.getReadyRetries(maxRetriesPerCycle);
+            
+            if (readyRetries.length > 0) {
+                logger.info('Processing ready retries', { retryCount: readyRetries.length });
+                await queue.enqueueRetries(readyRetries, executeTask);
+            }
+
+            // Log retry statistics
+            const retryStats = queue.getRetryStatistics();
+            logger.info('Retry queue statistics', retryStats);
                 if (status.status === 'SUCCESS') {
                     logger.info('Task executed successfully', { taskId });
                 } else {

--- a/keeper/src/queue.js
+++ b/keeper/src/queue.js
@@ -1,8 +1,9 @@
 const EventEmitter = require('events');
 const { createConcurrencyLimit } = require('./concurrency');
+const { RetryScheduler } = require('./retryScheduler');
 
 class ExecutionQueue extends EventEmitter {
-  constructor(limit, metricsServer) {
+  constructor(limit, metricsServer, retryScheduler) {
     super();
 
     this.concurrencyLimit = parseInt(
@@ -12,6 +13,7 @@ class ExecutionQueue extends EventEmitter {
 
     this.limit = createConcurrencyLimit(this.concurrencyLimit);
     this.metricsServer = metricsServer;
+    this.retryScheduler = retryScheduler || new RetryScheduler();
 
     this.depth = 0;
     this.inFlight = 0;
@@ -20,11 +22,51 @@ class ExecutionQueue extends EventEmitter {
 
     this.activePromises = [];
     this.failedTasks = new Set();
+
+    // Retry tracking
+    this.retryTaskIds = new Set(); // Tasks being retried in current cycle
   }
 
-  async enqueue(taskIds, executorFn) {
+  /**
+   * Initialize the retry scheduler
+   */
+  async initialize() {
+    await this.retryScheduler.initialize();
+  }
+
+  /**
+   * Get tasks ready for retry (fair scheduling)
+   * Returns a limited number of retries to prevent them from overtaking normal tasks
+   *
+   * @param {number} maxRetriesPerCycle - Maximum retries to process per cycle
+   * @returns {Array} - Array of task IDs ready for retry
+   */
+  getReadyRetries(maxRetriesPerCycle = 2) {
+    const readyRetries = this.retryScheduler.getReadyRetries();
+
+    // Limit retries per cycle to ensure fairness
+    // Retries should not overwhelm normal due tasks
+    const limitedRetries = readyRetries.slice(0, maxRetriesPerCycle);
+
+    // Mark these as being retried to prevent duplicates
+    limitedRetries.forEach(retry => {
+      this.retryTaskIds.add(retry.taskId);
+    });
+
+    return limitedRetries;
+  }
+
+  /**
+   * Enqueue normal due tasks
+   *
+   * @param {Array} taskIds - Task IDs to execute
+   * @param {Function} executorFn - Executor function
+   * @param {Object} taskConfigMap - Map of taskId to task config (for retry scheduling)
+   */
+  async enqueue(taskIds, executorFn, taskConfigMap = {}) {
+    // Filter out tasks that are already being retried
     const validTaskIds = taskIds.filter(
-      (id) => !this.failedTasks.has(id),
+      (id) => !this.failedTasks.has(id) && !this.retryTaskIds.has(id),
     );
 
     this.depth = validTaskIds.length;
@@ -46,6 +88,10 @@ class ExecutionQueue extends EventEmitter {
         try {
           await executorFn(taskId);
           this.completed++;
+
+          // Remove from retry queue if it was there
+          await this.retryScheduler.completeRetry(taskId, true);
+
           if (this.metricsServer) {
             this.metricsServer.increment('tasksExecutedTotal', 1);
           }
@@ -53,10 +99,27 @@ class ExecutionQueue extends EventEmitter {
         } catch (error) {
           this.failedCount++;
           this.failedTasks.add(taskId);
+
+          // Schedule retry for retryable errors
+          const taskConfig = taskConfigMap[taskId];
+          const retryMetadata = this.retryScheduler.getRetryMetadata(taskId);
+          const currentAttempt = retryMetadata?.currentAttempt || 0;
+
+          const scheduleResult = await this.retryScheduler.scheduleRetry({
+            taskId,
+            error,
+            currentAttempt,
+            taskConfig,
+          });
+
           if (this.metricsServer) {
             this.metricsServer.increment('tasksFailedTotal', 1);
+            if (scheduleResult.scheduled) {
+              this.metricsServer.increment('retriesScheduledTotal', 1);
+            }
           }
-          this.emit('task:failed', taskId, error);
+
+          this.emit('task:failed', taskId, error, scheduleResult);
         } finally {
           this.inFlight--;
         }
@@ -85,6 +148,86 @@ class ExecutionQueue extends EventEmitter {
       this.activePromises = [];
       this.completed = 0;
       this.failedCount = 0;
+
+      // Clear retry task IDs for next cycle
+      this.retryTaskIds.clear();
+    }
+  }
+
+  /**
+   * Enqueue retry tasks (separate from normal tasks for fairness)
+   *
+   * @param {Array} retryTasks - Array of retry metadata objects
+   * @param {Function} executorFn - Executor function
+   */
+  async enqueueRetries(retryTasks, executorFn) {
+    if (retryTasks.length === 0) {
+      return;
+    }
+
+    this.depth += retryTasks.length;
+
+    const cycleStartTime = Date.now();
+
+    const cyclePromises = retryTasks.map((retryTask) => {
+      return this.limit(async () => {
+        const { taskId } = retryTask;
+        this.inFlight++;
+        this.depth = Math.max(this.depth - 1, 0);
+
+        this.emit('retry:started', taskId, retryTask);
+
+        try {
+          await executorFn(taskId);
+          this.completed++;
+
+          // Mark retry as successful
+          await this.retryScheduler.completeRetry(taskId, true);
+
+          if (this.metricsServer) {
+            this.metricsServer.increment('retriesExecutedTotal', 1);
+            this.metricsServer.increment('tasksExecutedTotal', 1);
+          }
+          this.emit('retry:success', taskId, retryTask);
+        } catch (error) {
+          this.failedCount++;
+
+          // Update retry status (may reschedule if not at max retries)
+          const completeResult = await this.retryScheduler.completeRetry(taskId, false);
+
+          if (this.metricsServer) {
+            this.metricsServer.increment('retriesFailedTotal', 1);
+          }
+
+          this.emit('retry:failed', taskId, error, retryTask, completeResult);
+        } finally {
+          this.inFlight--;
+        }
+      });
+    });
+
+    this.activePromises.push(...cyclePromises);
+
+    try {
+      await Promise.all(cyclePromises);
+    } catch (_) {
+      // already handled
+    } finally {
+      const cycleDuration = Date.now() - cycleStartTime;
+      if (this.metricsServer?.record) {
+        this.metricsServer.record('lastRetryCycleDurationMs', cycleDuration);
+      }
+
+      this.emit('retry:cycle:complete', {
+        depth: retryTasks.length,
+        inFlight: this.inFlight,
+        completed: this.completed,
+        failed: this.failedCount,
+      });
+
+      this.activePromises = [];
+      this.completed = 0;
+      this.failedCount = 0;
     }
   }
 
@@ -99,6 +242,20 @@ class ExecutionQueue extends EventEmitter {
     while (this.inFlight > 0) {
       await new Promise((r) => setTimeout(r, 50));
     }
+  }
+
+  /**
+   * Get retry queue statistics
+   */
+  getRetryStatistics() {
+    return this.retryScheduler.getStatistics();
+  }
+
+  /**
+   * Shutdown gracefully
+   */
+  async shutdown() {
+    await this.retryScheduler.shutdown();
   }
 }
 

--- a/keeper/src/retry.js
+++ b/keeper/src/retry.js
@@ -267,7 +267,7 @@ export async function withRetry(fn, options = {}) {
  * @param {number} delay - Delay between attempts in milliseconds
  * @returns {Promise<*>}
  */
-export async function retry(fn, attempts = 3, delay = 1000) {
+async function retry(fn, attempts = 3, delay = 1000) {
   return withRetry(fn, {
     maxRetries: attempts - 1,
     baseDelayMs: delay,
@@ -280,7 +280,7 @@ export async function retry(fn, attempts = 3, delay = 1000) {
  * @param {Error} error - The error to check
  * @returns {boolean} - True if the error is retryable
  */
-export function isRetryableError(error) {
+function isRetryableError(error) {
   return classifyError(error) === ErrorClassification.RETRYABLE;
 }
 
@@ -289,9 +289,17 @@ export function isRetryableError(error) {
  * @param {Error} error - The error to check
  * @returns {boolean} - True if the error indicates a duplicate
  */
-export function isDuplicateTransactionError(error) {
+function isDuplicateTransactionError(error) {
   return classifyError(error) === ErrorClassification.DUPLICATE;
 }
 
-// Export error classifications for external use
-export { ErrorClassification };
+// CommonJS exports
+module.exports = {
+  withRetry,
+  retry,
+  classifyError,
+  calculateDelay,
+  isRetryableError,
+  isDuplicateTransactionError,
+  ErrorClassification,
+};

--- a/keeper/src/retryScheduler.js
+++ b/keeper/src/retryScheduler.js
@@ -1,0 +1,360 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { classifyError, calculateDelay } = require('./retry');
+
+/**
+ * Persistent Retry Scheduler
+ *
+ * Manages durable retry scheduling for failed keeper jobs.
+ * Persists retry metadata to disk and handles restart recovery.
+ */
+
+const DEFAULT_CONFIG = {
+  maxRetries: parseInt(process.env.MAX_RETRIES, 10) || 3,
+  baseDelayMs: parseInt(process.env.RETRY_BASE_DELAY_MS, 10) || 1000,
+  maxDelayMs: parseInt(process.env.MAX_RETRY_DELAY_MS, 10) || 30000,
+  retryRetentionDays: parseInt(process.env.RETRY_RETENTION_DAYS, 10) || 7,
+  storagePath: process.env.RETRY_STORAGE_PATH || './data/retries.json',
+  maxRetryQueueSize: parseInt(process.env.MAX_RETRY_QUEUE_SIZE, 10) || 100,
+};
+
+class RetryScheduler {
+  constructor(config = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.retryQueue = new Map(); // taskId -> retry metadata
+    this.initialized = false;
+  }
+
+  /**
+   * Initialize the retry scheduler
+   * Loads persisted retry metadata from disk
+   */
+  async initialize() {
+    try {
+      await this.loadRetries();
+      this.initialized = true;
+      console.log('RetryScheduler initialized with', this.retryQueue.size, 'pending retries');
+    } catch (error) {
+      console.error('Failed to initialize RetryScheduler:', error.message);
+      // Continue with empty queue if load fails
+      this.retryQueue = new Map();
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Load retry metadata from persistent storage
+   */
+  async loadRetries() {
+    try {
+      const data = await fs.readFile(this.config.storagePath, 'utf8');
+      const retries = JSON.parse(data);
+
+      // Convert array back to Map and filter expired entries
+      const now = Date.now();
+      const retentionMs = this.config.retryRetentionDays * 24 * 60 * 60 * 1000;
+
+      for (const retry of retries) {
+        // Remove expired entries
+        if (now - retry.createdAt > retentionMs) {
+          continue;
+        }
+
+        this.retryQueue.set(retry.taskId, retry);
+      }
+
+      console.log(`Loaded ${this.retryQueue.size} retries from storage (filtered expired)`);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        console.log('No existing retry storage found, starting fresh');
+        this.retryQueue = new Map();
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Persist retry metadata to disk
+   */
+  async persistRetries() {
+    try {
+      // Ensure directory exists
+      const dir = path.dirname(this.config.storagePath);
+      await fs.mkdir(dir, { recursive: true });
+
+      // Convert Map to array for JSON serialization
+      const retries = Array.from(this.retryQueue.values());
+
+      await fs.writeFile(
+        this.config.storagePath,
+        JSON.stringify(retries, null, 2),
+        'utf8',
+      );
+    } catch (error) {
+      console.error('Failed to persist retries:', error.message);
+      // Don't throw - persistence failures shouldn't break execution
+    }
+  }
+
+  /**
+   * Schedule a retry for a failed task
+   *
+   * @param {Object} taskInfo - Task information
+   * @param {number} taskInfo.taskId - Task ID
+   * @param {Error} taskInfo.error - Error that caused failure
+   * @param {number} taskInfo.currentAttempt - Current attempt number
+   * @param {Object} taskInfo.taskConfig - Task configuration
+   */
+  async scheduleRetry({ taskId, error, currentAttempt = 0, taskConfig }) {
+    if (!this.initialized) {
+      await this.initialize();
+    }
+
+    const classification = classifyError(error);
+
+    // Only schedule retry for retryable errors
+    if (classification !== 'retryable') {
+      return {
+        scheduled: false,
+        reason: `Error classification: ${classification}`,
+      };
+    }
+
+    // Check if we've exceeded max retries
+    if (currentAttempt >= this.config.maxRetries) {
+      return {
+        scheduled: false,
+        reason: 'Max retries exceeded',
+      };
+    }
+
+    // Check queue size limit
+    if (this.retryQueue.size >= this.config.maxRetryQueueSize) {
+      return {
+        scheduled: false,
+        reason: 'Retry queue full',
+      };
+    }
+
+    // Check if already scheduled
+    if (this.retryQueue.has(taskId)) {
+      return {
+        scheduled: false,
+        reason: 'Already scheduled for retry',
+      };
+    }
+
+    // Calculate next attempt time with exponential backoff
+    const delayMs = calculateDelay(currentAttempt, this.config.baseDelayMs, this.config.maxDelayMs);
+    const nextAttemptTime = Date.now() + delayMs;
+
+    // Create retry metadata
+    const retryMetadata = {
+      taskId,
+      nextAttemptTime,
+      currentAttempt: currentAttempt + 1,
+      maxRetries: this.config.maxRetries,
+      delayMs,
+      failureReason: {
+        message: error.message,
+        code: error.code,
+        classification,
+      },
+      taskConfig: {
+        target: taskConfig?.target,
+        functionName: taskConfig?.function_name,
+        interval: taskConfig?.interval,
+      },
+      createdAt: Date.now(),
+      lastUpdated: Date.now(),
+    };
+
+    // Add to queue
+    this.retryQueue.set(taskId, retryMetadata);
+
+    // Persist to disk
+    await this.persistRetries();
+
+    console.log(`Scheduled retry for task ${taskId} at ${new Date(nextAttemptTime).toISOString()}`);
+
+    return {
+      scheduled: true,
+      nextAttemptTime,
+      attemptNumber: retryMetadata.currentAttempt,
+    };
+  }
+
+  /**
+   * Get tasks ready for retry
+   *
+   * @param {number} currentTime - Current timestamp (default: Date.now())
+   * @returns {Array} - Array of task IDs ready for retry
+   */
+  getReadyRetries(currentTime = Date.now()) {
+    const readyRetries = [];
+
+    for (const [taskId, retry] of this.retryQueue) {
+      if (retry.nextAttemptTime <= currentTime) {
+        readyRetries.push({
+          taskId,
+          ...retry,
+        });
+      }
+    }
+
+    // Sort by nextAttemptTime (oldest first)
+    readyRetries.sort((a, b) => a.nextAttemptTime - b.nextAttemptTime);
+
+    return readyRetries;
+  }
+
+  /**
+   * Mark a retry as completed (success or final failure)
+   *
+   * @param {number} taskId - Task ID
+   * @param {boolean} success - Whether the retry succeeded
+   */
+  async completeRetry(taskId, success = false) {
+    if (!this.retryQueue.has(taskId)) {
+      return { removed: false, reason: 'Task not in retry queue' };
+    }
+
+    const retry = this.retryQueue.get(taskId);
+
+    // If successful, remove from queue
+    // If failed but not at max retries, reschedule
+    if (success) {
+      this.retryQueue.delete(taskId);
+      await this.persistRetries();
+      return { removed: true, reason: 'Retry succeeded' };
+    } else if (retry.currentAttempt >= retry.maxRetries) {
+      // Max retries exceeded, remove from queue
+      this.retryQueue.delete(taskId);
+      await this.persistRetries();
+      return { removed: true, reason: 'Max retries exceeded' };
+    }
+
+    // Reschedule with incremented attempt count
+    const delayMs = calculateDelay(retry.currentAttempt, this.config.baseDelayMs, this.config.maxDelayMs);
+    const nextAttemptTime = Date.now() + delayMs;
+
+    retry.currentAttempt += 1;
+    retry.nextAttemptTime = nextAttemptTime;
+    retry.delayMs = delayMs;
+    retry.lastUpdated = Date.now();
+
+    await this.persistRetries();
+
+    return {
+      removed: false,
+      rescheduled: true,
+      nextAttemptTime,
+      attemptNumber: retry.currentAttempt,
+    };
+  }
+
+  /**
+   * Remove a task from retry queue
+   *
+   * @param {number} taskId - Task ID
+   */
+  async removeRetry(taskId) {
+    if (this.retryQueue.has(taskId)) {
+      this.retryQueue.delete(taskId);
+      await this.persistRetries();
+      return { removed: true };
+    }
+    return { removed: false };
+  }
+
+  /**
+   * Get retry metadata for a task
+   *
+   * @param {number} taskId - Task ID
+   * @returns {Object|null} - Retry metadata or null if not found
+   */
+  getRetryMetadata(taskId) {
+    return this.retryQueue.get(taskId) || null;
+  }
+
+  /**
+   * Get all retry metadata (for visibility/monitoring)
+   *
+   * @returns {Array} - Array of all retry metadata
+   */
+  getAllRetries() {
+    return Array.from(this.retryQueue.values());
+  }
+
+  /**
+   * Get retry queue statistics
+   *
+   * @returns {Object} - Statistics about the retry queue
+   */
+  getStatistics() {
+    const now = Date.now();
+    const retentionMs = this.config.retryRetentionDays * 24 * 60 * 60 * 1000;
+
+    let pending = 0;
+    let overdue = 0;
+    let expired = 0;
+
+    for (const retry of this.retryQueue.values()) {
+      if (now - retry.createdAt > retentionMs) {
+        expired++;
+      } else if (retry.nextAttemptTime <= now) {
+        overdue++;
+      } else {
+        pending++;
+      }
+    }
+
+    return {
+      total: this.retryQueue.size,
+      pending,
+      overdue,
+      expired,
+      maxRetries: this.config.maxRetries,
+      queueSize: this.retryQueue.size,
+      maxQueueSize: this.config.maxRetryQueueSize,
+    };
+  }
+
+  /**
+   * Clean up expired retry entries
+   *
+   * @returns {number} - Number of entries removed
+   */
+  async cleanupExpired() {
+    const now = Date.now();
+    const retentionMs = this.config.retryRetentionDays * 24 * 60 * 60 * 1000;
+    let removed = 0;
+
+    for (const [taskId, retry] of this.retryQueue) {
+      if (now - retry.createdAt > retentionMs) {
+        this.retryQueue.delete(taskId);
+        removed++;
+      }
+    }
+
+    if (removed > 0) {
+      await this.persistRetries();
+      console.log(`Cleaned up ${removed} expired retry entries`);
+    }
+
+    return removed;
+  }
+
+  /**
+   * Shutdown gracefully - persist all retries
+   */
+  async shutdown() {
+    if (this.retryQueue.size > 0) {
+      await this.persistRetries();
+      console.log(`Persisted ${this.retryQueue.size} retries on shutdown`);
+    }
+  }
+}
+
+module.exports = { RetryScheduler, DEFAULT_CONFIG };


### PR DESCRIPTION
Closes #231

---

- Add RetryScheduler class with JSON file persistence
- Store retry metadata (next-attempt time, failure reason, retry counters)
- Implement exponential backoff with jitter for retry delays
- Add fair scheduling to limit retries per cycle
- Integrate with ExecutionQueue for retry task handling
- Add restart recovery by loading persisted retries
- Prevent duplicate retry attempts
- Add comprehensive tests for retry scheduler
- Add environment variables for configuration
- Document operational behavior in RETRY_SCHEDULING.md
- Convert retry.js to CommonJS exports for compatibility

 

- [ ] Scope is focused and avoids unrelated changes
- [ ] Commit messages are clear
- [ ] Documentation updated when needed
- [ ] ETA was provided when requesting assignment for the linked issue
