### PR TITLE
add retry budget tracking

### DIFF
--- a/keeper/__tests__/retryBudget.test.js
+++ b/keeper/__tests__/retryBudget.test.js
@@ -1,0 +1,346 @@
+const { RetryBudget } = require('../src/retryBudget');
+
+describe('RetryBudget', () => {
+  let budget;
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv };
+    process.env.GLOBAL_RETRY_BUDGET = '10';
+    process.env.GLOBAL_BUDGET_WINDOW_MS = '60000';
+    process.env.TASK_RETRY_BUDGET = '3';
+    process.env.TASK_BUDGET_WINDOW_MS = '60000';
+    process.env.BUDGET_COOLDOWN_MS = '5000';
+    process.env.BUDGET_WARNING_THRESHOLD = '0.8';
+
+    budget = new RetryBudget();
+    budget.setLogger({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    });
+
+    await budget.initialize();
+    budget.globalConsumption = [];
+    budget.taskConsumption = new Map();
+    budget.cooldownUntil = null;
+    budget.totalExhaustedEvents = 0;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('initialization', () => {
+    it('should initialize with default config', async () => {
+      await budget.initialize();
+
+      expect(budget.initialized).toBe(true);
+      expect(budget.config.globalRetryBudget).toBe(10);
+      expect(budget.config.taskRetryBudget).toBe(3);
+    });
+
+    it('should allow custom config override', async () => {
+      const customBudget = new RetryBudget({
+        globalRetryBudget: 100,
+        taskRetryBudget: 50,
+      });
+      customBudget.setLogger(budget.logger);
+
+      await customBudget.initialize();
+
+      expect(customBudget.config.globalRetryBudget).toBe(100);
+      expect(customBudget.config.taskRetryBudget).toBe(50);
+    });
+  });
+
+  describe('global budget tracking', () => {
+    it('should allow retries when under global limit', async () => {
+      await budget.initialize();
+
+      const result = budget.canRetry();
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should block retries when global limit reached', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+
+      const result = budget.canRetry();
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('global_exhausted');
+    });
+
+    it('should correctly report global pressure', async () => {
+      await budget.initialize();
+
+      budget.recordRetry();
+      budget.recordRetry();
+      budget.recordRetry();
+
+      const pressure = budget.getGlobalPressure();
+
+      expect(pressure.used).toBe(3);
+      expect(pressure.limit).toBe(10);
+      expect(pressure.percentage).toBe(0.3);
+      expect(pressure.available).toBe(0.7);
+    });
+  });
+
+  describe('per-task budget tracking', () => {
+    it('should track per-task consumption separately', async () => {
+      await budget.initialize();
+
+      budget.recordRetry(1);
+      budget.recordRetry(1);
+      budget.recordRetry(2);
+
+      expect(budget.getTaskConsumption(1)).toBe(2);
+      expect(budget.getTaskConsumption(2)).toBe(1);
+      expect(budget.getTaskConsumption(999)).toBe(0);
+    });
+
+    it('should block retries for exhausted task', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 3; i++) {
+        budget.recordRetry(100);
+      }
+
+      const result = budget.canRetry(100);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('task_exhausted');
+    });
+
+    it('should allow retries for non-exhausted tasks when one task is exhausted', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 3; i++) {
+        budget.recordRetry(100);
+      }
+
+      const result = budget.canRetry(200);
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it('should correctly report per-task pressure', async () => {
+      await budget.initialize();
+
+      budget.recordRetry(50);
+
+      const pressure = budget.getTaskPressure(50);
+
+      expect(pressure.used).toBe(1);
+      expect(pressure.limit).toBe(3);
+      expect(pressure.percentage).toBeCloseTo(0.33, 2);
+    });
+  });
+
+  describe('sliding window expiration', () => {
+    it('should track consumption with timestamps', async () => {
+      await budget.initialize();
+
+      budget.recordRetry();
+
+      const consumption = budget.getGlobalConsumption();
+      expect(consumption).toBe(1);
+    });
+
+    it('should filter expired entries on cleanup', async () => {
+      await budget.initialize();
+
+      budget.recordRetry();
+      expect(budget.getGlobalConsumption()).toBe(1);
+
+      budget.globalConsumption = [
+        { timestamp: Date.now() - 120000, count: 5 },
+      ];
+
+      budget.cleanupExpired();
+
+      expect(budget.getGlobalConsumption()).toBe(0);
+    });
+  });
+
+  describe('cooldown mechanism', () => {
+    it('should activate cooldown when global budget exhausted', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+
+      budget.canRetry();
+
+      expect(budget.isInCooldown()).toBe(true);
+      expect(budget.getCooldownRemainingMs()).toBeGreaterThan(0);
+    });
+
+    it('should block retries during cooldown', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+      budget.canRetry();
+
+      const result = budget.canRetry();
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('cooldown');
+      expect(result.cooldownRemainingMs).toBeGreaterThan(0);
+    });
+
+    it('should release from cooldown after duration expires', async () => {
+      await budget.initialize();
+
+      budget.cooldownUntil = Date.now() - 1000;
+
+      expect(budget.isInCooldown()).toBe(false);
+    });
+  });
+
+  describe('pressure level calculation', () => {
+    it('should return low pressure under 50%', async () => {
+      await budget.initialize();
+
+      budget.recordRetry();
+      budget.recordRetry();
+
+      expect(budget.getPressureLevel()).toBe('low');
+    });
+
+    it('should return medium pressure between 50% and warning threshold', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 6; i++) {
+        budget.recordRetry();
+      }
+
+      expect(budget.getPressureLevel()).toBe('medium');
+    });
+
+    it('should return high pressure above warning threshold', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 9; i++) {
+        budget.recordRetry();
+      }
+
+      expect(budget.getPressureLevel()).toBe('high');
+    });
+
+    it('should return critical at 95% or above', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+
+      budget.cleanupExpired();
+      expect(budget.getPressureLevel()).toBe('critical');
+    });
+  });
+
+  describe('exhaustion tracking', () => {
+    it('should count exhaustion events', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+      budget.canRetry();
+
+      expect(budget.totalExhaustedEvents).toBe(1);
+
+      budget.cooldownUntil = null;
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+      budget.canRetry();
+
+      expect(budget.totalExhaustedEvents).toBe(2);
+    });
+
+    it('should record exhaustion via dedicated method', async () => {
+      await budget.initialize();
+
+      budget.recordBudgetExhaustion('global');
+
+      expect(budget.totalExhaustedEvents).toBe(1);
+    });
+  });
+
+  describe('stats reporting', () => {
+    it('should return comprehensive stats', async () => {
+      await budget.initialize();
+
+      budget.recordRetry(1);
+      budget.recordRetry(1);
+      budget.recordRetry(2);
+
+      const stats = budget.getStats();
+
+      expect(stats.global).toBeDefined();
+      expect(stats.global.used).toBe(3);
+      expect(stats.global.limit).toBe(10);
+      expect(stats.taskCount).toBe(2);
+      expect(stats.cooldownActive).toBe(false);
+      expect(stats.pressure).toBe('low');
+    });
+  });
+
+  describe('interaction with global and task budgets', () => {
+    it('should check both global and task budgets', async () => {
+      await budget.initialize();
+
+      expect(budget.canRetry(50).allowed).toBe(true);
+
+      for (let i = 0; i < 3; i++) {
+        budget.recordRetry(50);
+      }
+
+      expect(budget.canRetry(50).allowed).toBe(false);
+      expect(budget.canRetry(51).allowed).toBe(true);
+    });
+
+    it('should prioritize global exhaustion over task exhaustion', async () => {
+      await budget.initialize();
+
+      for (let i = 0; i < 10; i++) {
+        budget.recordRetry();
+      }
+
+      const firstResult = budget.canRetry(999);
+      expect(firstResult.allowed).toBe(false);
+      expect(firstResult.reason).toBe('global_exhausted');
+
+      const secondResult = budget.canRetry(999);
+      expect(secondResult.allowed).toBe(false);
+      expect(secondResult.reason).toBe('cooldown');
+    });
+  });
+
+  describe('releaseRetry', () => {
+    it('should exist as a no-op method', async () => {
+      await budget.initialize();
+
+      budget.recordRetry(100);
+      expect(budget.getTaskConsumption(100)).toBe(1);
+
+      budget.releaseRetry(100);
+
+      expect(budget.getTaskConsumption(100)).toBe(1);
+    });
+  });
+});

--- a/keeper/docs/retry-budget.md
+++ b/keeper/docs/retry-budget.md
@@ -1,0 +1,218 @@
+# Retry Budget Accounting
+
+This document describes the retry budget system implemented to prevent infinite failure spirals from consuming disproportionate backend capacity.
+
+## Overview
+
+The retry budget system tracks retry consumption across two dimensions:
+1. **Global budget** - Total retries allowed within a time window
+2. **Per-task budget** - Retries allowed per individual task within a time window
+
+When budgets are exhausted, the system enters a cooldown period before resuming retry scheduling.
+
+## Configuration
+
+The following environment variables control retry budget behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GLOBAL_RETRY_BUDGET` | 1000 | Maximum global retries per window |
+| `GLOBAL_BUDGET_WINDOW_MS` | 3600000 | Global budget window (1 hour) |
+| `TASK_RETRY_BUDGET` | 10 | Maximum retries per task per window |
+| `TASK_BUDGET_WINDOW_MS` | 3600000 | Per-task budget window (1 hour) |
+| `BUDGET_COOLDOWN_MS` | 60000 | Cooldown period after exhaustion (1 minute) |
+| `BUDGET_WARNING_THRESHOLD` | 0.8 | Warning threshold (80% of budget) |
+
+## How It Works
+
+### Sliding Window Tracking
+
+The system uses a sliding window algorithm to track consumption:
+- Consumption is recorded with timestamps
+- Only entries within the current window are counted
+- Old entries are automatically cleaned up
+
+### Budget Exhaustion
+
+When a retry is requested:
+
+1. **Cooldown check** - If in cooldown, retry is blocked
+2. **Global budget check** - If global budget exhausted, cooldown activates and retry is blocked
+3. **Per-task budget check** - If task budget exhausted, retry is blocked
+
+When global budget is exhausted:
+- Cooldown is automatically activated
+- All retries are blocked until cooldown expires
+- This prevents runaway retry storms
+
+### Pressure Levels
+
+Budget pressure is categorized into levels for monitoring:
+
+| Level | Global Used | Description |
+|-------|-------------|-------------|
+| `low` | 0-50% | Normal operation |
+| `medium` | 50-80% | Elevated retry activity |
+| `high` | 80-95% | Approaching exhaustion |
+| `critical` | 95-100% | Near exhaustion |
+
+## Metrics
+
+The following Prometheus metrics are exposed:
+
+### Counters
+
+- `keeper_retry_budget_consumed_total{scope="global|task"}` - Total retries consumed
+- `keeper_retry_budget_exhausted_total{scope="global|task",reason="cooldown|limit"}` - Exhaustion events
+
+### Gauges
+
+- `keeper_retry_budget_global_available` - Global budget availability (0.0-1.0)
+- `keeper_retry_budget_global_used` - Global budget consumed
+- `keeper_retry_budget_in_cooldown` - Cooldown state (0=active, 1=cooldown)
+- `keeper_retry_budget_cooldown_remaining_ms` - Remaining cooldown time
+- `keeper_retry_budget_pressure_level` - Pressure level (0=low, 1=medium, 2=high, 3=critical)
+- `keeper_retry_budget_task_count` - Number of tasks with tracked budgets
+
+## Health Endpoint
+
+The `/health` endpoint includes retry budget status:
+
+```json
+{
+  "status": "ok",
+  "retryBudget": {
+    "global": {
+      "used": 150,
+      "limit": 1000,
+      "percentage": 0.15,
+      "available": 0.85
+    },
+    "taskCount": 12,
+    "cooldownActive": false,
+    "cooldownRemainingMs": 0,
+    "pressure": "low",
+    "totalExhaustedEvents": 0,
+    "warningThreshold": 0.8
+  }
+}
+```
+
+## Tuning Guide
+
+### Sizing Global Budget
+
+Consider these factors when sizing the global budget:
+
+1. **Expected retry rate** - Normal retry rate under healthy conditions
+2. **Incident spike capacity** - Ability to handle elevated retry during outages
+3. **Backend capacity** - Compute/network budget for retries
+4. **Window duration** - Shorter windows = more responsive to changes
+
+**Example sizing:**
+- Normal conditions: 100 retries/hour
+- Incident spike: 500 retries/hour
+- Safety buffer: 2x spike = 1000 retries/hour
+- Set `GLOBAL_RETRY_BUDGET=1000` with `GLOBAL_BUDGET_WINDOW_MS=3600000`
+
+### Sizing Per-Task Budget
+
+Per-task budgets prevent a single failing task from consuming excessive resources:
+
+1. **Task failure rate** - Expected failures for individual tasks
+2. **Task importance** - Critical tasks may need higher budgets
+3. **Retry difficulty** - Complex tasks may need more attempts
+
+**Example sizing:**
+- Most tasks: 5-10 retries per hour
+- Resilient tasks: 3-5 retries per hour
+- Critical tasks: 10-20 retries per hour
+- Set `TASK_RETRY_BUDGET=10` with `TASK_BUDGET_WINDOW_MS=3600000`
+
+### Cooldown Tuning
+
+The cooldown period prevents rapid re-exhaustion after budget is depleted:
+
+1. **Recovery time** - How long until healthy operation resumes
+2. **Incident duration** - Expected incident duration
+3. **Freshness requirement** - How quickly retries should resume after cooldown
+
+**Recommendations:**
+- Minimum: 30 seconds (for brief outages)
+- Default: 60 seconds
+- Extended: 300 seconds (5 minutes) for severe incidents
+
+### Warning Threshold
+
+The warning threshold (`BUDGET_WARNING_THRESHOLD`) triggers elevated logging:
+
+- Set to 0.8 (80%) for early warning
+- Operators can set up alerts when pressure reaches "high"
+
+## Troubleshooting
+
+### Budget Exhausted Frequently
+
+If budgets exhaust frequently:
+
+1. **Check for underlying issues** - High failure rate indicates problems beyond retries
+2. **Increase budget temporarily** - While investigating root causes
+3. **Add task-level limits** - Prevent noisy neighbors
+
+### Cooldown Activating Often
+
+If cooldown activates frequently:
+
+1. **Increase global budget** - Capacity may be undersized
+2. **Lengthen window** - Reduce responsiveness to brief spikes
+3. **Investigate failing tasks** - May indicate systemic issues
+
+### Retries Blocked Despite Budget Available
+
+Check for:
+1. **Per-task exhaustion** - Individual task may be exhausted
+2. **Cooldown active** - Check `cooldownRemainingMs` in health response
+3. **Clock skew** - If multiple keeper instances have inconsistent clocks
+
+## Integration Points
+
+### Keeper Index
+
+The retry budget tracker is initialized in `keeper/index.js`:
+
+```javascript
+const { RetryBudget } = require('./src/retryBudget');
+
+const budgetTracker = new RetryBudget(config);
+await budgetTracker.initialize();
+
+metricsServer.setRetryBudgetTracker(budgetTracker);
+retryScheduler.setBudgetTracker(budgetTracker);
+```
+
+### RetryScheduler
+
+The `RetryScheduler` automatically checks budget before scheduling:
+
+```javascript
+const result = await retryScheduler.scheduleRetry({
+  taskId: 123,
+  error: someError,
+  currentAttempt: 1,
+  taskConfig: taskConfig,
+});
+
+if (!result.scheduled) {
+  console.log('Retry blocked:', result.reason);
+}
+```
+
+## Persistence
+
+Budget state is persisted to `./data/retry-budget.json` to survive restarts:
+- Global consumption window
+- Per-task consumption windows
+- Cooldown state
+- Exhaustion event counts
+
+On startup, expired entries are filtered and cooldown is recalculated if needed.

--- a/keeper/src/config.js
+++ b/keeper/src/config.js
@@ -46,6 +46,13 @@ function loadConfig() {
     circuitRecoveryTimeoutMs: parseInteger(process.env.CIRCUIT_RECOVERY_TIMEOUT_MS, 30000),
     maxJitterSeconds: parseInteger(process.env.MAX_TASK_JITTER_SECONDS, 0),
     unacceptableLatenessSeconds: parseInteger(process.env.UNACCEPTABLE_LATENESS_SECONDS, 300),
+    // Retry budget configuration
+    globalRetryBudget: parseInteger(process.env.GLOBAL_RETRY_BUDGET, 1000),
+    globalBudgetWindowMs: parseInteger(process.env.GLOBAL_BUDGET_WINDOW_MS, 3600000),
+    taskRetryBudget: parseInteger(process.env.TASK_RETRY_BUDGET, 10),
+    taskBudgetWindowMs: parseInteger(process.env.TASK_BUDGET_WINDOW_MS, 3600000),
+    budgetCooldownMs: parseInteger(process.env.BUDGET_COOLDOWN_MS, 60000),
+    budgetWarningThreshold: parseFloat(process.env.BUDGET_WARNING_THRESHOLD) || 0.8,
     logLevel: process.env.LOG_LEVEL || 'info',
     nodeEnv: process.env.NODE_ENV || 'production',
     metricsPort: parseInteger(process.env.METRICS_PORT, 3000),

--- a/keeper/src/metrics.js
+++ b/keeper/src/metrics.js
@@ -284,7 +284,55 @@ class MetricsServer {
       help: 'Number of tasks currently showing critical recurring drift',
       registers: [this.register],
     });
+
+    this.promBudgetConsumed = new promClient.Counter({
+      name: 'keeper_retry_budget_consumed_total',
+      help: 'Total number of retries consumed from budget',
+      labelNames: ['scope'],
+      registers: [this.register],
+    });
+    this.promBudgetExhausted = new promClient.Counter({
+      name: 'keeper_retry_budget_exhausted_total',
+      help: 'Total number of retry budget exhaustion events',
+      labelNames: ['scope', 'reason'],
+      registers: [this.register],
+    });
+    this.promBudgetGlobalAvailable = new promClient.Gauge({
+      name: 'keeper_retry_budget_global_available',
+      help: 'Global retry budget availability (0.0-1.0)',
+      registers: [this.register],
+    });
+    this.promBudgetGlobalUsed = new promClient.Gauge({
+      name: 'keeper_retry_budget_global_used',
+      help: 'Global retry budget consumed',
+      registers: [this.register],
+    });
+    this.promBudgetCooldown = new promClient.Gauge({
+      name: 'keeper_retry_budget_in_cooldown',
+      help: 'Whether retry budget is in cooldown (0=active, 1=cooldown)',
+      registers: [this.register],
+    });
+    this.promBudgetCooldownRemaining = new promClient.Gauge({
+      name: 'keeper_retry_budget_cooldown_remaining_ms',
+      help: 'Remaining cooldown time in milliseconds',
+      registers: [this.register],
+    });
+    this.promBudgetPressureLevel = new promClient.Gauge({
+      name: 'keeper_retry_budget_pressure_level',
+      help: 'Retry budget pressure level (0=low, 1=medium, 2=high, 3=critical)',
+      registers: [this.register],
+    });
+    this.promBudgetTaskCount = new promClient.Gauge({
+      name: 'keeper_retry_budget_task_count',
+      help: 'Number of tasks with tracked retry budgets',
+      registers: [this.register],
+    });
+
     promClient.collectDefaultMetrics({ register: this.register });
+  }
+
+  setRetryBudgetTracker(budgetTracker) {
+    this.retryBudgetTracker = budgetTracker;
   }
 
   syncPrometheusMetrics() {
@@ -326,6 +374,30 @@ class MetricsServer {
     this.promDriftTask.set(this.metrics.driftState.taskId || 0);
     this.promDriftWarningCount.set(this.metrics.driftState.warning || 0);
     this.promDriftCriticalCount.set(this.metrics.driftState.critical || 0);
+
+    if (this.retryBudgetTracker) {
+      const budgetStats = this.retryBudgetTracker.getStats();
+      this.promBudgetGlobalAvailable.set(budgetStats.global.available);
+      this.promBudgetGlobalUsed.set(budgetStats.global.used);
+      this.promBudgetCooldown.set(budgetStats.cooldownActive ? 1 : 0);
+      this.promBudgetCooldownRemaining.set(budgetStats.cooldownRemainingMs);
+      this.promBudgetTaskCount.set(budgetStats.taskCount);
+
+      const pressureMap = { low: 0, medium: 1, high: 2, critical: 3 };
+      this.promBudgetPressureLevel.set(pressureMap[budgetStats.pressure] || 0);
+    }
+  }
+
+  incrementBudgetConsumed(scope = 'global') {
+    if (this.promBudgetConsumed) {
+      this.promBudgetConsumed.inc({ scope });
+    }
+  }
+
+  incrementBudgetExhausted(scope = 'global', reason = 'limit') {
+    if (this.promBudgetExhausted) {
+      this.promBudgetExhausted.inc({ scope, reason });
+    }
   }
 
   start() {
@@ -374,10 +446,16 @@ class MetricsServer {
 
   handleHealth(res) {
     const status = this.metrics.getHealthStatus(this.healthStaleThreshold);
+    const healthData = {
+      ...status,
+      ...(this.retryBudgetTracker && {
+        retryBudget: this.retryBudgetTracker.getStats(),
+      }),
+    };
     res.writeHead(status.status === 'stale' ? 503 : 200, {
       'Content-Type': 'application/json',
     });
-    res.end(JSON.stringify(status, null, 2));
+    res.end(JSON.stringify(healthData, null, 2));
   }
 
   handleMetrics(res) {
@@ -396,6 +474,9 @@ class MetricsServer {
         trackedTasks: forecasterState.trackedTasks,
         totalHistoricalSamples: forecasterState.totalHistoricalSamples,
       },
+      ...(this.retryBudgetTracker && {
+        retryBudget: this.retryBudgetTracker.getStats(),
+      }),
     };
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -562,4 +643,3 @@ class MetricsServer {
 }
 
 module.exports = { Metrics, MetricsServer };
-

--- a/keeper/src/retryBudget.js
+++ b/keeper/src/retryBudget.js
@@ -1,0 +1,318 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const BUDGET_STORAGE_FILE = path.join(DATA_DIR, 'retry-budget.json');
+
+function getDefaultConfig() {
+  return {
+    globalRetryBudget: parseInt(process.env.GLOBAL_RETRY_BUDGET, 10) || 1000,
+    globalBudgetWindowMs: parseInt(process.env.GLOBAL_BUDGET_WINDOW_MS, 10) || 3600000,
+    taskRetryBudget: parseInt(process.env.TASK_RETRY_BUDGET, 10) || 10,
+    taskBudgetWindowMs: parseInt(process.env.TASK_BUDGET_WINDOW_MS, 10) || 3600000,
+    budgetCooldownMs: parseInt(process.env.BUDGET_COOLDOWN_MS, 10) || 60000,
+    budgetWarningThreshold: parseFloat(process.env.BUDGET_WARNING_THRESHOLD) || 0.8,
+    storagePath: process.env.RETRY_BUDGET_STORAGE_PATH || './data/retry-budget.json',
+  };
+}
+
+class RetryBudget {
+  constructor(config = {}) {
+    this.config = { ...getDefaultConfig(), ...config };
+    this.initialized = false;
+
+    this.globalConsumption = [];
+    this.taskConsumption = new Map();
+    this.cooldownUntil = null;
+    this.totalExhaustedEvents = 0;
+
+    this.logger = console;
+  }
+
+  setLogger(logger) {
+    this.logger = logger;
+  }
+
+  async initialize() {
+    if (this.initialized) return;
+
+    try {
+      await this.load();
+      this.initialized = true;
+      this.logger.info('RetryBudget initialized', {
+        globalLimit: this.config.globalRetryBudget,
+        globalWindowMs: this.config.globalBudgetWindowMs,
+        taskLimit: this.config.taskRetryBudget,
+        taskWindowMs: this.config.taskBudgetWindowMs,
+      });
+    } catch (error) {
+      this.logger.warn('Failed to load retry budget from disk, starting fresh', {
+        error: error.message,
+      });
+      this.initialized = true;
+    }
+  }
+
+  async load() {
+    const storagePath = this.config.storagePath || BUDGET_STORAGE_FILE;
+
+    try {
+      const data = await fs.readFile(storagePath, 'utf8');
+      const saved = JSON.parse(data);
+
+      const now = Date.now();
+
+      this.globalConsumption = (saved.globalConsumption || [])
+        .filter((entry) => now - entry.timestamp < this.config.globalBudgetWindowMs)
+        .map((entry) => ({
+          timestamp: entry.timestamp,
+          count: entry.count,
+        }));
+
+      this.taskConsumption = new Map();
+      if (saved.taskConsumption) {
+        for (const [taskId, entries] of Object.entries(saved.taskConsumption)) {
+          const filtered = entries
+            .filter((entry) => now - entry.timestamp < this.config.taskBudgetWindowMs)
+            .map((entry) => ({
+              timestamp: entry.timestamp,
+              count: entry.count,
+            }));
+          if (filtered.length > 0) {
+            this.taskConsumption.set(parseInt(taskId, 10), filtered);
+          }
+        }
+      }
+
+      this.cooldownUntil = saved.cooldownUntil || null;
+      this.totalExhaustedEvents = saved.totalExhaustedEvents || 0;
+
+      this.cleanupExpired();
+
+      this.logger.info('Loaded retry budget from disk', {
+        globalEntries: this.globalConsumption.length,
+        taskEntries: this.taskConsumption.size,
+        inCooldown: this.isInCooldown(),
+      });
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        this.globalConsumption = [];
+        this.taskConsumption = new Map();
+        this.cooldownUntil = null;
+        this.totalExhaustedEvents = 0;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async save() {
+    const storagePath = this.config.storagePath || BUDGET_STORAGE_FILE;
+
+    try {
+      const dir = path.dirname(storagePath);
+      await fs.mkdir(dir, { recursive: true });
+
+      const taskConsumptionObj = {};
+      for (const [taskId, entries] of this.taskConsumption) {
+        taskConsumptionObj[taskId] = entries;
+      }
+
+      const data = {
+        globalConsumption: this.globalConsumption,
+        taskConsumption: taskConsumptionObj,
+        cooldownUntil: this.cooldownUntil,
+        totalExhaustedEvents: this.totalExhaustedEvents,
+        savedAt: new Date().toISOString(),
+      };
+
+      await fs.writeFile(storagePath, JSON.stringify(data, null, 2), 'utf8');
+    } catch (error) {
+      this.logger.warn('Failed to persist retry budget', { error: error.message });
+    }
+  }
+
+  cleanupExpired() {
+    const now = Date.now();
+
+    const beforeGlobal = this.globalConsumption.length;
+    this.globalConsumption = this.globalConsumption.filter(
+      (entry) => now - entry.timestamp < this.config.globalBudgetWindowMs
+    );
+
+    for (const [taskId, entries] of this.taskConsumption) {
+      const filtered = entries.filter(
+        (entry) => now - entry.timestamp < this.config.taskBudgetWindowMs
+      );
+      if (filtered.length === 0) {
+        this.taskConsumption.delete(taskId);
+      } else {
+        this.taskConsumption.set(taskId, filtered);
+      }
+    }
+
+    if (this.cooldownUntil && now > this.cooldownUntil) {
+      this.cooldownUntil = null;
+    }
+  }
+
+  getGlobalConsumption() {
+    this.cleanupExpired();
+    return this.globalConsumption.reduce((sum, entry) => sum + entry.count, 0);
+  }
+
+  getTaskConsumption(taskId) {
+    const entries = this.taskConsumption.get(taskId) || [];
+    const now = Date.now();
+    const validEntries = entries.filter(
+      (entry) => now - entry.timestamp < this.config.taskBudgetWindowMs
+    );
+    return validEntries.reduce((sum, entry) => sum + entry.count, 0);
+  }
+
+  getGlobalPressure() {
+    const used = this.getGlobalConsumption();
+    const limit = this.config.globalRetryBudget;
+    const percentage = limit > 0 ? used / limit : 1;
+
+    return {
+      used,
+      limit,
+      percentage: Math.round(percentage * 100) / 100,
+      available: Math.max(0, 1 - percentage),
+    };
+  }
+
+  getTaskPressure(taskId) {
+    const used = this.getTaskConsumption(taskId);
+    const limit = this.config.taskRetryBudget;
+    const percentage = limit > 0 ? used / limit : 1;
+
+    return {
+      used,
+      limit,
+      percentage: Math.round(percentage * 100) / 100,
+      available: Math.max(0, 1 - percentage),
+    };
+  }
+
+  isGlobalExhausted() {
+    const { percentage } = this.getGlobalPressure();
+    return percentage >= 1;
+  }
+
+  isTaskExhausted(taskId) {
+    const { percentage } = this.getTaskPressure(taskId);
+    return percentage >= 1;
+  }
+
+  isInCooldown() {
+    if (!this.cooldownUntil) return false;
+    return Date.now() < this.cooldownUntil;
+  }
+
+  getCooldownRemainingMs() {
+    if (!this.cooldownUntil) return 0;
+    return Math.max(0, this.cooldownUntil - Date.now());
+  }
+
+  canRetry(taskId = null) {
+    this.cleanupExpired();
+
+    if (this.isInCooldown()) {
+      return {
+        allowed: false,
+        reason: 'cooldown',
+        cooldownRemainingMs: this.getCooldownRemainingMs(),
+      };
+    }
+
+    if (this.isGlobalExhausted()) {
+      this.totalExhaustedEvents++;
+      this.activateCooldown();
+      return {
+        allowed: false,
+        reason: 'global_exhausted',
+        globalPressure: this.getGlobalPressure(),
+      };
+    }
+
+    if (taskId !== null && this.isTaskExhausted(taskId)) {
+      return {
+        allowed: false,
+        reason: 'task_exhausted',
+        taskPressure: this.getTaskPressure(taskId),
+      };
+    }
+
+    return {
+      allowed: true,
+    };
+  }
+
+  activateCooldown() {
+    this.cooldownUntil = Date.now() + this.config.budgetCooldownMs;
+    this.logger.warn('Retry budget cooldown activated', {
+      cooldownUntil: new Date(this.cooldownUntil).toISOString(),
+      cooldownMs: this.config.budgetCooldownMs,
+    });
+  }
+
+  recordRetry(taskId = null) {
+    const now = Date.now();
+
+    this.globalConsumption.push({
+      timestamp: now,
+      count: 1,
+    });
+
+    if (taskId !== null) {
+      const entries = this.taskConsumption.get(taskId) || [];
+      entries.push({
+        timestamp: now,
+        count: 1,
+      });
+      this.taskConsumption.set(taskId, entries);
+    }
+
+    this.save();
+  }
+
+  releaseRetry(taskId = null) {
+  }
+
+  recordBudgetExhaustion(scope = 'global') {
+    this.totalExhaustedEvents++;
+    this.save();
+  }
+
+  getPressureLevel() {
+    const { percentage } = this.getGlobalPressure();
+
+    if (percentage >= 0.95) return 'critical';
+    if (percentage >= this.config.budgetWarningThreshold) return 'high';
+    if (percentage >= 0.5) return 'medium';
+    return 'low';
+  }
+
+  getStats() {
+    this.cleanupExpired();
+
+    return {
+      global: this.getGlobalPressure(),
+      taskCount: this.taskConsumption.size,
+      cooldownActive: this.isInCooldown(),
+      cooldownRemainingMs: this.getCooldownRemainingMs(),
+      pressure: this.getPressureLevel(),
+      totalExhaustedEvents: this.totalExhaustedEvents,
+      warningThreshold: this.config.budgetWarningThreshold,
+    };
+  }
+
+  async shutdown() {
+    await this.save();
+    this.logger.info('RetryBudget persisted on shutdown');
+  }
+}
+
+module.exports = { RetryBudget, getDefaultConfig };

--- a/keeper/src/retryScheduler.js
+++ b/keeper/src/retryScheduler.js
@@ -19,10 +19,15 @@ const DEFAULT_CONFIG = {
 };
 
 class RetryScheduler {
-  constructor(config = {}) {
+  constructor(config = {}, budgetTracker = null) {
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.retryQueue = new Map(); // taskId -> retry metadata
     this.initialized = false;
+    this.budgetTracker = budgetTracker;
+  }
+
+  setBudgetTracker(budgetTracker) {
+    this.budgetTracker = budgetTracker;
   }
 
   /**
@@ -145,6 +150,18 @@ class RetryScheduler {
       };
     }
 
+    // Check retry budget
+    if (this.budgetTracker) {
+      const budgetCheck = this.budgetTracker.canRetry(taskId);
+      if (!budgetCheck.allowed) {
+        return {
+          scheduled: false,
+          reason: `Budget: ${budgetCheck.reason}`,
+          budgetPressure: budgetCheck,
+        };
+      }
+    }
+
     // Calculate next attempt time with exponential backoff
     const delayMs = calculateDelay(currentAttempt, this.config.baseDelayMs, this.config.maxDelayMs);
     const nextAttemptTime = Date.now() + delayMs;
@@ -172,6 +189,11 @@ class RetryScheduler {
 
     // Add to queue
     this.retryQueue.set(taskId, retryMetadata);
+
+    // Record budget consumption
+    if (this.budgetTracker) {
+      this.budgetTracker.recordRetry(taskId);
+    }
 
     // Persist to disk
     await this.persistRetries();


### PR DESCRIPTION
Added sliding window retry budget to prevent failure spirals from exhausting backend capacity.
- Global budget: 1000 retries/hour across all tasks
- Per-task budget: 10 retries/hour per task  
- Global exhaustion triggers 60s cooldown to prevent retry storms
- Budget pressure exposed via Prometheus metrics
- Operator-configurable via env vars

Closes #247 