### PR TITLE
feat(keeper): implement contract access control audit for administrative paths

### DIFF
--- a/keeper/__tests__/accessControl.test.js
+++ b/keeper/__tests__/accessControl.test.js
@@ -1,0 +1,750 @@
+'use strict';
+
+/**
+ * accessControl.test.js — Contract Access Control Audit Tests
+ *
+ * Issue #250: Verify that privileged contract actions cannot be triggered
+ * by the wrong actors.
+ *
+ * Coverage:
+ *   - Registry completeness (every entry point is catalogued)
+ *   - Keeper whitelist: empty (open), non-empty (restricted), partial matches
+ *   - Creator-only guards: authorized vs unauthorized callers
+ *   - Portfolio creator guards
+ *   - Keeper admin HTTP API: missing / invalid / valid tokens
+ *   - Admin-disabled state (no KEEPER_ADMIN_TOKEN configured)
+ *   - Whitelist audit helper (surfaces open-task warnings)
+ *   - Known contract bugs surfaced as documented findings
+ *   - AccessControlError structure (code, meta, name)
+ *   - Audit summary generation
+ *   - getEntryPointsByPrivilege / getKnownAmbiguities helpers
+ */
+
+const {
+  PrivilegeLevel,
+  CONTRACT_ENTRY_POINTS,
+  assertKeeperAuthorized,
+  assertCreatorAuthorized,
+  assertPortfolioCreatorAuthorized,
+  assertAdminTokenValid,
+  auditTaskWhitelist,
+  getEntryPointsByPrivilege,
+  getKnownAmbiguities,
+  generateAuditSummary,
+  AccessControlError,
+} = require('../src/accessControl');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ALICE = 'GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL';
+const BOB = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+const CAROL = 'GCLWGQPMKIF3VP4B4BQZGCNCJVNFPBZK6H7YOTNBWB6NLCR3D4EZUVT';
+
+function makeTaskConfig(overrides = {}) {
+  return {
+    creator: ALICE,
+    target: BOB,
+    function: 'run',
+    args: [],
+    resolver: null,
+    interval: 3600,
+    last_run: 0,
+    gas_balance: 500,
+    whitelist: [],
+    is_active: true,
+    blocked_by: [],
+    ...overrides,
+  };
+}
+
+function makePortfolio(overrides = {}) {
+  return {
+    creator: ALICE,
+    name: 'Test Portfolio',
+    is_active: true,
+    task_count: 0,
+    ...overrides,
+  };
+}
+
+// ── AccessControlError ────────────────────────────────────────────────────────
+
+describe('AccessControlError', () => {
+  it('sets name, message, code, and meta', () => {
+    const err = new AccessControlError('test message', 'TEST_CODE', { foo: 'bar' });
+    expect(err.name).toBe('AccessControlError');
+    expect(err.message).toBe('test message');
+    expect(err.code).toBe('TEST_CODE');
+    expect(err.meta).toEqual({ foo: 'bar' });
+  });
+
+  it('extends Error', () => {
+    const err = new AccessControlError('msg', 'CODE');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('meta defaults to empty object', () => {
+    const err = new AccessControlError('msg', 'CODE');
+    expect(err.meta).toEqual({});
+  });
+});
+
+// ── Registry completeness ─────────────────────────────────────────────────────
+
+describe('CONTRACT_ENTRY_POINTS registry', () => {
+  it('is a non-empty frozen array', () => {
+    expect(Array.isArray(CONTRACT_ENTRY_POINTS)).toBe(true);
+    expect(CONTRACT_ENTRY_POINTS.length).toBeGreaterThan(0);
+    expect(Object.isFrozen(CONTRACT_ENTRY_POINTS)).toBe(true);
+  });
+
+  it('every entry has fn, privilege, mechanism, and notes fields', () => {
+    for (const ep of CONTRACT_ENTRY_POINTS) {
+      expect(typeof ep.fn).toBe('string');
+      expect(typeof ep.privilege).toBe('string');
+      expect(typeof ep.mechanism).toBe('string');
+      expect(typeof ep.notes).toBe('string');
+    }
+  });
+
+  it('every privilege value is a known PrivilegeLevel', () => {
+    const validLevels = new Set(Object.values(PrivilegeLevel));
+    for (const ep of CONTRACT_ENTRY_POINTS) {
+      expect(validLevels.has(ep.privilege)).toBe(true);
+    }
+  });
+
+  it('catalogs all required privileged entry points', () => {
+    const fns = CONTRACT_ENTRY_POINTS.map(ep => ep.fn);
+
+    // Creator-owned
+    expect(fns).toContain('register');
+    expect(fns).toContain('pause_task');
+    expect(fns).toContain('resume_task');
+    expect(fns).toContain('cancel_task');
+    expect(fns).toContain('withdraw_gas');
+    expect(fns).toContain('add_dependency_with_rule');
+    expect(fns).toContain('request_vrf_randomness');
+    expect(fns).toContain('request_oracle_data');
+
+    // Keeper execution
+    expect(fns).toContain('execute');
+    expect(fns).toContain('batch_execute');
+    expect(fns).toContain('deposit_gas');
+
+    // Portfolio
+    expect(fns).toContain('add_task_to_portfolio');
+    expect(fns).toContain('execute_portfolio_tasks');
+
+    // Admin
+    expect(fns).toContain('set_admin_address');
+    expect(fns).toContain('set_vrf_oracle_address');
+    expect(fns).toContain('init_yield_strategy');
+
+    // Role management
+    expect(fns).toContain('assign_role');
+    expect(fns).toContain('revoke_role');
+    expect(fns).toContain('grant_permission');
+    expect(fns).toContain('revoke_permission');
+    expect(fns).toContain('delegate_permission');
+    expect(fns).toContain('revoke_delegation');
+
+    // Public
+    expect(fns).toContain('get_task');
+    expect(fns).toContain('monitor');
+  });
+
+  it('execute is classified as WHITELISTED_KEEPER', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'execute');
+    expect(ep.privilege).toBe(PrivilegeLevel.WHITELISTED_KEEPER);
+  });
+
+  it('get_task and monitor are PUBLIC with no auth mechanism', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'get_task');
+    expect(ep.privilege).toBe(PrivilegeLevel.PUBLIC);
+    expect(ep.mechanism).toBe('none');
+
+    const mon = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'monitor');
+    expect(mon.privilege).toBe(PrivilegeLevel.PUBLIC);
+  });
+});
+
+// ── Keeper whitelist authorization ────────────────────────────────────────────
+
+describe('assertKeeperAuthorized — whitelist enforcement', () => {
+  describe('open tasks (empty whitelist)', () => {
+    it('allows any keeper when whitelist is empty array', () => {
+      const task = makeTaskConfig({ whitelist: [] });
+      expect(() => assertKeeperAuthorized(task, BOB)).not.toThrow();
+      expect(() => assertKeeperAuthorized(task, CAROL)).not.toThrow();
+    });
+
+    it('allows any keeper when whitelist field is missing', () => {
+      const task = makeTaskConfig();
+      delete task.whitelist;
+      expect(() => assertKeeperAuthorized(task, BOB)).not.toThrow();
+    });
+  });
+
+  describe('restricted tasks (non-empty whitelist)', () => {
+    it('allows a keeper that appears in the whitelist', () => {
+      const task = makeTaskConfig({ whitelist: [BOB] });
+      expect(() => assertKeeperAuthorized(task, BOB)).not.toThrow();
+    });
+
+    it('rejects a keeper that is NOT in the whitelist', () => {
+      const task = makeTaskConfig({ whitelist: [BOB] });
+      expect(() => assertKeeperAuthorized(task, CAROL))
+        .toThrow(AccessControlError);
+    });
+
+    it('rejected error has code KEEPER_NOT_WHITELISTED', () => {
+      const task = makeTaskConfig({ whitelist: [BOB] });
+      let caught;
+      try {
+        assertKeeperAuthorized(task, CAROL);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught.code).toBe('KEEPER_NOT_WHITELISTED');
+    });
+
+    it('error meta includes keeperAddress and whitelist', () => {
+      const task = makeTaskConfig({ whitelist: [BOB] });
+      let caught;
+      try {
+        assertKeeperAuthorized(task, CAROL);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught.meta.keeperAddress).toBe(CAROL);
+      expect(caught.meta.whitelist).toEqual([BOB]);
+    });
+
+    it('allows keeper when whitelist has multiple entries and keeper matches one', () => {
+      const task = makeTaskConfig({ whitelist: [ALICE, BOB, CAROL] });
+      expect(() => assertKeeperAuthorized(task, BOB)).not.toThrow();
+    });
+
+    it('rejects keeper when whitelist has multiple entries and keeper matches none', () => {
+      const task = makeTaskConfig({ whitelist: [ALICE, BOB] });
+      expect(() => assertKeeperAuthorized(task, CAROL)).toThrow(AccessControlError);
+    });
+  });
+
+  describe('invalid arguments', () => {
+    it('throws INVALID_ARGS when taskConfig is null', () => {
+      let caught;
+      try {
+        assertKeeperAuthorized(null, BOB);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught.code).toBe('INVALID_ARGS');
+    });
+
+    it('throws INVALID_ARGS when keeperAddress is empty string', () => {
+      const task = makeTaskConfig();
+      let caught;
+      try {
+        assertKeeperAuthorized(task, '');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught.code).toBe('INVALID_ARGS');
+    });
+
+    it('throws INVALID_ARGS when keeperAddress is not a string', () => {
+      const task = makeTaskConfig();
+      let caught;
+      try {
+        assertKeeperAuthorized(task, 12345);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught.code).toBe('INVALID_ARGS');
+    });
+  });
+});
+
+// ── Creator authorization ─────────────────────────────────────────────────────
+
+describe('assertCreatorAuthorized — creator-only operations', () => {
+  it('allows the task creator', () => {
+    const task = makeTaskConfig({ creator: ALICE });
+    expect(() => assertCreatorAuthorized(task, ALICE)).not.toThrow();
+  });
+
+  it('rejects a non-creator caller', () => {
+    const task = makeTaskConfig({ creator: ALICE });
+    expect(() => assertCreatorAuthorized(task, BOB)).toThrow(AccessControlError);
+  });
+
+  it('rejected error has code NOT_CREATOR', () => {
+    const task = makeTaskConfig({ creator: ALICE });
+    let caught;
+    try {
+      assertCreatorAuthorized(task, BOB);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('NOT_CREATOR');
+  });
+
+  it('error meta identifies both caller and creator', () => {
+    const task = makeTaskConfig({ creator: ALICE });
+    let caught;
+    try {
+      assertCreatorAuthorized(task, BOB);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.meta.callerAddress).toBe(BOB);
+    expect(caught.meta.creator).toBe(ALICE);
+  });
+
+  it('throws INVALID_ARGS when taskConfig is null', () => {
+    let caught;
+    try {
+      assertCreatorAuthorized(null, ALICE);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('INVALID_ARGS');
+  });
+
+  it('throws INVALID_ARGS when callerAddress is missing', () => {
+    const task = makeTaskConfig();
+    let caught;
+    try {
+      assertCreatorAuthorized(task, '');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('INVALID_ARGS');
+  });
+
+  it('creator check is exact-match — prefix match does not count', () => {
+    const task = makeTaskConfig({ creator: ALICE });
+    // A truncated or partial address must be rejected
+    expect(() => assertCreatorAuthorized(task, ALICE.slice(0, 10)))
+      .toThrow(AccessControlError);
+  });
+});
+
+// ── Portfolio creator authorization ───────────────────────────────────────────
+
+describe('assertPortfolioCreatorAuthorized — portfolio operations', () => {
+  it('allows the portfolio creator', () => {
+    const portfolio = makePortfolio({ creator: ALICE });
+    expect(() => assertPortfolioCreatorAuthorized(portfolio, ALICE)).not.toThrow();
+  });
+
+  it('rejects a task creator who is not the portfolio creator', () => {
+    const portfolio = makePortfolio({ creator: ALICE });
+    // BOB owns a task in the portfolio but is not the portfolio creator
+    expect(() => assertPortfolioCreatorAuthorized(portfolio, BOB))
+      .toThrow(AccessControlError);
+  });
+
+  it('rejected error has code NOT_PORTFOLIO_CREATOR', () => {
+    const portfolio = makePortfolio({ creator: ALICE });
+    let caught;
+    try {
+      assertPortfolioCreatorAuthorized(portfolio, BOB);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('NOT_PORTFOLIO_CREATOR');
+  });
+
+  it('throws INVALID_ARGS when portfolio is null', () => {
+    let caught;
+    try {
+      assertPortfolioCreatorAuthorized(null, ALICE);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('INVALID_ARGS');
+  });
+});
+
+// ── Keeper admin HTTP API ─────────────────────────────────────────────────────
+
+describe('assertAdminTokenValid — keeper admin HTTP authorization', () => {
+  it('accepts a correct bearer token', () => {
+    expect(() => assertAdminTokenValid('secret-token', 'secret-token')).not.toThrow();
+  });
+
+  it('rejects a missing/undefined bearer token with MISSING_TOKEN', () => {
+    let caught;
+    try {
+      assertAdminTokenValid(undefined, 'secret-token');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('MISSING_TOKEN');
+  });
+
+  it('rejects an empty bearer token with MISSING_TOKEN', () => {
+    let caught;
+    try {
+      assertAdminTokenValid('', 'secret-token');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('MISSING_TOKEN');
+  });
+
+  it('rejects a wrong bearer token with INVALID_TOKEN', () => {
+    let caught;
+    try {
+      assertAdminTokenValid('wrong-token', 'secret-token');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('INVALID_TOKEN');
+  });
+
+  it('rejects when KEEPER_ADMIN_TOKEN is not configured (admin disabled)', () => {
+    let caught;
+    try {
+      assertAdminTokenValid('some-token', undefined);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.code).toBe('ADMIN_DISABLED');
+  });
+
+  it('token comparison is case-sensitive', () => {
+    expect(() => assertAdminTokenValid('Secret-Token', 'secret-token'))
+      .toThrow(AccessControlError);
+  });
+
+  it('token comparison is exact — extra whitespace is rejected', () => {
+    expect(() => assertAdminTokenValid(' secret-token', 'secret-token'))
+      .toThrow(AccessControlError);
+  });
+});
+
+// ── requireAdminAuth middleware (src/auth.js) ─────────────────────────────────
+
+describe('requireAdminAuth middleware — HTTP layer', () => {
+  const { requireAdminAuth } = require('../src/auth');
+
+  function mockRes() {
+    return {
+      statusCode: 200,
+      status(code) { this.statusCode = code; return this; },
+      json() {},
+    };
+  }
+
+  afterEach(() => {
+    delete process.env.KEEPER_ADMIN_TOKEN;
+  });
+
+  it('returns 401 when Authorization header is missing', () => {
+    const req = { headers: {} };
+    const res = mockRes();
+    requireAdminAuth(req, res, () => {});
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when Authorization header does not start with Bearer', () => {
+    const req = { headers: { authorization: 'Basic sometoken' } };
+    const res = mockRes();
+    requireAdminAuth(req, res, () => {});
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 403 when KEEPER_ADMIN_TOKEN is not set (admin disabled)', () => {
+    // No env var set
+    const req = { headers: { authorization: 'Bearer anything' } };
+    const res = mockRes();
+    requireAdminAuth(req, res, () => {});
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 403 when token does not match KEEPER_ADMIN_TOKEN', () => {
+    process.env.KEEPER_ADMIN_TOKEN = 'correct-token';
+    const req = { headers: { authorization: 'Bearer wrong-token' } };
+    const res = mockRes();
+    requireAdminAuth(req, res, () => {});
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('calls next() when token matches KEEPER_ADMIN_TOKEN', () => {
+    process.env.KEEPER_ADMIN_TOKEN = 'correct-token';
+    const req = { headers: { authorization: 'Bearer correct-token' } };
+    const res = mockRes();
+    let nextCalled = false;
+    requireAdminAuth(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+    expect(res.statusCode).toBe(200); // unchanged
+  });
+
+  it('does not call next() on authentication failure', () => {
+    process.env.KEEPER_ADMIN_TOKEN = 'correct-token';
+    const req = { headers: { authorization: 'Bearer wrong' } };
+    const res = mockRes();
+    let nextCalled = false;
+    requireAdminAuth(req, res, () => { nextCalled = true; });
+    expect(nextCalled).toBe(false);
+  });
+});
+
+// ── Whitelist audit helper ────────────────────────────────────────────────────
+
+describe('auditTaskWhitelist — open task detection', () => {
+  it('flags an empty whitelist as open with a warning', () => {
+    const task = makeTaskConfig({ whitelist: [] });
+    const result = auditTaskWhitelist(task, 42);
+    expect(result.isOpen).toBe(true);
+    expect(result.warning).toMatch(/42/); // includes task ID
+    expect(result.warning).toMatch(/empty whitelist/);
+  });
+
+  it('returns isOpen:false and no warning for a non-empty whitelist', () => {
+    const task = makeTaskConfig({ whitelist: [BOB] });
+    const result = auditTaskWhitelist(task, 42);
+    expect(result.isOpen).toBe(false);
+    expect(result.warning).toBeNull();
+  });
+
+  it('handles null taskConfig gracefully (treats as open)', () => {
+    const result = auditTaskWhitelist(null, 99);
+    expect(result.isOpen).toBe(true);
+  });
+
+  it('handles missing whitelist field (treats as open)', () => {
+    const task = makeTaskConfig();
+    delete task.whitelist;
+    const result = auditTaskWhitelist(task, 1);
+    expect(result.isOpen).toBe(true);
+  });
+});
+
+// ── Registry query helpers ─────────────────────────────────────────────────────
+
+describe('getEntryPointsByPrivilege', () => {
+  it('returns only entries matching the given privilege level', () => {
+    const creatorEps = getEntryPointsByPrivilege(PrivilegeLevel.CREATOR);
+    expect(creatorEps.length).toBeGreaterThan(0);
+    creatorEps.forEach(ep => expect(ep.privilege).toBe(PrivilegeLevel.CREATOR));
+  });
+
+  it('returns an empty array for an unknown privilege level', () => {
+    expect(getEntryPointsByPrivilege('nonexistent')).toEqual([]);
+  });
+
+  it('ADMIN entries include set_admin_address and set_vrf_oracle_address', () => {
+    const adminEps = getEntryPointsByPrivilege(PrivilegeLevel.ADMIN);
+    const fns = adminEps.map(ep => ep.fn);
+    expect(fns).toContain('set_admin_address');
+    expect(fns).toContain('set_vrf_oracle_address');
+  });
+
+  it('PUBLIC entries include get_task and monitor', () => {
+    const publicEps = getEntryPointsByPrivilege(PrivilegeLevel.PUBLIC);
+    const fns = publicEps.map(ep => ep.fn);
+    expect(fns).toContain('get_task');
+    expect(fns).toContain('monitor');
+  });
+});
+
+describe('getKnownAmbiguities', () => {
+  it('returns only entries with a severity field', () => {
+    const issues = getKnownAmbiguities();
+    expect(issues.length).toBeGreaterThan(0);
+    issues.forEach(ep => expect(ep.severity).toBeDefined());
+  });
+
+  it('surfaces set_admin_address as a CRITICAL finding', () => {
+    const issues = getKnownAmbiguities();
+    const adminBug = issues.find(ep => ep.fn === 'set_admin_address');
+    expect(adminBug).toBeDefined();
+    expect(adminBug.severity).toBe('CRITICAL');
+  });
+
+  it('surfaces init_yield_strategy as a HIGH severity finding', () => {
+    const issues = getKnownAmbiguities();
+    const yieldBug = issues.find(ep => ep.fn === 'init_yield_strategy');
+    expect(yieldBug).toBeDefined();
+    expect(yieldBug.severity).toBe('HIGH');
+  });
+
+  it('notes for set_admin_address mention the broken guard', () => {
+    const issues = getKnownAmbiguities();
+    const adminBug = issues.find(ep => ep.fn === 'set_admin_address');
+    expect(adminBug.notes).toMatch(/current_contract_address/);
+  });
+
+  it('notes for init_yield_strategy describe the always-false condition', () => {
+    const issues = getKnownAmbiguities();
+    const yieldBug = issues.find(ep => ep.fn === 'init_yield_strategy');
+    expect(yieldBug.notes).toMatch(/always false/);
+  });
+});
+
+// ── Audit summary ─────────────────────────────────────────────────────────────
+
+describe('generateAuditSummary', () => {
+  it('returns a non-empty string', () => {
+    const summary = generateAuditSummary();
+    expect(typeof summary).toBe('string');
+    expect(summary.length).toBeGreaterThan(0);
+  });
+
+  it('includes the known issue section', () => {
+    const summary = generateAuditSummary();
+    expect(summary).toMatch(/KNOWN ISSUES/);
+  });
+
+  it('includes CRITICAL finding for set_admin_address', () => {
+    const summary = generateAuditSummary();
+    expect(summary).toMatch(/CRITICAL/);
+    expect(summary).toMatch(/set_admin_address/);
+  });
+
+  it('includes all privilege levels', () => {
+    const summary = generateAuditSummary();
+    expect(summary).toMatch(/PUBLIC/i);
+    expect(summary).toMatch(/CREATOR/i);
+    expect(summary).toMatch(/ADMIN/i);
+    expect(summary).toMatch(/KEEPER/i);
+  });
+});
+
+// ── Contract-level authorization findings (documented bugs) ───────────────────
+
+describe('Documented authorization findings — for maintainer review', () => {
+  /**
+   * FINDING 1 (CRITICAL): set_admin_address broken guard
+   *
+   * Contract: lib.rs:3179
+   * The re-assignment guard uses `env.current_contract_address()` as the
+   * "caller" to compare against the stored admin.  current_contract_address()
+   * always returns the contract's own address, never an external caller's
+   * address.  This means the condition `caller != existing_admin` is always
+   * true for any external account, allowing any caller to overwrite the admin
+   * after the initial bootstrap.
+   *
+   * Expected behaviour: only the current admin (transaction signer) should be
+   * able to change the admin address.
+   * Fix: replace env.current_contract_address() with the signed address
+   * parameter passed into the function (or add a `new_admin: Address` arg
+   * and call new_admin.require_auth()).
+   */
+  it('FINDING-1 [CRITICAL]: set_admin_address guard is documented as broken', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'set_admin_address');
+    expect(ep.severity).toBe('CRITICAL');
+    expect(ep.notes).toMatch(/BUG/);
+    expect(ep.notes).toMatch(/any external caller/i);
+  });
+
+  /**
+   * FINDING 2 (HIGH): init_yield_strategy always-pass guard
+   *
+   * Contract: lib.rs:3265
+   * `let admin = env.current_contract_address();`
+   * `if admin != env.current_contract_address()` — both sides identical.
+   * The condition is always false, so the guard never fires.
+   * Any caller can initialise yield strategies with arbitrary protocol
+   * addresses and harvest functions.
+   *
+   * Fix: use a proper admin address comparison (same pattern as
+   * set_vrf_oracle_address at lib.rs:2845).
+   */
+  it('FINDING-2 [HIGH]: init_yield_strategy guard is documented as broken', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'init_yield_strategy');
+    expect(ep.severity).toBe('HIGH');
+    expect(ep.notes).toMatch(/always/);
+  });
+
+  /**
+   * FINDING 3 (MEDIUM): pre-admin bootstrap — role/permission assignment open
+   *
+   * Contract: lib.rs:3981
+   * assign_role, revoke_role, grant_permission, revoke_permission all gate
+   * on `if let Some(admin) = admin_address`.  If no admin has been set yet
+   * (DataKey::AdminAddress is None), the outer block is never entered and any
+   * caller can freely assign roles and permissions.
+   *
+   * This is a bootstrap race condition: if the admin address is not set
+   * atomically with contract deployment, a front-runner can claim admin-level
+   * permissions before the legitimate admin is established.
+   */
+  it('FINDING-3 [MEDIUM]: assign_role notes surface the bootstrap gap', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'assign_role');
+    expect(ep.notes).toMatch(/any actor/i);
+    expect(ep.notes).toMatch(/admin initialization/i);
+  });
+
+  /**
+   * FINDING 4 (LOW): whitelist empty == open task (semantic ambiguity)
+   *
+   * Contract: lib.rs:2015
+   * execute() checks `if !whitelist.is_empty() && !whitelist.contains(keeper)`.
+   * An empty whitelist means any keeper can execute.  Task creators who omit
+   * the whitelist field unknowingly publish open tasks.
+   *
+   * This is valid by design but the semantics are not surfaced to creators
+   * at registration time.
+   */
+  it('FINDING-4 [LOW]: execute whitelist semantics are documented', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'execute');
+    expect(ep.notes).toMatch(/empty whitelist/);
+    expect(ep.privilege).toBe(PrivilegeLevel.WHITELISTED_KEEPER);
+  });
+
+  /**
+   * FINDING 5 (LOW): role/permission expiry not enforced
+   *
+   * Contract: lib.rs:4007
+   * RoleAssignment.expires_at is stored but no auth-path checks the field.
+   * Expired roles remain valid until manually revoked.
+   *
+   * This is noted in the delegate_permission registry entry.
+   */
+  it('FINDING-5 [LOW]: delegation expiry ambiguity is documented', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'delegate_permission');
+    expect(ep.notes).toMatch(/expiry/i);
+    expect(ep.notes).toMatch(/Expired delegations/i);
+  });
+
+  /**
+   * FINDING 6 (LOW): fulfill_vrf_request uses address comparison not require_auth
+   *
+   * Contract: uses env.current_contract_address() comparison instead of
+   * caller.require_auth().  This means there is no cryptographic binding that
+   * the caller actually controls the configured oracle address — only that the
+   * stored oracle address matches.  If the oracle contract is compromised or
+   * the oracle config is manipulated (via Finding 1), arbitrary VRF responses
+   * can be injected.
+   */
+  it('FINDING-6 [LOW]: fulfill_vrf_request uses address comparison, not require_auth', () => {
+    const ep = CONTRACT_ENTRY_POINTS.find(e => e.fn === 'fulfill_vrf_request');
+    expect(ep.notes).toMatch(/no require_auth/);
+  });
+});
+
+// ── Privilege model sanity checks ─────────────────────────────────────────────
+
+describe('PrivilegeLevel — model sanity', () => {
+  it('is a frozen object', () => {
+    expect(Object.isFrozen(PrivilegeLevel)).toBe(true);
+  });
+
+  it('has at least PUBLIC, CREATOR, KEEPER, ADMIN privilege levels', () => {
+    expect(PrivilegeLevel.PUBLIC).toBeDefined();
+    expect(PrivilegeLevel.CREATOR).toBeDefined();
+    expect(PrivilegeLevel.KEEPER).toBeDefined();
+    expect(PrivilegeLevel.ADMIN).toBeDefined();
+  });
+
+  it('WHITELISTED_KEEPER is a stricter variant of KEEPER', () => {
+    expect(PrivilegeLevel.WHITELISTED_KEEPER).toBeDefined();
+    expect(PrivilegeLevel.WHITELISTED_KEEPER).not.toBe(PrivilegeLevel.KEEPER);
+  });
+});

--- a/keeper/src/accessControl.js
+++ b/keeper/src/accessControl.js
@@ -1,0 +1,610 @@
+'use strict';
+
+/**
+ * accessControl.js — Contract Access Control Audit for Administrative Paths
+ *
+ * Issue #250: Verify that privileged contract actions cannot be triggered by
+ * the wrong actors.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════
+ * PERMISSION MODEL (as implemented in contract/src/lib.rs)
+ * ══════════════════════════════════════════════════════════════════════════════
+ *
+ * The SoroTask contract enforces four distinct authorization layers:
+ *
+ * 1. SIGNATURE-BASED  (require_auth)
+ *    The Soroban host verifies that the named address signed the transaction.
+ *    Used for creator-owned operations (register, pause, cancel, withdraw…)
+ *    and keeper-owned operations (execute, batch_execute, settle_state_channel).
+ *
+ * 2. WHITELIST-BASED
+ *    execute() checks: if !whitelist.is_empty() && !whitelist.contains(keeper)
+ *    → Error::Unauthorized.
+ *    SEMANTICS AMBIGUITY: an empty whitelist means ANY keeper may execute.
+ *    A non-empty whitelist is strictly restrictive.  Task creators who forget
+ *    to populate the whitelist unknowingly publish an open task.
+ *
+ * 3. ADMIN-BASED
+ *    set_admin_address, set_vrf_oracle_address, update_tokenomics_config,
+ *    assign_role, revoke_role, grant_permission, revoke_permission, and
+ *    delegate_permission are all gated on the stored DataKey::AdminAddress.
+ *
+ *    ⚠ AMBIGUITY — BOOTSTRAP RACE:
+ *    set_admin_address allows the first caller to set the admin unchallenged
+ *    ("Anyone can set the initial admin" — lib.rs:3167).  Until an admin is
+ *    set, assign_role / grant_permission skip their admin check entirely
+ *    (the outer `if let Some(admin)` block is not entered), meaning any actor
+ *    can assign roles before the admin is initialized.
+ *
+ *    ⚠ BUG — BROKEN set_admin_address GUARD (lib.rs:3179):
+ *    The existing-admin guard uses `env.current_contract_address()` as the
+ *    caller, not the transaction signer.  `current_contract_address()` always
+ *    returns the contract's own address, which will never equal an externally
+ *    set AdminAddress.  The check therefore always fails, letting **any**
+ *    external caller overwrite the admin address after initial bootstrap.
+ *
+ *    ⚠ BUG — BROKEN init_yield_strategy GUARD (lib.rs:3265):
+ *    The guard `if admin != env.current_contract_address()` compares the
+ *    contract address with itself — the condition is always false, making
+ *    this function callable by any actor with no restriction.
+ *
+ * 4. ROLE / PERMISSION-BASED
+ *    assign_role, revoke_role, grant_permission, revoke_permission require
+ *    the caller to be admin OR hold the AdminAccess permission.
+ *    RoleAssignment carries an `expires_at` field (lib.rs:4007) but no code
+ *    path enforces expiry — expired roles remain valid indefinitely.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════
+ * KEEPER ADMIN API PERMISSION MODEL
+ * ══════════════════════════════════════════════════════════════════════════════
+ *
+ * The keeper's /admin/* HTTP endpoints are gated by requireAdminAuth()
+ * (src/auth.js), which validates a Bearer token against KEEPER_ADMIN_TOKEN.
+ *
+ * The admin API controls operational state only (pause / resume / status).
+ * It does NOT submit on-chain transactions and has no contract-level authority.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════
+ */
+
+// ── Privilege levels ──────────────────────────────────────────────────────────
+
+/**
+ * Enumeration of all authorization tiers used by the SoroTask contract.
+ * Ordered from least to most privileged.
+ */
+const PrivilegeLevel = Object.freeze({
+  PUBLIC: 'public',
+  CREATOR: 'creator',
+  KEEPER: 'keeper',
+  WHITELISTED_KEEPER: 'whitelisted_keeper',
+  ADMIN: 'admin',
+  ADMIN_OR_DELEGATE: 'admin_or_delegate',
+  CONTRACT_SELF: 'contract_self',
+  ORACLE_CONTRACT: 'oracle_contract',
+  CHANNEL_PARTICIPANT: 'channel_participant',
+});
+
+// ── Contract entry point registry ─────────────────────────────────────────────
+
+/**
+ * Authoritative registry of every public contract entry point, its required
+ * privilege level, the exact mechanism used, and any known ambiguities.
+ *
+ * This is the source of truth for the access control audit.  The test suite
+ * (accessControl.test.js) validates each entry in this registry.
+ *
+ * @type {readonly Object[]}
+ */
+const CONTRACT_ENTRY_POINTS = Object.freeze([
+  // ── Read-only (no auth) ──────────────────────────────────────────────────
+  {
+    fn: 'get_task',
+    privilege: PrivilegeLevel.PUBLIC,
+    mechanism: 'none',
+    notes: 'Read-only view. Returns null for non-existent tasks.',
+  },
+  {
+    fn: 'monitor',
+    privilege: PrivilegeLevel.PUBLIC,
+    mechanism: 'none',
+    notes: 'Returns executable task list. No state mutation.',
+  },
+
+  // ── Creator-owned task operations ────────────────────────────────────────
+  {
+    fn: 'register',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'Creator signs the transaction. Interval and payload are validated before storage.',
+  },
+  {
+    fn: 'pause_task',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'Panics with TaskAlreadyPaused if already inactive.',
+  },
+  {
+    fn: 'resume_task',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'Panics with TaskAlreadyActive if already active.',
+  },
+  {
+    fn: 'cancel_task',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'Removes task from storage. ID is never reused.',
+  },
+  {
+    fn: 'withdraw_gas',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'Transfers gas tokens back to creator.',
+  },
+  {
+    fn: 'add_dependency_with_rule',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'task.creator.require_auth()',
+    notes: 'A task cannot depend on itself (SelfDependency). Max 16 dependencies.',
+  },
+  {
+    fn: 'request_vrf_randomness',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'VRF oracle address must be set first via set_vrf_oracle_address.',
+  },
+  {
+    fn: 'request_oracle_data',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'task.creator.require_auth()',
+    notes: 'Oracle provider config must be set. Provider address validated.',
+  },
+  {
+    fn: 'submit_zk_condition',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'ZK verifier contract address is stored alongside the condition.',
+  },
+  {
+    fn: 'submit_merkle_proof',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'config.creator.require_auth()',
+    notes: 'Merkle root stored; proof is verified by verifier contract at verify time.',
+  },
+
+  // ── Portfolio operations (creator-owned) ─────────────────────────────────
+  {
+    fn: 'add_task_to_portfolio',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'portfolio.creator.require_auth()',
+    notes: 'Portfolio creator, not task creator, authorizes.',
+  },
+  {
+    fn: 'remove_task_from_portfolio',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'portfolio.creator.require_auth()',
+    notes: 'Same: portfolio creator only.',
+  },
+  {
+    fn: 'pause_portfolio',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'portfolio.creator.require_auth()',
+    notes: 'Pauses all tasks in the portfolio.',
+  },
+  {
+    fn: 'resume_portfolio',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'portfolio.creator.require_auth()',
+    notes: 'Resumes all tasks in the portfolio.',
+  },
+  {
+    fn: 'fund_portfolio',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'portfolio.creator.require_auth()',
+    notes: 'Deposits gas to all tasks proportionally.',
+  },
+  {
+    fn: 'execute_portfolio_tasks',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'portfolio.creator.require_auth()',
+    notes: 'Batch execution gated on portfolio creator; NOT keeper-level auth.',
+  },
+
+  // ── Keeper execution paths ────────────────────────────────────────────────
+  {
+    fn: 'execute',
+    privilege: PrivilegeLevel.WHITELISTED_KEEPER,
+    mechanism: 'keeper.require_auth() + whitelist check',
+    notes: [
+      'Two-stage auth: (1) keeper signs tx, (2) whitelist check if non-empty.',
+      'AMBIGUITY: empty whitelist = any keeper can execute (open task).',
+      'Task creators who omit a whitelist unknowingly publish open tasks.',
+    ].join(' '),
+  },
+  {
+    fn: 'batch_execute',
+    privilege: PrivilegeLevel.KEEPER,
+    mechanism: 'keeper.require_auth()',
+    notes: 'No per-task whitelist check in batch path. Max 100 tasks per call.',
+  },
+  {
+    fn: 'deposit_gas',
+    privilege: PrivilegeLevel.KEEPER,
+    mechanism: 'from.require_auth()',
+    notes: 'Depositor (not creator) authorizes. Any address may top up gas.',
+  },
+
+  // ── State channel operations ─────────────────────────────────────────────
+  {
+    fn: 'update_state_channel',
+    privilege: PrivilegeLevel.CHANNEL_PARTICIPANT,
+    mechanism: 'participants list check',
+    notes: 'Caller must be in channel.participants. No require_auth — membership check only.',
+  },
+  {
+    fn: 'settle_state_channel',
+    privilege: PrivilegeLevel.KEEPER,
+    mechanism: 'keeper.require_auth()',
+    notes: 'Keeper settles; triggers micro-task execution within the settlement.',
+  },
+
+  // ── Oracle / VRF fulfillment (contract-to-contract) ──────────────────────
+  {
+    fn: 'fulfill_oracle_data',
+    privilege: PrivilegeLevel.ORACLE_CONTRACT,
+    mechanism: 'caller.require_auth() + oracle address match',
+    notes: 'Oracle contract address must match DataKey::OracleConfig(provider).address.',
+  },
+  {
+    fn: 'fulfill_vrf_request',
+    privilege: PrivilegeLevel.ORACLE_CONTRACT,
+    mechanism: 'VRF oracle address match (no require_auth)',
+    notes: [
+      'Uses env.current_contract_address() comparison instead of require_auth.',
+      'AMBIGUITY: no cryptographic proof that caller is the configured oracle.',
+      'Any contract that somehow gets the VRF oracle address slot could fulfill.',
+    ].join(' '),
+  },
+
+  // ── ZK / Merkle verification ─────────────────────────────────────────────
+  {
+    fn: 'verify_zk_condition',
+    privilege: PrivilegeLevel.CONTRACT_SELF,
+    mechanism: 'verifier address check',
+    notes: 'Only the stored ZK verifier contract may call this.',
+  },
+  {
+    fn: 'verify_merkle_proof',
+    privilege: PrivilegeLevel.CONTRACT_SELF,
+    mechanism: 'verifier address check',
+    notes: 'Only the stored Merkle verifier contract may call this.',
+  },
+
+  // ── Admin / governance paths ─────────────────────────────────────────────
+  {
+    fn: 'set_admin_address',
+    privilege: PrivilegeLevel.ADMIN,
+    mechanism: 'existing admin check OR open bootstrap',
+    severity: 'CRITICAL',
+    notes: [
+      'BUG: guard uses env.current_contract_address() as "caller" (lib.rs:3179).',
+      'current_contract_address() == contract address, never == AdminAddress.',
+      'Result: ANY external caller can overwrite the admin address after bootstrap.',
+      'Bootstrap window (no admin set) also allows any first caller to claim admin.',
+    ].join(' '),
+  },
+  {
+    fn: 'set_vrf_oracle_address',
+    privilege: PrivilegeLevel.ADMIN,
+    mechanism: 'DataKey::AdminAddress comparison',
+    notes: 'Correctly guards against non-admin callers when admin is set.',
+  },
+  {
+    fn: 'update_tokenomics_config',
+    privilege: PrivilegeLevel.ADMIN,
+    mechanism: 'admin address OR governance execution path',
+    notes: 'Dual path: admin direct call OR governance-executed proposal.',
+  },
+  {
+    fn: 'init_yield_strategy',
+    privilege: PrivilegeLevel.ADMIN,
+    mechanism: 'broken — always passes (lib.rs:3265)',
+    severity: 'HIGH',
+    notes: [
+      'BUG: guard is `if admin != env.current_contract_address()` where',
+      'admin = env.current_contract_address(). Both sides are equal, so',
+      'the condition is always false. Any caller can init yield strategies.',
+    ].join(' '),
+  },
+
+  // ── Role & permission management ─────────────────────────────────────────
+  {
+    fn: 'assign_role',
+    privilege: PrivilegeLevel.ADMIN_OR_DELEGATE,
+    mechanism: 'admin address OR AdminAccess permission',
+    notes: [
+      'When no admin is set, the admin check block is skipped entirely.',
+      'Any actor can assign roles before admin initialization.',
+    ].join(' '),
+  },
+  {
+    fn: 'revoke_role',
+    privilege: PrivilegeLevel.ADMIN_OR_DELEGATE,
+    mechanism: 'admin address OR AdminAccess permission',
+    notes: 'Same pre-admin bootstrap gap as assign_role.',
+  },
+  {
+    fn: 'grant_permission',
+    privilege: PrivilegeLevel.ADMIN_OR_DELEGATE,
+    mechanism: 'admin address OR AdminAccess permission',
+    notes: 'Permissions include AdminAccess — escalation risk if grant is wide.',
+  },
+  {
+    fn: 'revoke_permission',
+    privilege: PrivilegeLevel.ADMIN_OR_DELEGATE,
+    mechanism: 'admin address OR AdminAccess permission',
+    notes: 'Revocation is immediate; no grace period.',
+  },
+  {
+    fn: 'delegate_permission',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'caller must hold the permissions being delegated',
+    notes: [
+      'Delegation expires after 30 days by default.',
+      'AMBIGUITY: expiry field exists but no enforcement in auth checks.',
+      'Expired delegations remain valid until explicitly revoked.',
+    ].join(' '),
+  },
+  {
+    fn: 'revoke_delegation',
+    privilege: PrivilegeLevel.CREATOR,
+    mechanism: 'original delegator address match',
+    notes: 'Only the address that created the delegation can revoke it.',
+  },
+  {
+    fn: 'initialize_keeper_reputation',
+    privilege: PrivilegeLevel.ADMIN_OR_DELEGATE,
+    mechanism: 'admin address OR AdminAccess permission',
+    notes: 'Creates an initial reputation record for a keeper address.',
+  },
+]);
+
+// ── Pre-flight authorization guards ──────────────────────────────────────────
+//
+// These functions run on the keeper side BEFORE submitting a transaction,
+// providing an early-exit with a diagnostic error rather than wasting an
+// RPC call that will be rejected by the contract.
+
+/**
+ * Assert that a keeper address is authorized to execute a given task.
+ *
+ * Replicates the contract's two-stage check:
+ *   1. keeper must be a string (address will be require_auth'd by Soroban)
+ *   2. If task whitelist is non-empty, keeper must appear in it
+ *
+ * @param   {Object}   taskConfig       - Decoded TaskConfig from the contract
+ * @param   {string}   keeperAddress    - The keeper's public key / address
+ * @throws  {AccessControlError}        - When the keeper is not authorized
+ */
+function assertKeeperAuthorized(taskConfig, keeperAddress) {
+  if (!taskConfig || typeof keeperAddress !== 'string' || !keeperAddress) {
+    throw new AccessControlError(
+      'assertKeeperAuthorized: taskConfig and keeperAddress are required',
+      'INVALID_ARGS',
+    );
+  }
+
+  const whitelist = taskConfig.whitelist || [];
+
+  // Empty whitelist = open task — any authenticated keeper may execute
+  if (whitelist.length === 0) {
+    return; // authorized (open)
+  }
+
+  // Non-empty whitelist — keeper must appear
+  if (!whitelist.includes(keeperAddress)) {
+    throw new AccessControlError(
+      `Keeper ${keeperAddress} is not in the task whitelist`,
+      'KEEPER_NOT_WHITELISTED',
+      { keeperAddress, whitelist },
+    );
+  }
+}
+
+/**
+ * Assert that a caller is the creator of a task.
+ * Used for creator-only operations (pause, cancel, withdraw_gas, etc.).
+ *
+ * @param   {Object} taskConfig      - Decoded TaskConfig
+ * @param   {string} callerAddress   - Address attempting the operation
+ * @throws  {AccessControlError}
+ */
+function assertCreatorAuthorized(taskConfig, callerAddress) {
+  if (!taskConfig || typeof callerAddress !== 'string' || !callerAddress) {
+    throw new AccessControlError(
+      'assertCreatorAuthorized: taskConfig and callerAddress are required',
+      'INVALID_ARGS',
+    );
+  }
+
+  if (taskConfig.creator !== callerAddress) {
+    throw new AccessControlError(
+      `Caller ${callerAddress} is not the task creator (${taskConfig.creator})`,
+      'NOT_CREATOR',
+      { callerAddress, creator: taskConfig.creator },
+    );
+  }
+}
+
+/**
+ * Assert that a portfolio operation is authorized by the portfolio creator.
+ *
+ * @param   {Object} portfolio       - Decoded Portfolio struct
+ * @param   {string} callerAddress
+ * @throws  {AccessControlError}
+ */
+function assertPortfolioCreatorAuthorized(portfolio, callerAddress) {
+  if (!portfolio || typeof callerAddress !== 'string' || !callerAddress) {
+    throw new AccessControlError(
+      'assertPortfolioCreatorAuthorized: portfolio and callerAddress are required',
+      'INVALID_ARGS',
+    );
+  }
+
+  if (portfolio.creator !== callerAddress) {
+    throw new AccessControlError(
+      `Caller ${callerAddress} is not the portfolio creator (${portfolio.creator})`,
+      'NOT_PORTFOLIO_CREATOR',
+      { callerAddress, creator: portfolio.creator },
+    );
+  }
+}
+
+/**
+ * Assert that the keeper admin HTTP token is valid.
+ *
+ * Mirrors the logic in src/auth.js so callers can validate pre-flight
+ * without going through the Express middleware stack.
+ *
+ * @param   {string|undefined} bearerToken   - Token from Authorization header
+ * @param   {string|undefined} expected      - Expected token (KEEPER_ADMIN_TOKEN)
+ * @throws  {AccessControlError}
+ */
+function assertAdminTokenValid(bearerToken, expected) {
+  if (!bearerToken) {
+    throw new AccessControlError('Missing admin bearer token', 'MISSING_TOKEN');
+  }
+
+  if (!expected) {
+    throw new AccessControlError(
+      'Admin API is disabled: KEEPER_ADMIN_TOKEN is not configured',
+      'ADMIN_DISABLED',
+    );
+  }
+
+  if (bearerToken !== expected) {
+    throw new AccessControlError('Invalid admin bearer token', 'INVALID_TOKEN');
+  }
+}
+
+/**
+ * Check whether a task's whitelist is empty (open task) and surface a warning.
+ *
+ * This is an informational check — open tasks are valid but may be
+ * unintentional.  Returns a diagnostic object rather than throwing.
+ *
+ * @param   {Object} taskConfig
+ * @param   {number} taskId
+ * @returns {{ isOpen: boolean, warning: string|null }}
+ */
+function auditTaskWhitelist(taskConfig, taskId) {
+  const whitelist = taskConfig?.whitelist || [];
+
+  if (whitelist.length === 0) {
+    return {
+      isOpen: true,
+      warning: `Task ${taskId} has an empty whitelist — any keeper can execute it. ` +
+               'If this is unintentional, add keeper addresses to the whitelist.',
+    };
+  }
+
+  return { isOpen: false, warning: null };
+}
+
+// ── Audit helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Return all known privileged entry points for a given privilege level.
+ *
+ * @param   {string} level - One of PrivilegeLevel.*
+ * @returns {Object[]}
+ */
+function getEntryPointsByPrivilege(level) {
+  return CONTRACT_ENTRY_POINTS.filter(ep => ep.privilege === level);
+}
+
+/**
+ * Return all entry points that carry a known severity flag (bug / ambiguity).
+ *
+ * @returns {Object[]}
+ */
+function getKnownAmbiguities() {
+  return CONTRACT_ENTRY_POINTS.filter(ep => ep.severity);
+}
+
+/**
+ * Generate a human-readable summary of the access control model for logging
+ * or documentation purposes.
+ *
+ * @returns {string}
+ */
+function generateAuditSummary() {
+  const byLevel = {};
+  for (const ep of CONTRACT_ENTRY_POINTS) {
+    if (!byLevel[ep.privilege]) {
+      byLevel[ep.privilege] = [];
+    }
+    byLevel[ep.privilege].push(ep.fn);
+  }
+
+  const lines = ['SoroTask Contract Access Control Audit Summary', '='.repeat(50)];
+
+  for (const [level, fns] of Object.entries(byLevel)) {
+    lines.push(`\n${level.toUpperCase()} (${fns.length}):`);
+    fns.forEach(fn => lines.push(`  - ${fn}`));
+  }
+
+  const ambiguities = getKnownAmbiguities();
+  if (ambiguities.length > 0) {
+    lines.push('\nKNOWN ISSUES / AMBIGUITIES:');
+    ambiguities.forEach(ep => {
+      lines.push(`  [${ep.severity}] ${ep.fn}: ${ep.notes}`);
+    });
+  }
+
+  return lines.join('\n');
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/**
+ * Structured error for access control violations.
+ * Carries a machine-readable code for test assertions.
+ */
+class AccessControlError extends Error {
+  /**
+   * @param {string} message
+   * @param {string} code     - Machine-readable code (KEEPER_NOT_WHITELISTED, etc.)
+   * @param {Object} [meta]   - Additional diagnostic context
+   */
+  constructor(message, code, meta = {}) {
+    super(message);
+    this.name = 'AccessControlError';
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // Constants
+  PrivilegeLevel,
+  CONTRACT_ENTRY_POINTS,
+
+  // Pre-flight guards
+  assertKeeperAuthorized,
+  assertCreatorAuthorized,
+  assertPortfolioCreatorAuthorized,
+  assertAdminTokenValid,
+
+  // Audit helpers
+  auditTaskWhitelist,
+  getEntryPointsByPrivilege,
+  getKnownAmbiguities,
+  generateAuditSummary,
+
+  // Error type
+  AccessControlError,
+};


### PR DESCRIPTION
## Summary

Resolves #250

- Introduces `keeper/src/accessControl.js` — an authoritative registry of every public contract entry point with its privilege level, auth mechanism, and any known ambiguities, plus pre-flight guard functions the keeper uses before submitting transactions
- Ships `keeper/__tests__/accessControl.test.js` with 60+ assertions covering every privilege tier, whitelist edge cases, admin API token gating, and all six documented contract findings
- Surfaces **2 critical/high contract bugs** and **4 lower-severity ambiguities** for maintainer action

## Permission Model (as audited)

| Privilege Level | Entry Points |
|---|---|
| `PUBLIC` | `get_task`, `monitor` |
| `CREATOR` | `register`, `pause_task`, `resume_task`, `cancel_task`, `withdraw_gas`, `add_dependency_with_rule`, `request_vrf_randomness`, `request_oracle_data`, `submit_zk_condition`, `submit_merkle_proof`, `delegate_permission`, `revoke_delegation` |
| `KEEPER` | `batch_execute`, `deposit_gas`, `settle_state_channel` |
| `WHITELISTED_KEEPER` | `execute` |
| `ADMIN` | `set_admin_address`, `set_vrf_oracle_address`, `update_tokenomics_config`, `init_yield_strategy` |
| `ADMIN_OR_DELEGATE` | `assign_role`, `revoke_role`, `grant_permission`, `revoke_permission`, `initialize_keeper_reputation` |
| `ORACLE_CONTRACT` | `fulfill_oracle_data`, `fulfill_vrf_request` |
| `CHANNEL_PARTICIPANT` | `update_state_channel` |
| `CONTRACT_SELF` | `verify_zk_condition`, `verify_merkle_proof` |

## Documented Findings

### [CRITICAL] `set_admin_address` — broken re-assignment guard
`lib.rs:3179` uses `env.current_contract_address()` as the "caller" to compare against the stored `AdminAddress`. Since `current_contract_address()` always returns the contract's own address (never an external caller's address), the guard always fails — **any external caller can overwrite the admin address after bootstrap**.

**Fix:** replace `env.current_contract_address()` with the transaction signer or add a `new_admin: Address` parameter with `new_admin.require_auth()`.

### [HIGH] `init_yield_strategy` — always-pass guard
`lib.rs:3265`: `let admin = env.current_contract_address(); if admin != env.current_contract_address()` — the condition is always `false`. **Any caller can register arbitrary yield strategies with arbitrary protocol addresses and harvest functions.**

**Fix:** use the same admin check pattern as `set_vrf_oracle_address` (lib.rs:2845).

### [MEDIUM] Bootstrap race — role/permission assignment before admin is set
`assign_role`, `revoke_role`, `grant_permission`, `revoke_permission` all gate on `if let Some(admin)`. Before `set_admin_address` is called, the block is never entered — **any actor can freely assign roles and permissions**.

### [LOW] Empty whitelist = open task (semantic ambiguity)
`execute()` at `lib.rs:2015`: `if !whitelist.is_empty() && !whitelist.contains(keeper)`. Creators who omit the whitelist unknowingly publish open tasks.

### [LOW] Role/delegation expiry not enforced
`expires_at` is stored in `RoleAssignment` (lib.rs:4007) but no auth-path code checks it. Expired roles remain valid indefinitely.

### [LOW] `fulfill_vrf_request` uses address comparison, not `require_auth`
No cryptographic proof that the caller controls the configured oracle address.

## Test plan

- [ ] `keeper/__tests__/accessControl.test.js` — 60+ unit assertions (no network required)
- [ ] Verify `assertKeeperAuthorized` rejects keepers absent from the task whitelist
- [ ] Verify `assertCreatorAuthorized` rejects non-creator callers for pause/cancel/withdraw
- [ ] Verify admin token middleware returns 401/403 on missing/wrong tokens
- [ ] Review the six documented findings with the contract team