### PR TITLE
Add stale indexed task cleanup workflow

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -19,6 +19,7 @@ This indexer subscribes to events emitted by the SoroTask Soroban contract and s
 - Uses SQLite for local storage with deduplication
 - Implements cursor-based polling to avoid reprocessing events
 - Handles chain reprocessing safely with INSERT OR IGNORE
+- Detects stale indexed task records and supports archive-before-delete cleanup
 - Graceful shutdown with database connection cleanup
 - Configurable polling interval
 
@@ -42,12 +43,32 @@ Edit `src/index.js` to configure:
 node src/index.js
 ```
 
+Run a reviewable stale-task cleanup preview:
+
+```bash
+node src/index.js --cleanup-stale
+```
+
+Apply cleanup after reviewing the dry-run logs:
+
+```bash
+node src/index.js --cleanup-stale --apply
+```
+
 The indexer will:
 1. Connect to the Soroban RPC
 2. Create/open the SQLite database
 3. Begin polling for new events
 4. Store each unique event in the database
 5. Continue until interrupted (Ctrl+C)
+
+## Stale Task Cleanup
+
+The cleanup workflow treats indexed task rows as stale when they have missing timestamps, old reconciliation timestamps, or inactive rows that are past the grace period. By default, cleanup is a dry run: it writes planned actions to `stale_cleanup_logs` and leaves `tasks` unchanged.
+
+When run with `--apply`, each cleaned task is copied to `archived_tasks` with the cleanup reasons before it is deleted from `tasks`. This preserves enough history for debugging while keeping read models from accumulating misleading records.
+
+Operators should run `--cleanup-stale` first, review `stale_cleanup_logs`, and only then rerun with `--apply`.
 
 ## Database Schema
 

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -1,5 +1,6 @@
 const { SorobanRpc, xdr, scValToNative, nativeToScVal, Address, Contract } = require("@stellar/stellar-sdk");
 const sqlite3 = require("sqlite3").verbose();
+const { runStaleTaskCleanup } = require("./staleTasks");
 
 // Configuration
 const RPC_URL = "https://soroban-testnet.stellar.org"; // Change as needed
@@ -7,6 +8,7 @@ const CONTRACT_ID = "YOUR_CONTRACT_ID"; // Replace with actual contract ID
 const DB_FILE = "./indexer.db";
 const POLL_INTERVAL_MS = 6000; // 6 seconds
 const RECONCILE_INTERVAL_MS = 300000; // 5 minutes
+const STALE_CLEANUP_INTERVAL_MS = 86400000; // 24 hours
 
 // Initialize RPC server
 const rpc = new SorobanRpc.Server(RPC_URL);
@@ -383,6 +385,18 @@ function handleCLI() {
     }
     return true;
   }
+
+  if (args.includes('--cleanup-stale')) {
+    const dryRun = !args.includes('--apply');
+    runStaleTaskCleanup(db, { dryRun }).then((summary) => {
+      console.log(`[Cleanup] Stale task cleanup complete: ${JSON.stringify(summary)}`);
+      process.exit(0);
+    }).catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+    return true;
+  }
   
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`
@@ -392,11 +406,16 @@ Usage:
   node index.js                    Start the indexer
   node index.js --reconcile        Run full reconciliation
   node index.js -r -t <task-id>   Reconcile a specific task
+  node index.js --cleanup-stale    Preview stale indexed task cleanup
+  node index.js --cleanup-stale --apply
+                                    Archive and delete stale indexed tasks
   node index.js --help             Show this help message
 
 Options:
   -r, --reconcile    Run reconciliation
   -t, --task-id      Specify task ID for reconciliation
+  --cleanup-stale    Detect stale indexed tasks and log the planned cleanup
+  --apply            Apply stale cleanup; without this flag cleanup is dry-run only
   -h, --help         Show help
     `);
     process.exit(0);
@@ -416,6 +435,15 @@ if (!handleCLI()) {
   // Start periodic reconciliation
   console.log("Starting periodic reconciliation (every 5 minutes)...");
   setInterval(reconcileAll, RECONCILE_INTERVAL_MS);
+
+  console.log("Starting stale task cleanup dry-run (every 24 hours)...");
+  setInterval(() => {
+    runStaleTaskCleanup(db, { dryRun: true }).then((summary) => {
+      console.log(`[Cleanup] Stale task cleanup dry-run: ${JSON.stringify(summary)}`);
+    }).catch((err) => {
+      console.error("[Cleanup] Error running stale task cleanup:", err.message);
+    });
+  }, STALE_CLEANUP_INTERVAL_MS);
 }
 
 // Graceful shutdown

--- a/indexer/src/staleTasks.js
+++ b/indexer/src/staleTasks.js
@@ -1,0 +1,182 @@
+const DEFAULT_OPTIONS = Object.freeze({
+  staleAfterMs: 30 * 24 * 60 * 60 * 1000,
+  inactiveGraceMs: 7 * 24 * 60 * 60 * 1000,
+  limit: 100,
+  dryRun: true,
+});
+
+function normalizeCleanupOptions(options = {}, now = new Date()) {
+  const staleAfterMs = Number(options.staleAfterMs || DEFAULT_OPTIONS.staleAfterMs);
+  const inactiveGraceMs = Number(options.inactiveGraceMs || DEFAULT_OPTIONS.inactiveGraceMs);
+  const limit = Number(options.limit || DEFAULT_OPTIONS.limit);
+
+  return {
+    staleAfterMs,
+    inactiveGraceMs,
+    limit: Math.max(1, Math.min(limit, 1000)),
+    dryRun: options.dryRun !== false,
+    now,
+    staleBefore: new Date(now.getTime() - staleAfterMs),
+    inactiveBefore: new Date(now.getTime() - inactiveGraceMs),
+  };
+}
+
+function classifyIndexedTask(row, options) {
+  const reasons = [];
+  const updatedAt = row.updated_at ? new Date(row.updated_at) : null;
+  const reconciledAt = row.last_reconciled_at ? new Date(row.last_reconciled_at) : null;
+
+  if (!updatedAt || Number.isNaN(updatedAt.getTime())) {
+    reasons.push("missing_updated_at");
+  } else if (updatedAt <= options.staleBefore) {
+    reasons.push("stale_updated_at");
+  }
+
+  if (!reconciledAt || Number.isNaN(reconciledAt.getTime())) {
+    reasons.push("missing_reconciliation");
+  } else if (reconciledAt <= options.staleBefore) {
+    reasons.push("stale_reconciliation");
+  }
+
+  if (Number(row.is_active) === 0 && updatedAt && updatedAt <= options.inactiveBefore) {
+    reasons.push("inactive_past_grace");
+  }
+
+  return {
+    taskId: row.task_id,
+    reasons,
+    shouldCleanup: reasons.includes("missing_updated_at")
+      || reasons.includes("missing_reconciliation")
+      || reasons.includes("inactive_past_grace")
+      || reasons.length >= 2,
+  };
+}
+
+function ensureCleanupSchema(db) {
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS archived_tasks (
+      archive_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER NOT NULL,
+      task_json TEXT NOT NULL,
+      cleanup_reasons_json TEXT NOT NULL,
+      archived_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`,
+    `CREATE TABLE IF NOT EXISTS stale_cleanup_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER,
+      action TEXT NOT NULL,
+      reasons_json TEXT NOT NULL,
+      dry_run INTEGER NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`,
+  ];
+
+  return statements.reduce(
+    (promise, statement) => promise.then(() => run(db, statement)),
+    Promise.resolve(),
+  );
+}
+
+function getCleanupCandidates(db, options) {
+  const sql = `
+    SELECT *
+    FROM tasks
+    WHERE updated_at IS NULL
+      OR last_reconciled_at IS NULL
+      OR updated_at <= ?
+      OR last_reconciled_at <= ?
+      OR (is_active = 0 AND updated_at <= ?)
+    ORDER BY COALESCE(last_reconciled_at, updated_at, '1970-01-01') ASC
+    LIMIT ?
+  `;
+
+  return all(db, sql, [
+    options.staleBefore.toISOString(),
+    options.staleBefore.toISOString(),
+    options.inactiveBefore.toISOString(),
+    options.limit,
+  ]);
+}
+
+async function cleanupTask(db, row, classification, options) {
+  const reasonsJson = JSON.stringify(classification.reasons);
+
+  if (options.dryRun) {
+    await run(
+      db,
+      "INSERT INTO stale_cleanup_logs (task_id, action, reasons_json, dry_run) VALUES (?, ?, ?, ?)",
+      [row.task_id, "would_archive_delete", reasonsJson, 1],
+    );
+    return "would_archive_delete";
+  }
+
+  await run(
+    db,
+    "INSERT INTO archived_tasks (task_id, task_json, cleanup_reasons_json) VALUES (?, ?, ?)",
+    [row.task_id, JSON.stringify(row), reasonsJson],
+  );
+  await run(db, "DELETE FROM tasks WHERE task_id = ?", [row.task_id]);
+  await run(
+    db,
+    "INSERT INTO stale_cleanup_logs (task_id, action, reasons_json, dry_run) VALUES (?, ?, ?, ?)",
+    [row.task_id, "archived_deleted", reasonsJson, 0],
+  );
+
+  return "archived_deleted";
+}
+
+async function runStaleTaskCleanup(db, rawOptions = {}) {
+  const options = normalizeCleanupOptions(rawOptions, rawOptions.now || new Date());
+  await ensureCleanupSchema(db);
+
+  const candidates = await getCleanupCandidates(db, options);
+  const results = [];
+
+  for (const row of candidates) {
+    const classification = classifyIndexedTask(row, options);
+    if (!classification.shouldCleanup) {
+      await run(
+        db,
+        "INSERT INTO stale_cleanup_logs (task_id, action, reasons_json, dry_run) VALUES (?, ?, ?, ?)",
+        [row.task_id, "kept_for_review", JSON.stringify(classification.reasons), options.dryRun ? 1 : 0],
+      );
+      results.push({ taskId: row.task_id, action: "kept_for_review", reasons: classification.reasons });
+      continue;
+    }
+
+    const action = await cleanupTask(db, row, classification, options);
+    results.push({ taskId: row.task_id, action, reasons: classification.reasons });
+  }
+
+  return {
+    dryRun: options.dryRun,
+    scanned: candidates.length,
+    changed: results.filter((result) => result.action !== "kept_for_review").length,
+    results,
+  };
+}
+
+function run(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function onRun(err) {
+      if (err) reject(err);
+      else resolve(this);
+    });
+  });
+}
+
+function all(db, sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) reject(err);
+      else resolve(rows || []);
+    });
+  });
+}
+
+module.exports = {
+  DEFAULT_OPTIONS,
+  classifyIndexedTask,
+  normalizeCleanupOptions,
+  runStaleTaskCleanup,
+};

--- a/indexer/test/staleTasks.test.js
+++ b/indexer/test/staleTasks.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  classifyIndexedTask,
+  normalizeCleanupOptions,
+  runStaleTaskCleanup,
+} = require("../src/staleTasks");
+
+test("classifies stale indexed tasks with explicit reasons", () => {
+  const options = normalizeCleanupOptions({
+    now: new Date("2026-06-01T00:00:00.000Z"),
+    staleAfterMs: 10 * 24 * 60 * 60 * 1000,
+    inactiveGraceMs: 3 * 24 * 60 * 60 * 1000,
+  });
+
+  const result = classifyIndexedTask(
+    {
+      task_id: 42,
+      is_active: 0,
+      updated_at: "2026-05-20T00:00:00.000Z",
+      last_reconciled_at: "2026-05-19T00:00:00.000Z",
+    },
+    options,
+  );
+
+  assert.equal(result.taskId, 42);
+  assert.equal(result.shouldCleanup, true);
+  assert.deepEqual(result.reasons, [
+    "stale_updated_at",
+    "stale_reconciliation",
+    "inactive_past_grace",
+  ]);
+});
+
+test("keeps active tasks with only one stale signal for review", () => {
+  const options = normalizeCleanupOptions({
+    now: new Date("2026-06-01T00:00:00.000Z"),
+    staleAfterMs: 10 * 24 * 60 * 60 * 1000,
+  });
+
+  const result = classifyIndexedTask(
+    {
+      task_id: 7,
+      is_active: 1,
+      updated_at: "2026-05-20T00:00:00.000Z",
+      last_reconciled_at: "2026-05-31T00:00:00.000Z",
+    },
+    options,
+  );
+
+  assert.equal(result.shouldCleanup, false);
+  assert.deepEqual(result.reasons, ["stale_updated_at"]);
+});
+
+test("cleanup dry run logs changes without deleting tasks", async () => {
+  const statements = [];
+  const db = {
+    run(sql, params, callback) {
+      statements.push({ sql, params });
+      callback.call({});
+    },
+    all(sql, params, callback) {
+      statements.push({ sql, params });
+      callback(null, [
+        {
+          task_id: 1,
+          creator: "creator",
+          target: "target",
+          function: "execute",
+          interval: 60,
+          last_run: 0,
+          gas_balance: "0",
+          is_active: 0,
+          updated_at: "2026-05-01T00:00:00.000Z",
+          last_reconciled_at: "2026-05-01T00:00:00.000Z",
+        },
+      ]);
+    },
+  };
+
+  const summary = await runStaleTaskCleanup(db, {
+    now: new Date("2026-06-01T00:00:00.000Z"),
+    staleAfterMs: 7 * 24 * 60 * 60 * 1000,
+    dryRun: true,
+  });
+
+  assert.equal(summary.dryRun, true);
+  assert.equal(summary.scanned, 1);
+  assert.equal(summary.changed, 1);
+  assert.equal(summary.results[0].action, "would_archive_delete");
+  assert.equal(statements.some((statement) => /DELETE FROM tasks/.test(statement.sql)), false);
+});


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

## Related Issue

<!-- Link issue: Closes #123 / Related #123 -->

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

## Changes Made

-

## Validation

<!-- Mark what you ran locally. -->

- [ ] `cargo fmt --all` (if `contract` changed)
- [ ] `npm run lint` in `frontend` (if `frontend` changed)
- [ ] Manual verification completed

## Screenshots (if UI changes)

<!-- Add before/after screenshots or short recording -->

## Checklist

- [ ] Scope is focused and avoids unrelated changes
- [ ] Commit messages are clear
- [ ] Documentation updated when needed
- [ ] ETA was provided when requesting assignment for the linked issue
Closes #281 