### PR TITLE
feat(frontend): dynamic task dependency graph visualization (#398)

### DIFF
--- a/frontend/app/graph-demo/page.tsx
+++ b/frontend/app/graph-demo/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import TaskDependencyGraph from "@/src/components/TaskDependencyGraph";
+import TaskDependencyManager, {
+  type Task as ManagerTask,
+} from "@/components/TaskDependencyManager";
+import { useTaskStore } from "@/src/store/taskStore";
+import type { Task, TaskDependency } from "@/src/types/task";
+
+const TASK_TITLES = [
+  "Provision infrastructure",
+  "Configure CI pipeline",
+  "Build auth service",
+  "Build task service",
+  "Write integration tests",
+  "Set up monitoring",
+  "Deploy to staging",
+  "Run load tests",
+  "Security review",
+  "Deploy to production",
+];
+
+function makeTask(index: number): Task {
+  const id = `t${index + 1}`;
+  return {
+    id,
+    title: TASK_TITLES[index] ?? `Task ${id}`,
+    description: null,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+const SEED_TASKS: Task[] = Array.from({ length: 10 }, (_, i) => makeTask(i));
+
+// A realistic DAG (12 edges, multiple converging/diverging paths) — not a chain.
+const SEED_DEPS: TaskDependency[] = [
+  { fromId: "t2", toId: "t1" },
+  { fromId: "t3", toId: "t1" },
+  { fromId: "t4", toId: "t1" },
+  { fromId: "t3", toId: "t2" },
+  { fromId: "t4", toId: "t2" },
+  { fromId: "t5", toId: "t3" },
+  { fromId: "t5", toId: "t4" },
+  { fromId: "t6", toId: "t2" },
+  { fromId: "t7", toId: "t5" },
+  { fromId: "t7", toId: "t6" },
+  { fromId: "t8", toId: "t7" },
+  { fromId: "t9", toId: "t7" },
+  { fromId: "t10", toId: "t8" },
+  { fromId: "t10", toId: "t9" },
+];
+
+function toManagerTask(task: Task, deps: TaskDependency[]): ManagerTask {
+  const numericId = Number(task.id.replace(/\D/g, "")) || 0;
+  const blockedBy = deps
+    .filter((d) => d.fromId === task.id)
+    .map((d) => Number(d.toId.replace(/\D/g, "")) || 0);
+  return {
+    id: numericId,
+    creator: "demo",
+    target: "demo",
+    function: "run",
+    interval: 60,
+    lastRun: 0,
+    gasBalance: 0,
+    isActive: true,
+    blockedBy,
+  };
+}
+
+export default function GraphDemoPage() {
+  const [seeded, setSeeded] = useState(false);
+  const tasks = useTaskStore((s) => s.tasks);
+  const taskIds = useTaskStore((s) => s.taskIds);
+  const deps = useTaskStore((s) => s.dependencies);
+
+  useEffect(() => {
+    const store = useTaskStore.getState();
+    store.setTasks(SEED_TASKS);
+    store.setDependencies(SEED_DEPS);
+    setSeeded(true);
+  }, []);
+
+  function handleAddRandomDependency() {
+    if (taskIds.length < 2) return;
+    const store = useTaskStore.getState();
+    // Try a handful of random pairs; addDependency rejects cycles/dupes/self.
+    for (let attempt = 0; attempt < 25; attempt++) {
+      const from = taskIds[Math.floor(Math.random() * taskIds.length)];
+      const to = taskIds[Math.floor(Math.random() * taskIds.length)];
+      if (from === to) continue;
+      const err = store.addDependency(from, to);
+      if (!err) return;
+    }
+  }
+
+  const managerTasks: ManagerTask[] = taskIds
+    .map((id) => tasks[id])
+    .filter(Boolean)
+    .map((t) => toManagerTask(t, deps));
+
+  const firstManagerTask = managerTasks[0];
+
+  return (
+    <main className="mx-auto flex max-w-5xl flex-col gap-6 p-6 text-neutral-100">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Task Dependency Graph</h1>
+        <p className="text-sm text-neutral-400">
+          A live, auto-laid-out view of how seeded tasks depend on each other.
+        </p>
+      </header>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleAddRandomDependency}
+          className="rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400"
+        >
+          Add Random Dependency
+        </button>
+        <span className="text-xs text-neutral-500">
+          {deps.length} dependencies · {taskIds.length} tasks
+        </span>
+      </div>
+
+      {seeded && <TaskDependencyGraph data-testid="demo-graph" />}
+
+      {firstManagerTask && (
+        <section className="rounded-xl border border-neutral-700/50 bg-neutral-900 p-4">
+          <TaskDependencyManager
+            task={firstManagerTask}
+            allTasks={managerTasks}
+            onAddDependency={async (taskId, dependsOnId) => {
+              useTaskStore
+                .getState()
+                .addDependency(`t${taskId}`, `t${dependsOnId}`);
+            }}
+            onRemoveDependency={async (taskId, dependsOnId) => {
+              useTaskStore
+                .getState()
+                .removeDependency(`t${taskId}`, `t${dependsOnId}`);
+            }}
+          />
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.24",
+        "@types/dagre": "^0.7.54",
+        "dagre": "^0.8.5",
         "next": "16.2.1",
         "next-auth": "^5.0.0-beta.31",
         "react": "19.2.4",
@@ -259,6 +261,28 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -4694,6 +4718,16 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/@reactflow/background": {
       "version": "11.3.14",
       "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
@@ -7336,6 +7370,19 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/dagre": {
+      "version": "0.7.54",
+      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
+      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "dev": true,
@@ -7527,6 +7574,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -8325,6 +8379,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-html": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.9.tgz",
+      "integrity": "sha512-ozbS3LuenHVxNRh/wdnN16QapUHzauqSomAl1jwwJRRsGwFwtj644lIhxfWu0Fy0acCij2+AEgHvjscq3dlVXg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
       }
     },
     "node_modules/ansi-html-community": {
@@ -9751,6 +9818,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -10117,6 +10191,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -10149,6 +10230,18 @@
       "dependencies": {
         "browserslist": "^4.28.1"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -10468,6 +10561,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "dev": true,
@@ -10597,6 +10703,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -10738,6 +10854,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "dev": true,
@@ -10768,6 +10894,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/detect-libc": {
@@ -11029,6 +11166,13 @@
         "objectorarray": "^1.0.5"
       }
     },
+    "node_modules/endent/node_modules/dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
@@ -11054,12 +11198,32 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-define-property": {
@@ -12341,6 +12505,22 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "dev": true,
@@ -12840,6 +13020,15 @@
       "version": "4.2.11",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -13493,6 +13682,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -13771,6 +13976,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -15596,6 +15814,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "dev": true,
@@ -15975,7 +16203,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -16864,6 +17091,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/objectorarray": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -16885,6 +17119,24 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16973,6 +17225,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -17824,6 +18083,41 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react-docgen/node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/react-dom": {
@@ -19275,6 +19569,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "dev": true,
@@ -19829,14 +20130,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -20356,6 +20649,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.24",
+    "@types/dagre": "^0.7.54",
+    "dagre": "^0.8.5",
     "next": "16.2.1",
     "next-auth": "^5.0.0-beta.31",
     "react": "19.2.4",

--- a/frontend/src/components/TaskDependencyGraph.tsx
+++ b/frontend/src/components/TaskDependencyGraph.tsx
@@ -1,24 +1,19 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import ReactFlow, {
   Background,
   Controls,
   MiniMap,
-  type Node,
-  type Edge,
   type NodeMouseHandler,
-  MarkerType,
   useNodesState,
   useEdgesState,
 } from "reactflow";
 import "reactflow/dist/style.css";
-import type { TaskDependency } from "@/src/types/task";
-import {
-  buildGraphData,
-  filterToNeighbourhood,
-} from "@/src/lib/graphUtils";
 import { useTaskStore } from "@/src/store/taskStore";
+import { useTaskGraph } from "@/src/hooks/useTaskGraph";
+import { nodeTypes } from "@/src/components/graph/TaskNode";
+import { GraphErrorBoundary } from "@/src/components/graph/GraphErrorBoundary";
 
 interface TaskDependencyGraphProps {
   /** Filter graph to only the neighbourhood of this task id */
@@ -27,92 +22,28 @@ interface TaskDependencyGraphProps {
   "data-testid"?: string;
 }
 
-/** Convert our GraphNode/GraphEdge into ReactFlow Node/Edge shapes */
-function toRFNodes(
-  nodes: ReturnType<typeof buildGraphData>["nodes"]
-): Node[] {
-  return nodes.map((n, i) => ({
-    id: n.id,
-    data: { label: n.label },
-    position: { x: (i % 5) * 200, y: Math.floor(i / 5) * 120 },
-    style: n.selected
-      ? {
-          background: "#2563eb",
-          color: "#fff",
-          border: "2px solid #1d4ed8",
-          borderRadius: 8,
-          fontWeight: 600,
-        }
-      : {
-          background: "#262626",
-          color: "#e5e5e5",
-          border: "1px solid #404040",
-          borderRadius: 8,
-        },
-  }));
-}
-
-function toRFEdges(
-  edges: ReturnType<typeof buildGraphData>["edges"]
-): Edge[] {
-  return edges.map((e) => ({
-    id: e.id,
-    source: e.source,
-    target: e.target,
-    markerEnd: { type: MarkerType.ArrowClosed, color: "#6b7280" },
-    style: { stroke: "#6b7280" },
-    animated: false,
-  }));
-}
-
-export default function TaskDependencyGraph({
+function TaskDependencyGraphInner({
   focusTaskId = null,
   onNodeClick,
   "data-testid": testId,
 }: TaskDependencyGraphProps) {
   const tasks = useTaskStore((s) => s.tasks);
-  const allDeps = useTaskStore((s) => s.dependencies);
   const selectedTaskId = useTaskStore((s) => s.selectedTaskId);
   const selectTask = useTaskStore((s) => s.selectTask);
 
   const [filter, setFilter] = useState("");
 
-  // Optionally narrow to neighbourhood of focusTaskId
-  const deps: TaskDependency[] = useMemo(
-    () =>
-      focusTaskId
-        ? filterToNeighbourhood(focusTaskId, allDeps)
-        : allDeps,
-    [focusTaskId, allDeps]
-  );
+  const {
+    nodes: graphNodes,
+    edges: graphEdges,
+    isEmpty,
+    totalNodeCount,
+    unfilteredNodeCount,
+    isLargeGraph,
+  } = useTaskGraph({ focusTaskId, filterText: filter });
 
-  const { nodes: gNodes, edges: gEdges } = useMemo(
-    () => buildGraphData(tasks, deps, selectedTaskId),
-    [tasks, deps, selectedTaskId]
-  );
-
-  // Apply text filter
-  const filteredNodes = useMemo(() => {
-    if (!filter.trim()) return gNodes;
-    const q = filter.toLowerCase();
-    return gNodes.filter((n) => n.label.toLowerCase().includes(q));
-  }, [gNodes, filter]);
-
-  const filteredNodeIds = useMemo(
-    () => new Set(filteredNodes.map((n) => n.id)),
-    [filteredNodes]
-  );
-
-  const filteredEdges = useMemo(
-    () =>
-      gEdges.filter(
-        (e) => filteredNodeIds.has(e.source) && filteredNodeIds.has(e.target)
-      ),
-    [gEdges, filteredNodeIds]
-  );
-
-  const [nodes, , onNodesChange] = useNodesState(toRFNodes(filteredNodes));
-  const [edges, , onEdgesChange] = useEdgesState(toRFEdges(filteredEdges));
+  const [nodes, , onNodesChange] = useNodesState(graphNodes);
+  const [edges, , onEdgesChange] = useEdgesState(graphEdges);
 
   const handleNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
@@ -122,7 +53,7 @@ export default function TaskDependencyGraph({
     [selectTask, onNodeClick]
   );
 
-  if (Object.keys(tasks).length === 0 || gNodes.length === 0) {
+  if (Object.keys(tasks).length === 0 || isEmpty) {
     return (
       <div
         data-testid={testId ? `${testId}-empty` : "graph-empty"}
@@ -134,11 +65,10 @@ export default function TaskDependencyGraph({
     );
   }
 
+  const selectedTask = selectedTaskId ? tasks[selectedTaskId] : null;
+
   return (
-    <div
-      data-testid={testId}
-      className="flex flex-col gap-3"
-    >
+    <div data-testid={testId} className="flex flex-col gap-3">
       {/* Filter bar */}
       <div className="flex items-center gap-3">
         <input
@@ -151,9 +81,25 @@ export default function TaskDependencyGraph({
         />
         {filter && (
           <span className="text-xs text-neutral-500">
-            {filteredNodes.length} / {gNodes.length} nodes
+            {totalNodeCount} / {unfilteredNodeCount} nodes
           </span>
         )}
+      </div>
+
+      {/* Large-graph warning banner */}
+      {isLargeGraph && (
+        <div
+          data-testid="graph-large-warning"
+          role="alert"
+          className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-4 py-2 text-sm text-yellow-300"
+        >
+          Large graph — showing top 200 nodes. Use the filter to narrow down.
+        </div>
+      )}
+
+      {/* Live region announcing selection for screen readers */}
+      <div aria-live="polite" className="sr-only" data-testid="graph-live-region">
+        {selectedTask ? `Selected Task: ${selectedTask.title}` : ""}
       </div>
 
       {/* Graph canvas */}
@@ -165,6 +111,7 @@ export default function TaskDependencyGraph({
         <ReactFlow
           nodes={nodes}
           edges={edges}
+          nodeTypes={nodeTypes}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onNodeClick={handleNodeClick}
@@ -178,23 +125,26 @@ export default function TaskDependencyGraph({
           <Controls />
           <MiniMap
             nodeColor={(n) =>
-              (n.style?.background as string) ?? "#262626"
+              n.selected ? "#2563eb" : "#262626"
             }
             maskColor="rgba(0,0,0,0.6)"
           />
         </ReactFlow>
       </div>
 
+      {/* Keyboard / interaction hint */}
+      <p className="text-xs text-neutral-500" data-testid="graph-hint">
+        Tip: Click a node to select it. Use scroll to zoom.
+      </p>
+
       {/* Selected task detail strip */}
-      {selectedTaskId && tasks[selectedTaskId] && (
+      {selectedTask && (
         <div
           data-testid="graph-selected-task"
           className="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm text-blue-300"
         >
           Selected:{" "}
-          <span className="font-semibold">
-            {tasks[selectedTaskId].title}
-          </span>
+          <span className="font-semibold">{selectedTask.title}</span>
           <button
             type="button"
             onClick={() => selectTask(null)}
@@ -206,5 +156,13 @@ export default function TaskDependencyGraph({
         </div>
       )}
     </div>
+  );
+}
+
+export default function TaskDependencyGraph(props: TaskDependencyGraphProps) {
+  return (
+    <GraphErrorBoundary>
+      <TaskDependencyGraphInner {...props} />
+    </GraphErrorBoundary>
   );
 }

--- a/frontend/src/components/__tests__/TaskDependencyGraph.test.tsx
+++ b/frontend/src/components/__tests__/TaskDependencyGraph.test.tsx
@@ -255,3 +255,56 @@ describe("focusTaskId prop", () => {
     expect(screen.getByTestId("node-d")).toBeInTheDocument();
   });
 });
+
+// ── large graph banner ────────────────────────────────────────────────────────
+
+describe("large graph banner", () => {
+  it("does not show the large-graph warning for small graphs", () => {
+    seedStore([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+    render(<TaskDependencyGraph />);
+    expect(screen.queryByTestId("graph-large-warning")).not.toBeInTheDocument();
+  });
+
+  it("shows the large-graph warning above 200 nodes", () => {
+    const tasks: Task[] = [];
+    const deps: { fromId: string; toId: string }[] = [];
+    for (let i = 0; i < 250; i++) tasks.push(makeTask(`n${i}`));
+    for (let i = 0; i < 249; i++) {
+      deps.push({ fromId: `n${i}`, toId: `n${i + 1}` });
+    }
+    seedStore(tasks, deps);
+    render(<TaskDependencyGraph />);
+    expect(screen.getByTestId("graph-large-warning")).toBeInTheDocument();
+    expect(
+      screen.getByText(/showing top 200 nodes/i)
+    ).toBeInTheDocument();
+  });
+});
+
+// ── accessibility & hints ─────────────────────────────────────────────────────
+
+describe("accessibility and hints", () => {
+  beforeEach(() => {
+    seedStore([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+  });
+
+  it("renders the keyboard hint text", () => {
+    render(<TaskDependencyGraph />);
+    expect(screen.getByTestId("graph-hint")).toHaveTextContent(
+      /click a node to select it/i
+    );
+  });
+
+  it("announces the selected task in the live region", () => {
+    render(<TaskDependencyGraph />);
+    fireEvent.click(screen.getByTestId("node-a"));
+    expect(screen.getByTestId("graph-live-region")).toHaveTextContent(
+      "Selected Task: Task a"
+    );
+  });
+
+  it("has an empty live region when nothing is selected", () => {
+    render(<TaskDependencyGraph />);
+    expect(screen.getByTestId("graph-live-region")).toHaveTextContent("");
+  });
+});

--- a/frontend/src/components/graph/GraphErrorBoundary.tsx
+++ b/frontend/src/components/graph/GraphErrorBoundary.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+interface GraphErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface GraphErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class GraphErrorBoundary extends Component<
+  GraphErrorBoundaryProps,
+  GraphErrorBoundaryState
+> {
+  constructor(props: GraphErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+    this.handleRetry = this.handleRetry.bind(this);
+  }
+
+  static getDerivedStateFromError(): GraphErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  handleRetry() {
+    this.setState({ hasError: false });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          data-testid="graph-error-boundary"
+          className="flex flex-col items-center justify-center gap-3 rounded-xl border border-neutral-700/50 bg-neutral-900 py-16 text-center text-neutral-300"
+        >
+          <p>Graph failed to load. Try refreshing the page.</p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="rounded-lg bg-blue-500 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default GraphErrorBoundary;

--- a/frontend/src/components/graph/TaskNode.tsx
+++ b/frontend/src/components/graph/TaskNode.tsx
@@ -1,0 +1,63 @@
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "reactflow";
+import { truncateLabel } from "@/src/lib/graphUtils";
+
+export type TaskNodeStatus = "selected" | "has_run" | "pending";
+
+export interface TaskNodeData {
+  label: string;
+  status: TaskNodeStatus;
+}
+
+export const TASK_NODE_WIDTH = 180;
+
+const STATUS_DOT: Record<TaskNodeStatus, string> = {
+  selected: "bg-blue-500",
+  has_run: "bg-green-500",
+  pending: "bg-yellow-500",
+};
+
+const STATUS_LABEL: Record<TaskNodeStatus, string> = {
+  selected: "Selected",
+  has_run: "Has run",
+  pending: "Pending",
+};
+
+function TaskNodeComponent({ id, data, selected }: NodeProps<TaskNodeData>) {
+  const status: TaskNodeStatus = selected ? "selected" : data.status;
+
+  return (
+    <div
+      data-testid={`task-node-${id}`}
+      style={{ width: TASK_NODE_WIDTH }}
+      className={`rounded-lg border px-3 py-2 shadow-sm transition-colors ${
+        status === "selected"
+          ? "border-blue-500 bg-blue-600 text-white"
+          : "border-neutral-700 bg-neutral-900 text-neutral-100"
+      }`}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-neutral-500" />
+      <div className="flex items-center gap-2">
+        <span
+          data-testid={`task-node-status-${id}`}
+          aria-label={STATUS_LABEL[status]}
+          title={STATUS_LABEL[status]}
+          className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_DOT[status]}`}
+        />
+        <span className="truncate text-sm font-medium" title={data.label}>
+          {truncateLabel(data.label, 24)}
+        </span>
+      </div>
+      <div className="mt-1 font-mono text-[10px] text-neutral-400">{id}</div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-neutral-500"
+      />
+    </div>
+  );
+}
+
+export const TaskNode = memo(TaskNodeComponent);
+
+export const nodeTypes = { taskNode: TaskNode };

--- a/frontend/src/components/graph/__tests__/GraphErrorBoundary.test.tsx
+++ b/frontend/src/components/graph/__tests__/GraphErrorBoundary.test.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GraphErrorBoundary } from "../GraphErrorBoundary";
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
+
+function Ok() {
+  return <div data-testid="ok-child">all good</div>;
+}
+
+/** A child that throws on first render but can be told to stop throwing. */
+function Recoverable({ throwOnRender }: { throwOnRender: boolean }) {
+  if (throwOnRender) throw new Error("kaboom");
+  return <div data-testid="recovered-child">recovered</div>;
+}
+
+let errorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("GraphErrorBoundary", () => {
+  it("renders children when there is no error", () => {
+    render(
+      <GraphErrorBoundary>
+        <Ok />
+      </GraphErrorBoundary>
+    );
+    expect(screen.getByTestId("ok-child")).toBeInTheDocument();
+  });
+
+  it("renders the fallback when a child throws", () => {
+    render(
+      <GraphErrorBoundary>
+        <Boom />
+      </GraphErrorBoundary>
+    );
+    expect(
+      screen.getByText(/graph failed to load\. try refreshing the page\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("exposes the fallback with role=alert", () => {
+    render(
+      <GraphErrorBoundary>
+        <Boom />
+      </GraphErrorBoundary>
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders a retry button in the fallback", () => {
+    render(
+      <GraphErrorBoundary>
+        <Boom />
+      </GraphErrorBoundary>
+    );
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("resets error state and re-renders children when retry is clicked", () => {
+    function Wrapper() {
+      const [crash, setCrash] = useState(true);
+      return (
+        <div>
+          <button onClick={() => setCrash(false)}>fix</button>
+          <GraphErrorBoundary>
+            <Recoverable throwOnRender={crash} />
+          </GraphErrorBoundary>
+        </div>
+      );
+    }
+
+    render(<Wrapper />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    // Fix the underlying cause, then retry to clear the boundary.
+    fireEvent.click(screen.getByText("fix"));
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(screen.getByTestId("recovered-child")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/graph/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/graph/__tests__/TaskNode.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { TaskNode, nodeTypes, type TaskNodeData } from "../TaskNode";
+import type { NodeProps } from "reactflow";
+
+jest.mock("reactflow", () => ({
+  __esModule: true,
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+}));
+
+function renderNode(
+  id: string,
+  data: TaskNodeData,
+  selected = false
+) {
+  const props = {
+    id,
+    data,
+    selected,
+    type: "taskNode",
+    dragging: false,
+    isConnectable: true,
+    xPos: 0,
+    yPos: 0,
+    zIndex: 0,
+  } as unknown as NodeProps<TaskNodeData>;
+  return render(<TaskNode {...props} />);
+}
+
+describe("TaskNode", () => {
+  it("renders the task title", () => {
+    renderNode("a", { label: "Build the thing", status: "pending" });
+    expect(screen.getByText("Build the thing")).toBeInTheDocument();
+  });
+
+  it("truncates long titles to 24 chars with an ellipsis", () => {
+    const long = "This title is definitely longer than twenty four chars";
+    renderNode("a", { label: long, status: "pending" });
+    const text = screen.getByText(/…$/);
+    expect(text.textContent!.length).toBe(24);
+  });
+
+  it("renders the node id in monospace", () => {
+    renderNode("node-xyz", { label: "T", status: "pending" });
+    expect(screen.getByText("node-xyz")).toBeInTheDocument();
+  });
+
+  it("shows a yellow dot for pending status", () => {
+    renderNode("a", { label: "T", status: "pending" });
+    expect(screen.getByTestId("task-node-status-a")).toHaveClass("bg-yellow-500");
+  });
+
+  it("shows a green dot for has_run status", () => {
+    renderNode("a", { label: "T", status: "has_run" });
+    expect(screen.getByTestId("task-node-status-a")).toHaveClass("bg-green-500");
+  });
+
+  it("shows a blue dot when the node is selected (overrides data status)", () => {
+    renderNode("a", { label: "T", status: "has_run" }, true);
+    expect(screen.getByTestId("task-node-status-a")).toHaveClass("bg-blue-500");
+  });
+
+  it("applies selected styling when selected", () => {
+    renderNode("a", { label: "T", status: "pending" }, true);
+    expect(screen.getByTestId("task-node-a")).toHaveClass("bg-blue-600");
+  });
+
+  it("applies default styling when not selected", () => {
+    renderNode("a", { label: "T", status: "pending" });
+    expect(screen.getByTestId("task-node-a")).toHaveClass("bg-neutral-900");
+  });
+
+  it("gives the status dot an accessible label", () => {
+    renderNode("a", { label: "T", status: "has_run" });
+    expect(screen.getByLabelText("Has run")).toBeInTheDocument();
+  });
+
+  it("exports a nodeTypes map keyed by taskNode", () => {
+    expect(nodeTypes.taskNode).toBe(TaskNode);
+  });
+});

--- a/frontend/src/hooks/__tests__/useTaskGraph.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskGraph.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, act } from "@testing-library/react";
+import { useTaskGraph } from "../useTaskGraph";
+import { useTaskStore } from "@/src/store/taskStore";
+import type { Task } from "@/src/types/task";
+
+// Mock the dagre-backed layout so the hook stays fast and deterministic.
+jest.mock("@/src/lib/graphLayout", () => ({
+  __esModule: true,
+  DEFAULT_NODE_HEIGHT: 60,
+  layoutGraph: (
+    nodes: { id: string; width: number; height: number }[]
+  ) =>
+    nodes.map((n, i) => ({ ...n, x: i * 100, y: i * 50 })),
+}));
+
+// reactflow only needs MarkerType in this hook.
+jest.mock("reactflow", () => ({
+  __esModule: true,
+  MarkerType: { ArrowClosed: "arrowclosed" },
+}));
+
+function makeTask(id: string, title = `Task ${id}`): Task {
+  return {
+    id,
+    title,
+    description: null,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+function seed(tasks: Task[], deps: { fromId: string; toId: string }[] = []) {
+  act(() => {
+    useTaskStore.getState().setTasks(tasks);
+    useTaskStore.getState().setDependencies(deps);
+  });
+}
+
+beforeEach(() => {
+  act(() => useTaskStore.getState().reset());
+});
+
+describe("useTaskGraph", () => {
+  it("returns isEmpty=true with no tasks", () => {
+    const { result } = renderHook(() => useTaskGraph());
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.nodes).toHaveLength(0);
+    expect(result.current.edges).toHaveLength(0);
+  });
+
+  it("builds RF nodes and edges from the store", () => {
+    seed([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+    const { result } = renderHook(() => useTaskGraph());
+    expect(result.current.isEmpty).toBe(false);
+    expect(result.current.nodes.map((n) => n.id).sort()).toEqual(["a", "b"]);
+    expect(result.current.edges).toHaveLength(1);
+    expect(result.current.edges[0]).toMatchObject({ source: "a", target: "b" });
+  });
+
+  it("assigns the taskNode type and laid-out positions", () => {
+    seed([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+    const { result } = renderHook(() => useTaskGraph());
+    const node = result.current.nodes[0];
+    expect(node.type).toBe("taskNode");
+    expect(node.position).toEqual({ x: 0, y: 0 });
+  });
+
+  it("marks the selected node with selected status", () => {
+    seed([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+    act(() => useTaskStore.getState().selectTask("a"));
+    const { result } = renderHook(() => useTaskGraph());
+    const a = result.current.nodes.find((n) => n.id === "a")!;
+    expect(a.data.status).toBe("selected");
+    expect(a.selected).toBe(true);
+  });
+
+  it("applies the text filter case-insensitively", () => {
+    seed(
+      [makeTask("a", "Alpha"), makeTask("b", "Beta")],
+      [{ fromId: "a", toId: "b" }]
+    );
+    const { result } = renderHook(() => useTaskGraph({ filterText: "ALPHA" }));
+    expect(result.current.nodes.map((n) => n.id)).toEqual(["a"]);
+    expect(result.current.totalNodeCount).toBe(1);
+    expect(result.current.unfilteredNodeCount).toBe(2);
+  });
+
+  it("drops edges whose endpoints are filtered out", () => {
+    seed(
+      [makeTask("a", "Alpha"), makeTask("b", "Beta")],
+      [{ fromId: "a", toId: "b" }]
+    );
+    const { result } = renderHook(() => useTaskGraph({ filterText: "Alpha" }));
+    expect(result.current.edges).toHaveLength(0);
+  });
+
+  it("limits to the neighbourhood when focusTaskId is set", () => {
+    seed(
+      [makeTask("a"), makeTask("b"), makeTask("c"), makeTask("d")],
+      [
+        { fromId: "a", toId: "b" },
+        { fromId: "b", toId: "c" },
+        { fromId: "d", toId: "c" },
+      ]
+    );
+    const { result } = renderHook(() => useTaskGraph({ focusTaskId: "a" }));
+    const ids = result.current.nodes.map((n) => n.id).sort();
+    expect(ids).toEqual(["a", "b"]);
+  });
+
+  it("flags and slices large graphs above the threshold", () => {
+    const tasks: Task[] = [];
+    const deps: { fromId: string; toId: string }[] = [];
+    for (let i = 0; i < 250; i++) tasks.push(makeTask(`n${i}`));
+    // Chain them so every node is referenced.
+    for (let i = 0; i < 249; i++) {
+      deps.push({ fromId: `n${i}`, toId: `n${i + 1}` });
+    }
+    seed(tasks, deps);
+    const { result } = renderHook(() => useTaskGraph());
+    expect(result.current.isLargeGraph).toBe(true);
+    expect(result.current.totalNodeCount).toBe(250);
+    expect(result.current.nodes).toHaveLength(200);
+  });
+
+  it("does not flag graphs at or below the threshold", () => {
+    seed([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+    const { result } = renderHook(() => useTaskGraph());
+    expect(result.current.isLargeGraph).toBe(false);
+  });
+
+  it("returns stable node references across re-renders with unchanged inputs", () => {
+    seed([makeTask("a"), makeTask("b")], [{ fromId: "a", toId: "b" }]);
+    const { result, rerender } = renderHook(() => useTaskGraph());
+    const first = result.current.nodes;
+    rerender();
+    expect(result.current.nodes).toBe(first);
+  });
+});

--- a/frontend/src/hooks/useTaskGraph.ts
+++ b/frontend/src/hooks/useTaskGraph.ts
@@ -1,0 +1,133 @@
+import { useMemo } from "react";
+import { MarkerType, type Node, type Edge } from "reactflow";
+import { useTaskStore } from "@/src/store/taskStore";
+import {
+  buildGraphData,
+  filterToNeighbourhood,
+  shouldVirtualizeGraph,
+  GRAPH_VIRTUALIZE_THRESHOLD,
+} from "@/src/lib/graphUtils";
+import {
+  layoutGraph,
+  DEFAULT_NODE_HEIGHT,
+} from "@/src/lib/graphLayout";
+import { TASK_NODE_WIDTH, type TaskNodeData } from "@/src/components/graph/TaskNode";
+
+export interface UseTaskGraphOptions {
+  focusTaskId?: string | null;
+  filterText?: string;
+}
+
+export interface UseTaskGraphResult {
+  nodes: Node<TaskNodeData>[];
+  edges: Edge[];
+  isEmpty: boolean;
+  /** Number of nodes after the text filter is applied. */
+  totalNodeCount: number;
+  /** Number of nodes before the text filter is applied. */
+  unfilteredNodeCount: number;
+  isLargeGraph: boolean;
+}
+
+/**
+ * Builds ReactFlow-ready nodes and edges from the task store, applying an
+ * optional focus-neighbourhood filter, a text filter, large-graph slicing, and
+ * a dagre layout. Heavily memoized so ReactFlow doesn't re-render on every
+ * keystroke when inputs are unchanged.
+ */
+export function useTaskGraph(
+  options: UseTaskGraphOptions = {}
+): UseTaskGraphResult {
+  const { focusTaskId = null, filterText = "" } = options;
+
+  const tasks = useTaskStore((s) => s.tasks);
+  const allDeps = useTaskStore((s) => s.dependencies);
+  const selectedTaskId = useTaskStore((s) => s.selectedTaskId);
+
+  const deps = useMemo(
+    () => (focusTaskId ? filterToNeighbourhood(focusTaskId, allDeps) : allDeps),
+    [focusTaskId, allDeps]
+  );
+
+  const { nodes: gNodes, edges: gEdges } = useMemo(
+    () => buildGraphData(tasks, deps, selectedTaskId),
+    [tasks, deps, selectedTaskId]
+  );
+
+  const filteredNodes = useMemo(() => {
+    const q = filterText.trim().toLowerCase();
+    if (!q) return gNodes;
+    return gNodes.filter((n) => n.label.toLowerCase().includes(q));
+  }, [gNodes, filterText]);
+
+  const totalNodeCount = filteredNodes.length;
+  const isLargeGraph = shouldVirtualizeGraph(totalNodeCount);
+
+  const visibleNodes = useMemo(
+    () =>
+      isLargeGraph
+        ? filteredNodes.slice(0, GRAPH_VIRTUALIZE_THRESHOLD)
+        : filteredNodes,
+    [filteredNodes, isLargeGraph]
+  );
+
+  const visibleNodeIds = useMemo(
+    () => new Set(visibleNodes.map((n) => n.id)),
+    [visibleNodes]
+  );
+
+  const visibleEdges = useMemo(
+    () =>
+      gEdges.filter(
+        (e) => visibleNodeIds.has(e.source) && visibleNodeIds.has(e.target)
+      ),
+    [gEdges, visibleNodeIds]
+  );
+
+  const nodes = useMemo<Node<TaskNodeData>[]>(() => {
+    const positioned = layoutGraph(
+      visibleNodes.map((n) => ({
+        id: n.id,
+        width: TASK_NODE_WIDTH,
+        height: DEFAULT_NODE_HEIGHT,
+      })),
+      visibleEdges.map((e) => ({ source: e.source, target: e.target }))
+    );
+    const posById = new Map(positioned.map((p) => [p.id, p]));
+
+    return visibleNodes.map((n) => {
+      const pos = posById.get(n.id);
+      return {
+        id: n.id,
+        type: "taskNode",
+        position: { x: pos?.x ?? 0, y: pos?.y ?? 0 },
+        selected: n.selected,
+        data: {
+          label: n.label,
+          status: n.selected ? "selected" : "pending",
+        },
+      };
+    });
+  }, [visibleNodes, visibleEdges]);
+
+  const edges = useMemo<Edge[]>(
+    () =>
+      visibleEdges.map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        markerEnd: { type: MarkerType.ArrowClosed, color: "#6b7280" },
+        style: { stroke: "#6b7280" },
+      })),
+    [visibleEdges]
+  );
+
+  return {
+    nodes,
+    edges,
+    isEmpty: gNodes.length === 0,
+    totalNodeCount,
+    unfilteredNodeCount: gNodes.length,
+    isLargeGraph,
+  };
+}

--- a/frontend/src/lib/__tests__/graphLayout.test.ts
+++ b/frontend/src/lib/__tests__/graphLayout.test.ts
@@ -1,0 +1,139 @@
+import {
+  layoutGraph,
+  DEFAULT_NODE_WIDTH,
+  DEFAULT_NODE_HEIGHT,
+  type LayoutInputNode,
+  type LayoutInputEdge,
+} from "../graphLayout";
+
+// Mock dagre so layout stays fast and deterministic. The mock records what was
+// configured and returns predictable centre coordinates per node.
+const mockSetGraph = jest.fn();
+const mockSetNode = jest.fn();
+const mockSetEdge = jest.fn();
+const mockSetDefaultEdgeLabel = jest.fn();
+const mockLayout = jest.fn();
+const nodeStore = new Map<string, { width: number; height: number }>();
+
+jest.mock("dagre", () => {
+  return {
+    __esModule: true,
+    default: {
+      graphlib: {
+        Graph: jest.fn().mockImplementation(() => ({
+          setDefaultEdgeLabel: (...args: unknown[]) => mockSetDefaultEdgeLabel(...args),
+          setGraph: (...args: unknown[]) => mockSetGraph(...args),
+          setNode: (id: string, dims: { width: number; height: number }) => {
+            nodeStore.set(id, dims);
+            mockSetNode(id, dims);
+          },
+          setEdge: (...args: unknown[]) => mockSetEdge(...args),
+          node: (id: string) => {
+            const dims = nodeStore.get(id);
+            if (!dims) return undefined;
+            // Deterministic centre: x = index-free width offset, y from height.
+            return { x: dims.width, y: dims.height };
+          },
+        })),
+      },
+      layout: (...args: unknown[]) => mockLayout(...args),
+    },
+  };
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  nodeStore.clear();
+});
+
+function node(id: string): LayoutInputNode {
+  return { id, width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT };
+}
+
+describe("layoutGraph", () => {
+  it("returns a positioned node for every input node", () => {
+    const nodes = [node("a"), node("b")];
+    const result = layoutGraph(nodes, []);
+    expect(result.map((n) => n.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("converts dagre centre coordinates to top-left positions", () => {
+    const result = layoutGraph([node("a")], []);
+    // mock centre = (width, height); top-left = centre - half dims
+    expect(result[0].x).toBe(DEFAULT_NODE_WIDTH - DEFAULT_NODE_WIDTH / 2);
+    expect(result[0].y).toBe(DEFAULT_NODE_HEIGHT - DEFAULT_NODE_HEIGHT / 2);
+  });
+
+  it("applies default layout options (TB, nodesep 80, ranksep 100)", () => {
+    layoutGraph([node("a")], []);
+    expect(mockSetGraph).toHaveBeenCalledWith({
+      rankdir: "TB",
+      nodesep: 80,
+      ranksep: 100,
+    });
+  });
+
+  it("allows overriding layout options", () => {
+    layoutGraph([node("a")], [], { rankdir: "LR", nodesep: 10, ranksep: 20 });
+    expect(mockSetGraph).toHaveBeenCalledWith({
+      rankdir: "LR",
+      nodesep: 10,
+      ranksep: 20,
+    });
+  });
+
+  it("registers each node with dagre", () => {
+    layoutGraph([node("a"), node("b")], []);
+    expect(mockSetNode).toHaveBeenCalledTimes(2);
+    expect(mockSetNode).toHaveBeenCalledWith("a", {
+      width: DEFAULT_NODE_WIDTH,
+      height: DEFAULT_NODE_HEIGHT,
+    });
+  });
+
+  it("registers edges that connect known nodes", () => {
+    const edges: LayoutInputEdge[] = [{ source: "a", target: "b" }];
+    layoutGraph([node("a"), node("b")], edges);
+    expect(mockSetEdge).toHaveBeenCalledWith("a", "b");
+  });
+
+  it("skips edges referencing unknown nodes", () => {
+    const edges: LayoutInputEdge[] = [
+      { source: "a", target: "ghost" },
+      { source: "ghost", target: "b" },
+    ];
+    layoutGraph([node("a"), node("b")], edges);
+    expect(mockSetEdge).not.toHaveBeenCalled();
+  });
+
+  it("calls dagre.layout exactly once", () => {
+    layoutGraph([node("a")], []);
+    expect(mockLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns origin coordinates when dagre has no position for a node", () => {
+    // Override node() to return undefined by registering nothing in the store.
+    const result = layoutGraph(
+      [{ id: "x", width: 100, height: 40 }],
+      []
+    );
+    // store has x because setNode populates it; force missing by clearing.
+    nodeStore.clear();
+    const fallback = layoutGraph(
+      [{ id: "y", width: 100, height: 40 }],
+      []
+    );
+    expect(result[0]).toBeDefined();
+    expect(fallback[0].id).toBe("y");
+  });
+
+  it("handles an empty graph", () => {
+    expect(layoutGraph([], [])).toEqual([]);
+  });
+
+  it("preserves node width and height in the output", () => {
+    const result = layoutGraph([{ id: "a", width: 200, height: 50 }], []);
+    expect(result[0].width).toBe(200);
+    expect(result[0].height).toBe(50);
+  });
+});

--- a/frontend/src/lib/__tests__/graphUtils.test.ts
+++ b/frontend/src/lib/__tests__/graphUtils.test.ts
@@ -5,6 +5,9 @@ import {
   validateDependency,
   wouldCreateCycle,
   filterToNeighbourhood,
+  shouldVirtualizeGraph,
+  truncateLabel,
+  GRAPH_VIRTUALIZE_THRESHOLD,
 } from "../graphUtils";
 import type { Task, TaskDependency } from "@/src/types/task";
 
@@ -250,5 +253,58 @@ describe("filterToNeighbourhood", () => {
 
   it("returns empty array for empty deps", () => {
     expect(filterToNeighbourhood("a", [])).toHaveLength(0);
+  });
+});
+
+// ── shouldVirtualizeGraph ─────────────────────────────────────────────────────
+
+describe("shouldVirtualizeGraph", () => {
+  it("returns false at or below the threshold", () => {
+    expect(shouldVirtualizeGraph(0)).toBe(false);
+    expect(shouldVirtualizeGraph(GRAPH_VIRTUALIZE_THRESHOLD)).toBe(false);
+  });
+
+  it("returns true above the threshold", () => {
+    expect(shouldVirtualizeGraph(GRAPH_VIRTUALIZE_THRESHOLD + 1)).toBe(true);
+    expect(shouldVirtualizeGraph(1000)).toBe(true);
+  });
+
+  it("uses 200 as the threshold", () => {
+    expect(GRAPH_VIRTUALIZE_THRESHOLD).toBe(200);
+    expect(shouldVirtualizeGraph(200)).toBe(false);
+    expect(shouldVirtualizeGraph(201)).toBe(true);
+  });
+});
+
+// ── truncateLabel ─────────────────────────────────────────────────────────────
+
+describe("truncateLabel", () => {
+  it("leaves short labels unchanged", () => {
+    expect(truncateLabel("short")).toBe("short");
+  });
+
+  it("leaves labels exactly at maxLen unchanged", () => {
+    const label = "a".repeat(24);
+    expect(truncateLabel(label)).toBe(label);
+  });
+
+  it("truncates long labels with an ellipsis to maxLen total chars", () => {
+    const label = "a".repeat(40);
+    const result = truncateLabel(label);
+    expect(result.length).toBe(24);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("respects a custom maxLen", () => {
+    expect(truncateLabel("abcdef", 4)).toBe("abc…");
+  });
+
+  it("returns an empty string for a non-positive maxLen", () => {
+    expect(truncateLabel("abc", 0)).toBe("");
+    expect(truncateLabel("abc", -5)).toBe("");
+  });
+
+  it("returns just an ellipsis when maxLen is 1", () => {
+    expect(truncateLabel("abc", 1)).toBe("…");
   });
 });

--- a/frontend/src/lib/graphLayout.ts
+++ b/frontend/src/lib/graphLayout.ts
@@ -1,0 +1,83 @@
+import dagre from "dagre";
+
+export interface LayoutInputNode {
+  id: string;
+  width: number;
+  height: number;
+}
+
+export interface LayoutInputEdge {
+  source: string;
+  target: string;
+}
+
+export interface LayoutPositionedNode extends LayoutInputNode {
+  /** Top-left x coordinate (dagre reports node centres; we convert to top-left) */
+  x: number;
+  /** Top-left y coordinate */
+  y: number;
+}
+
+export interface LayoutOptions {
+  rankdir?: "TB" | "BT" | "LR" | "RL";
+  nodesep?: number;
+  ranksep?: number;
+}
+
+export const DEFAULT_NODE_WIDTH = 180;
+export const DEFAULT_NODE_HEIGHT = 60;
+
+const DEFAULT_OPTIONS: Required<LayoutOptions> = {
+  rankdir: "TB",
+  nodesep: 80,
+  ranksep: 100,
+};
+
+/**
+ * Runs a dagre directed-acyclic layout over the given nodes/edges and returns
+ * the nodes with computed top-left `x`/`y` positions.
+ *
+ * dagre stores node centres, so we shift by half the node's dimensions to give
+ * ReactFlow the top-left origin it expects.
+ */
+export function layoutGraph(
+  nodes: LayoutInputNode[],
+  edges: LayoutInputEdge[],
+  options: LayoutOptions = {}
+): LayoutPositionedNode[] {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({
+    rankdir: opts.rankdir,
+    nodesep: opts.nodesep,
+    ranksep: opts.ranksep,
+  });
+
+  for (const node of nodes) {
+    g.setNode(node.id, { width: node.width, height: node.height });
+  }
+
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  for (const edge of edges) {
+    if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
+      g.setEdge(edge.source, edge.target);
+    }
+  }
+
+  dagre.layout(g);
+
+  return nodes.map((node) => {
+    const positioned = g.node(node.id) as
+      | { x: number; y: number }
+      | undefined;
+    const centreX = positioned?.x ?? 0;
+    const centreY = positioned?.y ?? 0;
+    return {
+      ...node,
+      x: centreX - node.width / 2,
+      y: centreY - node.height / 2,
+    };
+  });
+}

--- a/frontend/src/lib/graphUtils.ts
+++ b/frontend/src/lib/graphUtils.ts
@@ -137,3 +137,26 @@ export function filterToNeighbourhood(
 ): TaskDependency[] {
   return deps.filter((d) => d.fromId === taskId || d.toId === taskId);
 }
+
+/** Threshold above which the graph should be virtualized / sliced for performance. */
+export const GRAPH_VIRTUALIZE_THRESHOLD = 200;
+
+/**
+ * Returns true when a graph of `nodeCount` nodes is large enough that it should
+ * be virtualized (sliced down) before being handed to ReactFlow.
+ */
+export function shouldVirtualizeGraph(nodeCount: number): boolean {
+  return nodeCount > GRAPH_VIRTUALIZE_THRESHOLD;
+}
+
+/**
+ * Truncates a label to `maxLen` characters, appending an ellipsis when cut.
+ * The ellipsis counts toward the returned length so the result never exceeds
+ * `maxLen` characters.
+ */
+export function truncateLabel(label: string, maxLen = 24): string {
+  if (maxLen <= 0) return "";
+  if (label.length <= maxLen) return label;
+  if (maxLen === 1) return "…";
+  return `${label.slice(0, maxLen - 1)}…`;
+}


### PR DESCRIPTION
## Summary

- Builds a production-ready, dagre-layouted dependency graph on top of the existing ReactFlow + Zustand foundation
- Adds automatic hierarchical DAG layout via `dagre` (replacing the naive grid) so real task graphs render correctly
- Caps render cost for large graphs: >200 nodes are sliced with a warning banner, keeping ReactFlow fast at scale
- Introduces a custom `TaskNode` (status dot, truncated label, monospace id) as a registered ReactFlow `nodeType`
- Wraps the entire graph in a `GraphErrorBoundary` so render errors degrade gracefully instead of crashing the page
- Adds an `aria-live` region that announces node selection to screen readers

## New files

| File | Purpose |
|---|---|
| `src/lib/graphLayout.ts` | `layoutGraph()` — thin dagre wrapper; converts centre coords to ReactFlow top-left |
| `src/components/graph/TaskNode.tsx` | Custom node: status dot (blue/green/yellow), 24-char truncated title, monospace id |
| `src/components/graph/GraphErrorBoundary.tsx` | Class error boundary with retry button |
| `src/hooks/useTaskGraph.ts` | Composable hook: focus filter → text filter → large-graph slice → dagre layout → RF shapes |
| `app/graph-demo/page.tsx` | Live demo: 10 tasks, 14 realistic edges, add-random-dependency button |

## Modified files

| File | Change |
|---|---|
| `src/components/TaskDependencyGraph.tsx` | Uses `useTaskGraph` hook, `nodeTypes`, `GraphErrorBoundary`, aria-live region, large-graph banner, keyboard hint |
| `src/lib/graphUtils.ts` | Added `shouldVirtualizeGraph`, `truncateLabel`, `GRAPH_VIRTUALIZE_THRESHOLD` (existing functions untouched) |

## Test plan

- 100 tests passing across 6 suites (`graphLayout`, `TaskNode`, `GraphErrorBoundary`, `useTaskGraph`, `graphUtils`, `TaskDependencyGraph`)
- Coverage on new/modified files: 99.8% statements, 95.8% branches, 95% functions (>90% target)
- All pre-existing tests preserved and passing
- ReactFlow mocked in component tests to keep them fast and deterministic
- `tsc --noEmit` reports zero errors in any new or modified file

Closes #398