### PR TITLE
[#585] [Frontend] Construct Role-based Access Control (RBAC) UI Engine Mechanism

### DIFF
--- a/frontend/app/settings/rbac/page.tsx
+++ b/frontend/app/settings/rbac/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { AuthProvider } from "@/context/AuthContext";
+import { RbacSettingsPanel } from "@/src/components/RbacSettingsPanel";
+import { RbacUiEngineProvider } from "@/src/lib/rbac/RbacUiEngineProvider";
+
+export default function RbacSettingsPage() {
+  return (
+    <AuthProvider>
+      <div className="min-h-screen bg-neutral-900 text-neutral-100 px-6 py-10">
+        <div className="mx-auto max-w-5xl">
+          <RbacUiEngineProvider>
+            <RbacSettingsPanel />
+          </RbacUiEngineProvider>
+        </div>
+      </div>
+    </AuthProvider>
+  );
+}

--- a/frontend/docs/rbac-ui-engine.md
+++ b/frontend/docs/rbac-ui-engine.md
@@ -1,0 +1,39 @@
+# RBAC UI Engine
+
+SoroTask provides a fault-tolerant Role-based Access Control (RBAC) UI engine that handles network partitions and RPC failures gracefully.
+
+## Architecture
+
+| Module | Responsibility |
+| --- | --- |
+| `src/lib/rbac/engine.ts` | Permission evaluation with role inheritance and offline grace period |
+| `src/lib/rbac/api.ts` | API client with retry, caching, and degraded-mode fallback |
+| `src/lib/rbac/RbacUiEngineProvider.tsx` | React context bridging auth state and RBAC engine |
+| `src/components/RbacSettingsPanel.tsx` | Settings UI wired to `RoleBasedAccessControl` |
+
+## Connection states
+
+| State | Behavior |
+| --- | --- |
+| `online` | Live permissions from API |
+| `degraded` | Partial API failure; cached permissions used |
+| `offline` | Network partition; cached permissions with grace period |
+
+## Usage
+
+```tsx
+import { RbacUiEngineProvider } from "@/src/lib/rbac/RbacUiEngineProvider";
+import { RbacSettingsPanel } from "@/src/components/RbacSettingsPanel";
+
+<RbacUiEngineProvider>
+  <RbacSettingsPanel />
+</RbacUiEngineProvider>
+```
+
+## PermissionGuard integration
+
+`PermissionGuard` continues to work with `AuthContext`. The RBAC engine adds an additional layer for workspace-level permissions and offline resilience via cached permission sets.
+
+## Events
+
+Connection state changes emit `sorotask:rbac-state-change` for monitoring and UI feedback.

--- a/frontend/src/components/RbacSettingsPanel.tsx
+++ b/frontend/src/components/RbacSettingsPanel.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import RoleBasedAccessControl, {
+  type Workspace,
+} from "@/components/RoleBasedAccessControl";
+import { useRbacUiEngine } from "./RbacUiEngineProvider";
+import { getRbacApi } from "./api";
+
+const defaultWorkspace: Workspace = {
+  id: "ws-default",
+  name: "Default Workspace",
+  description: "Manage team access and roles",
+  owner: "admin_address",
+  createdAt: new Date().toISOString(),
+  members: [],
+  roles: [],
+};
+
+type RbacSettingsPanelProps = {
+  workspace?: Workspace;
+};
+
+export function RbacSettingsPanel({
+  workspace = defaultWorkspace,
+}: RbacSettingsPanelProps) {
+  const { connectionState, lastError, refreshPermissions } = useRbacUiEngine();
+  const api = getRbacApi();
+
+  const handleUpdate = async (updated: Workspace) => {
+    await api.syncWorkspace(updated.id, updated);
+    await refreshPermissions();
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold">Role-based Access Control</h2>
+          <p className="text-sm text-neutral-400">
+            Manage workspace members, roles, and permissions.
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-medium ${
+            connectionState === "online"
+              ? "bg-emerald-500/10 text-emerald-300"
+              : connectionState === "degraded"
+                ? "bg-amber-500/10 text-amber-300"
+                : "bg-rose-500/10 text-rose-300"
+          }`}
+        >
+          {connectionState}
+        </span>
+      </div>
+
+      {lastError && (
+        <p className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-100">
+          RBAC service unavailable — using cached permissions. {lastError}
+        </p>
+      )}
+
+      <RoleBasedAccessControl
+        workspace={workspace}
+        onUpdateWorkspace={handleUpdate}
+        onAddMember={async () => refreshPermissions()}
+        onRemoveMember={async () => refreshPermissions()}
+        onUpdateMemberRole={async () => refreshPermissions()}
+        onCreateRole={async (role) => ({
+          ...role,
+          id: `role-${Date.now()}`,
+          createdAt: new Date().toISOString(),
+        })}
+        onUpdateRole={async () => refreshPermissions()}
+        onDeleteRole={async () => refreshPermissions()}
+      />
+    </section>
+  );
+}

--- a/frontend/src/lib/rbac/RbacUiEngineProvider.tsx
+++ b/frontend/src/lib/rbac/RbacUiEngineProvider.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/context/AuthContext";
+import type { Permission } from "@/types/auth";
+import { getRbacApi } from "./api";
+import { getRbacEngine } from "./engine";
+import { RBAC_EVENT_NAME, type RbacConnectionState, type RbacStateChangeEvent } from "./types";
+
+type RbacUiEngineContextValue = {
+  connectionState: RbacConnectionState;
+  cachedPermissions: Permission[];
+  evaluate: (permissions: Permission[], requireAll?: boolean) => boolean;
+  hasPermission: (permission: Permission) => boolean;
+  refreshPermissions: () => Promise<void>;
+  lastError: string | null;
+};
+
+const RbacUiEngineContext = createContext<RbacUiEngineContextValue | undefined>(
+  undefined,
+);
+
+export function RbacUiEngineProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user } = useAuth();
+  const engine = useMemo(() => getRbacEngine(), []);
+  const api = useMemo(() => getRbacApi(), []);
+
+  const [connectionState, setConnectionState] =
+    useState<RbacConnectionState>("online");
+  const [cachedPermissions, setCachedPermissions] = useState<Permission[]>([]);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const refreshPermissions = useCallback(async () => {
+    if (!user?.id) return;
+
+    const result = await api.fetchPermissions(user.id);
+    setConnectionState(result.connectionState);
+    engine.setConnectionState(result.connectionState);
+
+    if (result.data) {
+      setCachedPermissions(result.data);
+    }
+
+    setLastError(result.error?.message ?? null);
+  }, [api, engine, user?.id]);
+
+  useEffect(() => {
+    refreshPermissions();
+
+    const handleStateChange = (event: Event) => {
+      const detail = (event as CustomEvent<RbacStateChangeEvent>).detail;
+      setConnectionState(detail.connectionState);
+      engine.setConnectionState(detail.connectionState);
+      setLastError(detail.error ?? null);
+    };
+
+    window.addEventListener(RBAC_EVENT_NAME, handleStateChange);
+    return () => window.removeEventListener(RBAC_EVENT_NAME, handleStateChange);
+  }, [engine, refreshPermissions]);
+
+  const evaluate = useCallback(
+    (permissions: Permission[], requireAll = true) => {
+      if (!user) return false;
+
+      return engine.evaluate(
+        permissions,
+        {
+          userPermissions: user.permissions,
+          userRole: user.role,
+          cachedPermissions,
+          connectionState,
+        },
+        requireAll,
+      ).allowed;
+    },
+    [cachedPermissions, connectionState, engine, user],
+  );
+
+  const hasPermission = useCallback(
+    (permission: Permission) => evaluate([permission], true),
+    [evaluate],
+  );
+
+  const value = useMemo(
+    () => ({
+      connectionState,
+      cachedPermissions,
+      evaluate,
+      hasPermission,
+      refreshPermissions,
+      lastError,
+    }),
+    [cachedPermissions, connectionState, evaluate, hasPermission, lastError, refreshPermissions],
+  );
+
+  return (
+    <RbacUiEngineContext.Provider value={value}>
+      {children}
+    </RbacUiEngineContext.Provider>
+  );
+}
+
+export function useRbacUiEngine(): RbacUiEngineContextValue {
+  const context = useContext(RbacUiEngineContext);
+  if (!context) {
+    throw new Error("useRbacUiEngine must be used within RbacUiEngineProvider");
+  }
+  return context;
+}

--- a/frontend/src/lib/rbac/__tests__/api.test.ts
+++ b/frontend/src/lib/rbac/__tests__/api.test.ts
@@ -1,0 +1,56 @@
+import { createRbacApi, resetRbacApi } from "../api";
+
+describe("rbac api", () => {
+  beforeEach(() => {
+    resetRbacApi();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    resetRbacApi();
+    jest.restoreAllMocks();
+  });
+
+  it("returns cached permissions when API URL is not configured", async () => {
+    const api = createRbacApi({ baseUrl: "" });
+    const result = await api.fetchPermissions("user-1");
+
+    expect(result.connectionState).toBe("offline");
+    expect(result.data).toBeNull();
+  });
+
+  it("fetches permissions successfully", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ["tasks:read", "tasks:create"],
+    });
+
+    const api = createRbacApi({ baseUrl: "http://localhost:3000" });
+    const result = await api.fetchPermissions("user-1");
+
+    expect(result.data).toEqual(["tasks:read", "tasks:create"]);
+    expect(result.connectionState).toBe("online");
+    expect(result.fromCache).toBe(false);
+  });
+
+  it("falls back to cache on network failure", async () => {
+    const api = createRbacApi({ baseUrl: "http://localhost:3000", cacheKey: "test_rbac" });
+    api.writeCache("test_rbac:permissions:user-1", ["tasks:read"]);
+
+    (global.fetch as jest.Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const result = await api.fetchPermissions("user-1");
+
+    expect(result.fromCache).toBe(true);
+    expect(result.connectionState).toBe("offline");
+    expect(result.data).toEqual(["tasks:read"]);
+  });
+
+  it("queues workspace sync offline", async () => {
+    const api = createRbacApi({ baseUrl: "" });
+    const result = await api.syncWorkspace("ws-1", { name: "Test" });
+
+    expect(result.data?.success).toBe(true);
+    expect(result.fromCache).toBe(true);
+  });
+});

--- a/frontend/src/lib/rbac/__tests__/engine.test.ts
+++ b/frontend/src/lib/rbac/__tests__/engine.test.ts
@@ -1,0 +1,76 @@
+import { createRbacEngine, getRbacEngine, resetRbacEngine } from "../engine";
+import { DEFAULT_RBAC_POLICIES } from "../types";
+import type { Permission } from "@/types/auth";
+
+describe("rbac engine", () => {
+  beforeEach(() => {
+    resetRbacEngine();
+  });
+
+  afterEach(() => {
+    resetRbacEngine();
+  });
+
+  it("evaluates permissions for admin role", () => {
+    const engine = createRbacEngine();
+
+    const result = engine.evaluate(["tasks:read", "admin:users"], {
+      userPermissions: [],
+      userRole: "admin",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.missingPermissions).toHaveLength(0);
+  });
+
+  it("denies missing permissions for viewer role", () => {
+    const engine = createRbacEngine();
+
+    const result = engine.evaluate(["tasks:create"], {
+      userPermissions: [],
+      userRole: "viewer",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.missingPermissions).toContain("tasks:create");
+  });
+
+  it("supports requireAny evaluation", () => {
+    const engine = createRbacEngine();
+
+    const result = engine.evaluate(
+      ["tasks:create", "tasks:read"],
+      { userPermissions: [], userRole: "viewer" },
+      false,
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("uses cached permissions when offline", () => {
+    const engine = createRbacEngine();
+    engine.setConnectionState("offline");
+
+    const cached: Permission[] = ["tasks:read", "tasks:create"];
+    const result = engine.evaluate(["tasks:read"], {
+      userPermissions: [],
+      userRole: "viewer",
+      cachedPermissions: cached,
+      connectionState: "offline",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.usedCache).toBe(true);
+  });
+
+  it("returns default policies", () => {
+    const engine = createRbacEngine();
+    expect(engine.getPolicies()).toEqual(DEFAULT_RBAC_POLICIES);
+  });
+
+  it("reuses singleton engine", () => {
+    const first = getRbacEngine();
+    const second = getRbacEngine();
+    expect(first).toBe(second);
+  });
+});

--- a/frontend/src/lib/rbac/api.ts
+++ b/frontend/src/lib/rbac/api.ts
@@ -1,0 +1,227 @@
+import type { Permission } from "@/types/auth";
+import {
+  RBAC_EVENT_NAME,
+  type RbacConnectionState,
+  type RbacStateChangeEvent,
+} from "./types";
+
+export type RbacApiResponse<T> = {
+  data: T | null;
+  error: Error | null;
+  fromCache: boolean;
+  connectionState: RbacConnectionState;
+};
+
+export type RbacApiOptions = {
+  baseUrl?: string;
+  retryAttempts?: number;
+  retryDelayMs?: number;
+  cacheKey?: string;
+};
+
+const DEFAULT_CACHE_KEY = "sorotask_rbac_cache";
+
+function emitStateChange(event: RbacStateChangeEvent): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent<RbacStateChangeEvent>(RBAC_EVENT_NAME, {
+        detail: event,
+      }),
+    );
+  }
+}
+
+function readCache<T>(key: string): T | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache<T>(key: string, value: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Ignore storage failures
+  }
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) return true;
+  if (error instanceof Error) {
+    return (
+      error.message.includes("fetch") ||
+      error.message.includes("network") ||
+      error.message.includes("Failed to fetch")
+    );
+  }
+  return false;
+}
+
+async function fetchWithRetry(
+  url: string,
+  attempts: number,
+  delayMs: number,
+): Promise<Response> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok && response.status >= 500 && attempt < attempts) {
+        throw new Error(`Server error: ${response.status}`);
+      }
+      return response;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs * attempt));
+      }
+    }
+  }
+
+  throw lastError ?? new Error("Request failed");
+}
+
+export function createRbacApi(options: RbacApiOptions = {}) {
+  const baseUrl = options.baseUrl ?? process.env.NEXT_PUBLIC_API_URL ?? "";
+  const retryAttempts = options.retryAttempts ?? 3;
+  const retryDelayMs = options.retryDelayMs ?? 500;
+  const cacheKey = options.cacheKey ?? DEFAULT_CACHE_KEY;
+
+  const fetchPermissions = async (
+    userId: string,
+  ): Promise<RbacApiResponse<Permission[]>> => {
+    const cacheField = `${cacheKey}:permissions:${userId}`;
+    const cached = readCache<Permission[]>(cacheField);
+
+    if (!baseUrl) {
+      return {
+        data: cached,
+        error: cached ? null : new Error("API URL not configured"),
+        fromCache: Boolean(cached),
+        connectionState: cached ? "degraded" : "offline",
+      };
+    }
+
+    try {
+      const response = await fetchWithRetry(
+        `${baseUrl}/api/rbac/permissions/${userId}`,
+        retryAttempts,
+        retryDelayMs,
+      );
+
+      if (!response.ok) {
+        throw new Error(`RBAC API error: ${response.status}`);
+      }
+
+      const data = (await response.json()) as Permission[];
+      writeCache(cacheField, data);
+
+      emitStateChange({
+        connectionState: "online",
+        timestamp: new Date().toISOString(),
+      });
+
+      return {
+        data,
+        error: null,
+        fromCache: false,
+        connectionState: "online",
+      };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const state: RbacConnectionState = isNetworkError(error)
+        ? "offline"
+        : "degraded";
+
+      emitStateChange({
+        connectionState: state,
+        timestamp: new Date().toISOString(),
+        error: err.message,
+      });
+
+      return {
+        data: cached,
+        error: err,
+        fromCache: Boolean(cached),
+        connectionState: state,
+      };
+    }
+  };
+
+  const syncWorkspace = async (
+    workspaceId: string,
+    payload: unknown,
+  ): Promise<RbacApiResponse<{ success: boolean }>> => {
+    const cacheField = `${cacheKey}:workspace:${workspaceId}`;
+
+    if (!baseUrl) {
+      writeCache(cacheField, payload);
+      return {
+        data: { success: true },
+        error: null,
+        fromCache: true,
+        connectionState: "degraded",
+      };
+    }
+
+    try {
+      const response = await fetchWithRetry(
+        `${baseUrl}/api/rbac/workspaces/${workspaceId}`,
+        retryAttempts,
+        retryDelayMs,
+      );
+
+      if (!response.ok) {
+        throw new Error(`Workspace sync error: ${response.status}`);
+      }
+
+      const data = (await response.json()) as { success: boolean };
+      writeCache(cacheField, payload);
+
+      return {
+        data,
+        error: null,
+        fromCache: false,
+        connectionState: "online",
+      };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      writeCache(cacheField, payload);
+
+      return {
+        data: { success: false },
+        error: err,
+        fromCache: true,
+        connectionState: isNetworkError(error) ? "offline" : "degraded",
+      };
+    }
+  };
+
+  return {
+    fetchPermissions,
+    syncWorkspace,
+    readCache,
+    writeCache,
+  };
+}
+
+let globalApi: ReturnType<typeof createRbacApi> | null = null;
+
+export function getRbacApi(
+  options?: RbacApiOptions,
+): ReturnType<typeof createRbacApi> {
+  if (!globalApi) {
+    globalApi = createRbacApi(options);
+  }
+  return globalApi;
+}
+
+export function resetRbacApi(): void {
+  globalApi = null;
+}

--- a/frontend/src/lib/rbac/engine.ts
+++ b/frontend/src/lib/rbac/engine.ts
@@ -1,0 +1,132 @@
+import type { Permission, UserRole } from "@/types/auth";
+import {
+  DEFAULT_RBAC_POLICIES,
+  type RbacConnectionState,
+  type RbacEngineOptions,
+  type RbacEvaluationContext,
+  type RbacEvaluationResult,
+  type RbacPolicy,
+} from "./types";
+
+function resolveRolePermissions(
+  role: UserRole,
+  policies: RbacPolicy[],
+): Permission[] {
+  const policy = policies.find((entry) => entry.role === role);
+  if (!policy) {
+    return [];
+  }
+
+  const inherited = (policy.inherits ?? []).flatMap((inheritedRole) =>
+    resolveRolePermissions(inheritedRole, policies),
+  );
+
+  return Array.from(new Set([...policy.permissions, ...inherited]));
+}
+
+function effectivePermissions(context: RbacEvaluationContext, policies: RbacPolicy[]): Permission[] {
+  if (context.userPermissions.length > 0) {
+    return context.userPermissions;
+  }
+
+  return resolveRolePermissions(context.userRole, policies);
+}
+
+export function createRbacEngine(options: RbacEngineOptions = {}) {
+  const policies = options.defaultPolicies ?? DEFAULT_RBAC_POLICIES;
+  const offlineGracePeriodMs = options.offlineGracePeriodMs ?? 300_000;
+
+  let lastOnlineAt = Date.now();
+  let connectionState: RbacConnectionState = "online";
+
+  const setConnectionState = (next: RbacConnectionState) => {
+    connectionState = next;
+    if (next === "online") {
+      lastOnlineAt = Date.now();
+    }
+  };
+
+  const evaluate = (
+    required: Permission[],
+    context: RbacEvaluationContext,
+    requireAll = true,
+  ): RbacEvaluationResult => {
+    const state = context.connectionState ?? connectionState;
+    const permissions =
+      state === "offline" && context.cachedPermissions?.length
+        ? context.cachedPermissions
+        : effectivePermissions(context, policies);
+
+    const usedCache = state === "offline" && Boolean(context.cachedPermissions?.length);
+
+    const check = (permission: Permission) => permissions.includes(permission);
+    const missingPermissions = required.filter((permission) => !check(permission));
+
+    const allowed = requireAll
+      ? missingPermissions.length === 0
+      : required.some(check);
+
+    if (state === "offline" && !usedCache) {
+      const withinGrace = Date.now() - lastOnlineAt < offlineGracePeriodMs;
+      return {
+        allowed: withinGrace ? allowed : false,
+        missingPermissions: withinGrace ? missingPermissions : required,
+        usedCache: false,
+        connectionState: state,
+      };
+    }
+
+    return {
+      allowed,
+      missingPermissions,
+      usedCache,
+      connectionState: state,
+    };
+  };
+
+  const hasPermission = (
+    permission: Permission,
+    context: RbacEvaluationContext,
+  ): boolean => evaluate([permission], context).allowed;
+
+  const hasAllPermissions = (
+    permissions: Permission[],
+    context: RbacEvaluationContext,
+  ): boolean => evaluate(permissions, context, true).allowed;
+
+  const hasAnyPermission = (
+    permissions: Permission[],
+    context: RbacEvaluationContext,
+  ): boolean => evaluate(permissions, context, false).allowed;
+
+  const getPolicies = (): RbacPolicy[] => [...policies];
+
+  const getConnectionState = (): RbacConnectionState => connectionState;
+
+  return {
+    evaluate,
+    hasPermission,
+    hasAllPermissions,
+    hasAnyPermission,
+    getPolicies,
+    getConnectionState,
+    setConnectionState,
+  };
+}
+
+let globalEngine: ReturnType<typeof createRbacEngine> | null = null;
+
+export function getRbacEngine(
+  options?: RbacEngineOptions,
+): ReturnType<typeof createRbacEngine> {
+  if (!globalEngine) {
+    globalEngine = createRbacEngine(options);
+  }
+  return globalEngine;
+}
+
+export function resetRbacEngine(): void {
+  globalEngine = null;
+}
+
+export { resolveRolePermissions };

--- a/frontend/src/lib/rbac/types.ts
+++ b/frontend/src/lib/rbac/types.ts
@@ -1,0 +1,71 @@
+import type { Permission, UserRole } from "@/types/auth";
+
+export type RbacConnectionState = "online" | "offline" | "degraded";
+
+export type RbacPolicy = {
+  role: UserRole;
+  permissions: Permission[];
+  inherits?: UserRole[];
+};
+
+export type RbacEvaluationContext = {
+  userPermissions: Permission[];
+  userRole: UserRole;
+  policies?: RbacPolicy[];
+  connectionState?: RbacConnectionState;
+  cachedPermissions?: Permission[];
+};
+
+export type RbacEvaluationResult = {
+  allowed: boolean;
+  missingPermissions: Permission[];
+  usedCache: boolean;
+  connectionState: RbacConnectionState;
+};
+
+export type RbacEngineOptions = {
+  defaultPolicies?: RbacPolicy[];
+  offlineGracePeriodMs?: number;
+};
+
+export const DEFAULT_RBAC_POLICIES: RbacPolicy[] = [
+  {
+    role: "admin",
+    permissions: [
+      "tasks:create",
+      "tasks:read",
+      "tasks:update",
+      "tasks:delete",
+      "tasks:execute",
+      "tasks:pause",
+      "tasks:resume",
+      "admin:users",
+      "admin:settings",
+      "admin:system",
+    ],
+  },
+  {
+    role: "user",
+    permissions: [
+      "tasks:create",
+      "tasks:read",
+      "tasks:update",
+      "tasks:delete",
+      "tasks:execute",
+      "tasks:pause",
+      "tasks:resume",
+    ],
+  },
+  {
+    role: "viewer",
+    permissions: ["tasks:read"],
+  },
+];
+
+export const RBAC_EVENT_NAME = "sorotask:rbac-state-change";
+
+export type RbacStateChangeEvent = {
+  connectionState: RbacConnectionState;
+  timestamp: string;
+  error?: string;
+};


### PR DESCRIPTION
## Summary
- Add RBAC engine with role-based permission evaluation and offline grace period
- Add fault-tolerant API client with retry, caching, and degraded-mode fallback
- Wire RoleBasedAccessControl into dedicated /settings/rbac route

Closes #585

## Test plan
- [x] RBAC engine and API unit tests pass

Made with [Cursor](https://cursor.com)