### PR TITLE
feat(frontend): add ABI-driven template builder forms

### DIFF
--- a/frontend/app/template-builder/README.md
+++ b/frontend/app/template-builder/README.md
@@ -1,0 +1,22 @@
+# Template Builder ABI Import
+
+The template builder now accepts a Soroban contract ABI and turns each exported function into a configurable action card.
+
+## How to use it
+
+1. Open the template builder at /template-builder.
+2. Paste a contract ABI JSON (array of functions or an object with a functions array) into the Import Custom ABI panel.
+3. Enter the contract address and optional label.
+4. Click Import. Each function becomes a custom action in the Custom tab.
+5. Drop the generated action onto the canvas and fill out the generated form fields.
+
+## Supported parameter types
+
+The form generator understands common Soroban-like parameter types, including:
+
+- address
+- numeric types such as u32, u64, i128
+- bool (rendered as a select)
+- string and bytes
+
+The builder validates required values before a template can be saved.

--- a/frontend/app/template-builder/__tests__/ActionBlockCard.test.tsx
+++ b/frontend/app/template-builder/__tests__/ActionBlockCard.test.tsx
@@ -59,6 +59,17 @@ describe('ActionBlockCard', () => {
     expect(screen.getByLabelText(/min_amount/)).toBeInTheDocument();
   });
 
+  it('renders a select for boolean parameters', () => {
+    renderCard({
+      block: {
+        ...BASE_BLOCK,
+        inputs: [{ name: 'approve', type: 'bool' }],
+        args: {},
+      },
+    });
+    expect(screen.getByLabelText(/approve/)).toBeInstanceOf(HTMLSelectElement);
+  });
+
   it('shows "Needs input" when not configured', () => {
     renderCard();
     expect(screen.getByText('Needs input')).toBeInTheDocument();

--- a/frontend/app/template-builder/__tests__/useTemplateBuilder.test.ts
+++ b/frontend/app/template-builder/__tests__/useTemplateBuilder.test.ts
@@ -82,6 +82,23 @@ describe('parseAbi', () => {
     expect(result.abi?.contractAddress).toBe('CNEW'); // caller address wins
   });
 
+  it('parses Soroban-style ABI objects with typed inputs', () => {
+    const raw = JSON.stringify({
+      name: 'Counter',
+      version: '2',
+      functions: [
+        {
+          name: 'increment',
+          inputs: [{ name: 'by', type: { kind: 'u32' } }],
+          outputs: [],
+        },
+      ],
+    });
+    const result = parseAbi(raw, 'CADDRESS', 'Counter');
+    expect(result.success).toBe(true);
+    expect(result.abi?.functions[0].inputs[0].type).toBe('u32');
+  });
+
   it('returns error when array items are malformed', () => {
     const result = parseAbi(JSON.stringify([{ notName: 'x' }]), 'CADDR');
     expect(result.success).toBe(false);
@@ -197,6 +214,23 @@ describe('useTemplateBuilder', () => {
     act(() => result.current.addBlock(HARVEST));
     act(() => result.current.updateArg('ghost', 'pool_id', 'X'));
     expect(result.current.blocks[0].args['pool_id']).toBeUndefined();
+  });
+
+  it('requires valid values for typed numeric inputs', () => {
+    const { result } = setup();
+    act(() =>
+      result.current.addBlock({
+        ...HARVEST,
+        inputs: [{ name: 'amount', type: 'u64' }],
+      }),
+    );
+    const id = result.current.blocks[0].instanceId;
+
+    act(() => result.current.updateArg(id, 'amount', 'not-a-number'));
+    expect(result.current.blocks[0].isConfigured).toBe(false);
+
+    act(() => result.current.updateArg(id, 'amount', '42'));
+    expect(result.current.blocks[0].isConfigured).toBe(true);
   });
 
   // --- updateContractAddress ---

--- a/frontend/app/template-builder/components/ActionBlockCard.tsx
+++ b/frontend/app/template-builder/components/ActionBlockCard.tsx
@@ -140,14 +140,27 @@ export function ActionBlockCard({
                   <span className="ml-1 text-red-400" aria-label="required">*</span>
                 )}
               </label>
-              <input
-                id={`${block.instanceId}-arg-${param.name}`}
-                type="text"
-                value={block.args[param.name] ?? ''}
-                onChange={(e) => onArgChange(block.instanceId, param.name, e.target.value)}
-                placeholder={param.optional ? 'optional' : 'required'}
-                className="w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1.5 text-xs font-mono text-neutral-200 placeholder-neutral-600 outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-              />
+              {param.type === 'bool' ? (
+                <select
+                  id={`${block.instanceId}-arg-${param.name}`}
+                  value={block.args[param.name] ?? ''}
+                  onChange={(e) => onArgChange(block.instanceId, param.name, e.target.value)}
+                  className="w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1.5 text-xs font-mono text-neutral-200 placeholder-neutral-600 outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="">{param.optional ? 'optional' : 'select value'}</option>
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                </select>
+              ) : (
+                <input
+                  id={`${block.instanceId}-arg-${param.name}`}
+                  type={['u8', 'u16', 'u32', 'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128'].includes(param.type) ? 'number' : 'text'}
+                  value={block.args[param.name] ?? ''}
+                  onChange={(e) => onArgChange(block.instanceId, param.name, e.target.value)}
+                  placeholder={param.optional ? 'optional' : 'required'}
+                  className="w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1.5 text-xs font-mono text-neutral-200 placeholder-neutral-600 outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                />
+              )}
             </div>
           ))}
         </div>

--- a/frontend/app/template-builder/page.tsx
+++ b/frontend/app/template-builder/page.tsx
@@ -4,7 +4,7 @@ import { TemplateBuilder } from './components/TemplateBuilder';
 export const metadata: Metadata = {
   title: 'Task Template Builder | SoroTask',
   description:
-    'Compose complex task execution flows using pre-defined on-chain actions and custom ABIs.',
+    'Compose complex task execution flows using pre-defined actions or import a Soroban contract ABI to generate a validated form.',
 };
 
 export default function TemplateBuilderPage() {

--- a/frontend/app/template-builder/types.ts
+++ b/frontend/app/template-builder/types.ts
@@ -8,12 +8,21 @@
 
 export type AbiParamType =
   | 'address'
+  | 'u8'
+  | 'u16'
   | 'u32'
   | 'u64'
+  | 'u128'
+  | 'i8'
+  | 'i16'
+  | 'i32'
+  | 'i64'
   | 'i128'
   | 'bool'
   | 'string'
-  | 'bytes';
+  | 'bytes'
+  | 'symbol'
+  | 'void';
 
 export interface AbiParam {
   name: string;

--- a/frontend/app/template-builder/useTemplateBuilder.ts
+++ b/frontend/app/template-builder/useTemplateBuilder.ts
@@ -8,6 +8,8 @@ import {
   AbiFunction,
   AbiParseResult,
   FlowTemplate,
+  AbiParam,
+  AbiParamType,
 } from './types';
 
 // ---------------------------------------------------------------------------
@@ -19,6 +21,91 @@ interface TemplateBuilderState {
   templateName: string;
   importedAbis: ContractAbi[];
   errors: Record<string, string>; // instanceId → error message
+}
+
+const KNOWN_PARAM_TYPES: AbiParamType[] = [
+  'address',
+  'u8',
+  'u16',
+  'u32',
+  'u64',
+  'u128',
+  'i8',
+  'i16',
+  'i32',
+  'i64',
+  'i128',
+  'bool',
+  'string',
+  'bytes',
+  'symbol',
+  'void',
+];
+
+function normalizeAbiType(rawType: unknown): AbiParamType {
+  if (typeof rawType === 'string') {
+    return (KNOWN_PARAM_TYPES.includes(rawType as AbiParamType)
+      ? (rawType as AbiParamType)
+      : 'string') as AbiParamType;
+  }
+
+  if (typeof rawType === 'object' && rawType !== null) {
+    const candidate = rawType as Record<string, unknown>;
+    const nested = candidate.kind ?? candidate.type ?? candidate.name;
+    if (typeof nested === 'string') {
+      return normalizeAbiType(nested);
+    }
+  }
+
+  return 'string';
+}
+
+function normalizeAbiParam(param: unknown): AbiParam | null {
+  if (!param || typeof param !== 'object') return null;
+
+  const candidate = param as Record<string, unknown>;
+  const name = typeof candidate.name === 'string' ? candidate.name : '';
+  if (!name) return null;
+
+  return {
+    name,
+    type: normalizeAbiType(candidate.type),
+    optional: candidate.optional === true,
+  };
+}
+
+function isArgConfigured(value: string | undefined, param: AbiParam): boolean {
+  const trimmed = value?.trim() ?? '';
+  if (!trimmed) {
+    return param.optional === true;
+  }
+
+  switch (param.type) {
+    case 'bool':
+      return ['true', 'false', '1', '0'].includes(trimmed.toLowerCase());
+    case 'u8':
+    case 'u16':
+    case 'u32':
+    case 'u64':
+    case 'u128':
+      return /^\d+$/.test(trimmed);
+    case 'i8':
+    case 'i16':
+    case 'i32':
+    case 'i64':
+    case 'i128':
+      return /^-?\d+$/.test(trimmed);
+    case 'address':
+      return trimmed.startsWith('C') || /^G[A-Z2-7]{55}$/.test(trimmed);
+    default:
+      return true;
+  }
+}
+
+function isBlockConfigured(block: ActionBlock): boolean {
+  return block.inputs
+    .filter((param) => !param.optional)
+    .every((param) => isArgConfigured(block.args[param.name], param));
 }
 
 const initialState: TemplateBuilderState = {
@@ -73,9 +160,7 @@ function reducer(state: TemplateBuilderState, action: Action): TemplateBuilderSt
       const blocks = state.blocks.map((b) => {
         if (b.instanceId !== action.instanceId) return b;
         const args = { ...b.args, [action.argName]: action.value };
-        const isConfigured = b.inputs
-          .filter((p) => !p.optional)
-          .every((p) => args[p.name]?.trim());
+        const isConfigured = isBlockConfigured({ ...b, args });
         return { ...b, args, isConfigured };
       });
       return { ...state, blocks };
@@ -148,7 +233,13 @@ export function parseAbi(
     if (!fns.every((f) => typeof f.name === 'string' && Array.isArray(f.inputs))) {
       return { success: false, error: 'Array items must have name and inputs fields' };
     }
-    return { success: true, abi: { contractAddress, label, functions: fns } };
+    const normalizedFunctions = fns.map((fn) => ({
+      ...fn,
+      inputs: (fn.inputs ?? [])
+        .map(normalizeAbiParam)
+        .filter((param): param is AbiParam => param !== null),
+    }));
+    return { success: true, abi: { contractAddress, label, functions: normalizedFunctions } };
   }
 
   // Accept ContractAbi object
@@ -159,9 +250,15 @@ export function parseAbi(
     Array.isArray((parsed as ContractAbi).functions)
   ) {
     const obj = parsed as ContractAbi;
+    const normalizedFunctions = (obj.functions ?? []).map((fn) => ({
+      ...fn,
+      inputs: (fn.inputs ?? [])
+        .map(normalizeAbiParam)
+        .filter((param): param is AbiParam => param !== null),
+    }));
     return {
       success: true,
-      abi: { contractAddress, label, functions: obj.functions },
+      abi: { contractAddress, label, functions: normalizedFunctions },
     };
   }
 


### PR DESCRIPTION
Closes #413 
## Summary

<!-- What does this PR change and why? -->

## Related Issue

<!-- Link issue: Closes #123 / Related #123 -->

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

## Changes Made

-

## Validation

<!-- Mark what you ran locally. -->

- [ ] `cargo fmt --all` (if `contract` changed)
- [ ] `npm run lint` in `frontend` (if `frontend` changed)
- [ ] Manual verification completed

## Screenshots (if UI changes)

<!-- Add before/after screenshots or short recording -->

## Checklist

- [ ] Scope is focused and avoids unrelated changes
- [ ] Commit messages are clear
- [ ] Documentation updated when needed
- [ ] ETA was provided when requesting assignment for the linked issue
