### PR TITLE
feat(frontend): add task loading skeletons

### DIFF
--- a/frontend/app/tasks/page.tsx
+++ b/frontend/app/tasks/page.tsx
@@ -5,7 +5,9 @@ import { useTasks } from "@/src/hooks/tasks";
 import { useLayoutStore } from "@/src/store/layoutStore";
 import SplitPaneLayout from "@/src/components/layout/SplitPaneLayout";
 import TaskCardWithSelection from "@/components/TaskCardWithSelection";
+import { TaskListSkeleton } from "@/components/skeletons";
 import type { TaskFilters } from "@/src/lib/query/keys";
+import type { Task, TaskStatus } from "@/src/lib/mockApi/tasks";
 
 export default function TasksPage() {
   const [filters, setFilters] = useState<TaskFilters>({});
@@ -38,12 +40,13 @@ export default function TasksPage() {
           <div className="flex gap-3 items-center">
             <select
               value={filters.status || ""}
-              onChange={(e) =>
+              onChange={(e) => {
+                const status = e.target.value as TaskStatus | "";
                 setFilters((prev) => ({
                   ...prev,
-                  status: e.target.value as any || undefined,
-                }))
-              }
+                  status: status || undefined,
+                }));
+              }}
               className="bg-neutral-900 border border-neutral-700 rounded-lg px-3 py-2 text-sm text-neutral-200"
             >
               <option value="">All Status</option>
@@ -71,16 +74,7 @@ export default function TasksPage() {
           onScroll={handleScroll}
           className="flex-1 overflow-y-auto px-6 py-6"
         >
-          {isLoading && (
-            <div className="space-y-4">
-              {[...Array(5)].map((_, i) => (
-                <div
-                  key={i}
-                  className="h-32 bg-neutral-800 rounded-xl animate-pulse"
-                />
-              ))}
-            </div>
-          )}
+          {isLoading && <TaskListSkeleton rows={5} />}
 
           {!isLoading && tasks && tasks.length === 0 && (
             <div className="text-center py-12">
@@ -90,7 +84,7 @@ export default function TasksPage() {
 
           {!isLoading && tasks && tasks.length > 0 && (
             <div className="space-y-4">
-              {tasks.map((task: any) => (
+              {tasks.map((task: Task) => (
                 <TaskCardWithSelection key={task.id} task={task} />
               ))}
             </div>

--- a/frontend/components/skeletons/index.tsx
+++ b/frontend/components/skeletons/index.tsx
@@ -1,0 +1,69 @@
+const pulse = "animate-pulse rounded bg-neutral-200 dark:bg-neutral-700";
+
+export function CardSkeleton() {
+  return (
+    <div className="space-y-3 rounded-xl border border-neutral-200 p-5 dark:border-neutral-800">
+      <div className={`${pulse} h-4 w-1/3`} />
+      <div className={`${pulse} h-3 w-full`} />
+      <div className={`${pulse} h-3 w-4/5`} />
+      <div className={`${pulse} mt-4 h-8 w-1/4`} />
+    </div>
+  );
+}
+
+export function TableSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="space-y-2">
+      <div className={`${pulse} h-4 w-full`} />
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className={`${pulse} h-10 w-full`} />
+      ))}
+    </div>
+  );
+}
+
+export function ChartSkeleton() {
+  return <div className={`${pulse} h-48 w-full rounded-xl`} />;
+}
+
+export function StatCardSkeleton() {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="space-y-2 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800"
+        >
+          <div className={`${pulse} h-3 w-1/2`} />
+          <div className={`${pulse} h-7 w-2/3`} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TaskListSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-4" aria-busy="true" aria-label="Loading tasks">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-xl border border-neutral-800 bg-neutral-900/80 p-4 shadow-sm"
+        >
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <div className="space-y-2">
+              <div className={`${pulse} h-4 w-44`} />
+              <div className={`${pulse} h-3 w-64 max-w-full`} />
+            </div>
+            <div className={`${pulse} h-6 w-20 rounded-full`} />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className={`${pulse} h-3 w-full`} />
+            <div className={`${pulse} h-3 w-5/6`} />
+            <div className={`${pulse} h-3 w-2/3`} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add frontend skeleton components at the path used by dashboard loading imports
- add a reusable task-list skeleton with accessible busy semantics
- replace the tasks page's generic loading blocks with the task-list skeleton
- remove touched-file \ny\ casts from the tasks page while wiring the loading state

Closes #698

## Validation
- \git diff --check\`n- \
px eslint app/tasks/page.tsx components/skeletons/index.tsx --quiet\`n
## Notes
- Full \
px tsc --noEmit --pretty false --project tsconfig.json\ is blocked by existing baseline parse errors in \components/AIAssistant/hooks/__tests__/useAIAssistant.test.ts\ where JSX is in a \.ts\ file.
- Full \
pm run lint -- --quiet\ is blocked by existing repository-wide lint errors unrelated to this PR.