### PR TITLE
Enforce minimum task bounty

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -64,6 +64,8 @@ pub enum Error {
     InvalidInsurancePolicy = 33,
     TaskNotFound = 36,
     InvalidUpgradeVersion = 37,
+    BountyBelowMinimum = 38,
+    InvalidBounty = 39,
 }
 
 #[contracttype]
@@ -649,6 +651,7 @@ pub enum DataKey {
     DelegationCounter,
     KeeperReputation(Address),
     KeeperReputationCounter,
+    MinBounty,
 }
 
 fn enter_security_guard(env: &Env) {
@@ -866,6 +869,28 @@ fn require_proxy_admin(env: &Env, admin: &Address) -> ProxyConfig {
     config
 }
 
+fn get_min_bounty(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinBounty)
+        .unwrap_or(0)
+}
+
+fn require_config_admin(env: &Env, admin: &Address) {
+    let configured_admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::AdminAddress)
+        .or_else(|| read_proxy_config(env).map(|config| config.admin))
+        .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized));
+
+    admin.require_auth();
+
+    if &configured_admin != admin {
+        panic_with_error!(env, Error::Unauthorized);
+    }
+}
+
 #[contract]
 pub struct InsuranceContract;
 
@@ -1056,6 +1081,10 @@ impl SoroTaskContract {
             panic_with_error!(&env, Error::InvalidInterval);
         }
 
+        if config.gas_balance < get_min_bounty(&env) {
+            panic_with_error!(&env, Error::BountyBelowMinimum);
+        }
+
         // Validate payload arguments before storage
         if let Err(e) = Self::validate_args(&config.args) {
             panic_with_error!(&env, e);
@@ -1129,6 +1158,36 @@ impl SoroTaskContract {
             .persistent()
             .get(&DataKey::Counter)
             .unwrap_or(0)
+    }
+
+    /// Returns the globally configured minimum bounty required for task registration.
+    pub fn get_min_bounty(env: Env) -> i128 {
+        get_min_bounty(&env)
+    }
+
+    /// Updates the globally required minimum bounty for new task registrations.
+    pub fn set_min_bounty(env: Env, admin: Address, min_bounty: i128) {
+        enter_security_guard(&env);
+
+        require_config_admin(&env, &admin);
+
+        if min_bounty < 0 {
+            panic_with_error!(&env, Error::InvalidBounty);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MinBounty, &min_bounty);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "MinBountyUpdated"),
+                Symbol::new(&env, "v1"),
+            ),
+            (admin, min_bounty),
+        );
+
+        exit_security_guard(&env);
     }
 
     pub fn monitor(env: Env) -> Vec<ExecutableTask> {

--- a/contract/src/test_access_control.rs
+++ b/contract/src/test_access_control.rs
@@ -128,6 +128,74 @@ fn test_register_edge_case_zero_interval() {
     );
 }
 
+#[test]
+fn test_set_min_bounty_authorized_admin_succeeds() {
+    let (env, client) = setup_authed();
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.init_proxy(&admin, &token, &1);
+    client.set_min_bounty(&admin, &500);
+
+    assert_eq!(client.get_min_bounty(), 500);
+}
+
+#[test]
+fn test_set_min_bounty_unauthorized_actor_rejected() {
+    let (env, client) = setup_authed();
+    let admin = Address::generate(&env);
+    let wrong_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.init_proxy(&admin, &token, &1);
+    let result = client.try_set_min_bounty(&wrong_admin, &500);
+
+    assert_eq!(
+        result,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            Error::Unauthorized as u32
+        )))
+    );
+}
+
+#[test]
+fn test_register_rejects_bounty_below_minimum() {
+    let (env, client) = setup_authed();
+    let admin = Address::generate(&env);
+    let target = env.register_contract(None, MockTarget);
+
+    client.init_proxy(&admin, &Address::generate(&env), &1);
+    client.set_min_bounty(&admin, &1_000);
+
+    let mut cfg = base_config(&env, target);
+    cfg.gas_balance = 999;
+
+    let result = client.try_register(&cfg);
+    assert_eq!(
+        result,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            Error::BountyBelowMinimum as u32
+        )))
+    );
+    assert_eq!(client.get_counter(), 0);
+}
+
+#[test]
+fn test_register_accepts_bounty_at_minimum() {
+    let (env, client) = setup_authed();
+    let admin = Address::generate(&env);
+    let target = env.register_contract(None, MockTarget);
+
+    client.init_proxy(&admin, &Address::generate(&env), &1);
+    client.set_min_bounty(&admin, &1_000);
+
+    let mut cfg = base_config(&env, target);
+    cfg.gas_balance = 1_000;
+
+    let task_id = client.register(&cfg);
+    assert_eq!(client.get_task(&task_id).unwrap().gas_balance, 1_000);
+}
+
 // =============================================================================
 // 2. pause_task
 // =============================================================================


### PR DESCRIPTION
Summary
- Adds a global, admin-configurable minimum bounty for new task registrations.
- Enforces the minimum against `TaskConfig.gas_balance` before a task ID is allocated, so rejected low-bounty registrations do not consume IDs.
- Keeps backwards compatibility by defaulting the minimum bounty to `0` until an admin configures it.

Issue
- Closes #696

Changes
- Added `MinBounty` contract storage and public `get_min_bounty` / `set_min_bounty` contract methods.
- Added admin authorization for minimum bounty updates using the configured `AdminAddress` / proxy admin path.
- Added `BountyBelowMinimum` and `InvalidBounty` contract errors.
- Updated `register` to revert when `gas_balance` is below the configured minimum bounty.
- Added access-control and registration tests for authorized updates, unauthorized updates, below-minimum rejection, and at-minimum acceptance.

Validation
- Passed: `git diff --check`
- Not run: `cargo fmt` / contract tests because `cargo` is not installed or available in PATH in this local environment.

Notes
- The minimum bounty defaults to `0`, so existing deployments preserve current registration behavior until an admin sets a higher threshold.
