### PR TITLE
Implement Ledger WebUSB bridge

### DIFF
--- a/frontend/app/lib/__tests__/hardwareWallet.test.ts
+++ b/frontend/app/lib/__tests__/hardwareWallet.test.ts
@@ -1,8 +1,96 @@
-import { detectLedgerSupport, isWebHidSupported } from "../hardwareWallet";
+import {
+  connectHardwareWallet,
+  detectLedgerSupport,
+  isLedgerWebUsbSupported,
+} from "../hardwareWallet";
 
 describe("hardwareWallet", () => {
-  it("reports WebHID unsupported in jsdom", async () => {
-    expect(await isWebHidSupported()).toBe(false);
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("reports Ledger WebUSB unsupported in jsdom", async () => {
+    expect(await isLedgerWebUsbSupported()).toBe(false);
     expect(await detectLedgerSupport()).toBe(false);
+  });
+
+  it("connects to a selected Ledger device through WebUSB", async () => {
+    const device = {
+      opened: false,
+      configuration: null,
+      open: jest.fn(async function open(this: { opened: boolean }) {
+        this.opened = true;
+      }),
+      selectConfiguration: jest.fn(async function selectConfiguration(
+        this: { configuration: unknown },
+      ) {
+        this.configuration = { configurationValue: 1 };
+      }),
+      claimInterface: jest.fn(),
+      productName: "Ledger Nano X",
+      serialNumber: "serial-1",
+    };
+    const requestDevice = jest.fn().mockResolvedValue(device);
+    Object.defineProperty(global.navigator, "usb", {
+      configurable: true,
+      value: { requestDevice },
+    });
+
+    const session = await connectHardwareWallet("ledger");
+
+    expect(requestDevice).toHaveBeenCalledWith({
+      filters: [{ vendorId: 0x2c97 }],
+    });
+    expect(device.open).toHaveBeenCalled();
+    expect(device.selectConfiguration).toHaveBeenCalledWith(1);
+    expect(device.claimInterface).toHaveBeenCalledWith(0);
+    expect(session).toEqual({
+      kind: "ledger",
+      address: "Ledger Nano X",
+      transport: "webusb",
+      device: {
+        productName: "Ledger Nano X",
+        serialNumber: "serial-1",
+        vendorId: 0x2c97,
+      },
+    });
+  });
+
+  it("throws a classified error when the user does not select a Ledger device", async () => {
+    Object.defineProperty(global.navigator, "usb", {
+      configurable: true,
+      value: {
+        requestDevice: jest
+          .fn()
+          .mockRejectedValue(new DOMException("No device selected", "NotFoundError")),
+      },
+    });
+
+    await expect(connectHardwareWallet("ledger")).rejects.toMatchObject({
+      name: "HardwareWalletConnectionError",
+      code: "device_not_selected",
+      retriable: true,
+    });
+  });
+
+  it("throws a classified error when the Ledger interface cannot be claimed", async () => {
+    Object.defineProperty(global.navigator, "usb", {
+      configurable: true,
+      value: {
+        requestDevice: jest.fn().mockResolvedValue({
+          opened: false,
+          configuration: { configurationValue: 1 },
+          open: jest.fn(),
+          claimInterface: jest.fn().mockRejectedValue(new Error("busy")),
+          productName: "Ledger Nano S",
+        }),
+      },
+    });
+
+    await expect(connectHardwareWallet("ledger")).rejects.toMatchObject({
+      name: "HardwareWalletConnectionError",
+      code: "device_unavailable",
+      retriable: true,
+    });
   });
 });

--- a/frontend/app/lib/hardwareWallet.ts
+++ b/frontend/app/lib/hardwareWallet.ts
@@ -1,6 +1,6 @@
 /**
  * Hardware wallet adapters for Ledger and Trezor on Stellar.
- * Uses WebHID where available; falls back to extension-based signing flows.
+ * Uses Ledger WebUSB where available; falls back to extension-based signing flows.
  */
 
 export type HardwareWalletKind = "freighter" | "ledger" | "trezor";
@@ -14,16 +14,65 @@ export type HardwareWalletStatus =
 export type HardwareWalletSession = {
   kind: HardwareWalletKind;
   address: string;
-  transport: "webhid" | "extension";
+  transport: "webusb" | "extension";
+  device?: {
+    productName?: string;
+    serialNumber?: string;
+    vendorId: number;
+  };
 };
 
-export async function isWebHidSupported(): Promise<boolean> {
-  if (typeof navigator === "undefined") return false;
-  return Boolean(navigator.hid);
+export type HardwareWalletErrorCode =
+  | "unsupported"
+  | "device_not_selected"
+  | "permission_denied"
+  | "device_unavailable";
+
+type LedgerUsbDevice = {
+  opened: boolean;
+  configuration: unknown | null;
+  productName?: string;
+  serialNumber?: string;
+  vendorId?: number;
+  open: () => Promise<void>;
+  selectConfiguration: (configurationValue: number) => Promise<void>;
+  claimInterface: (interfaceNumber: number) => Promise<void>;
+};
+
+type LedgerUsb = {
+  requestDevice: (options: { filters: Array<{ vendorId: number }> }) => Promise<LedgerUsbDevice>;
+};
+
+type WebUsbNavigator = Navigator & {
+  usb?: LedgerUsb;
+};
+
+const LEDGER_VENDOR_ID = 0x2c97;
+const LEDGER_INTERFACE_NUMBER = 0;
+
+export class HardwareWalletConnectionError extends Error {
+  constructor(
+    public readonly code: HardwareWalletErrorCode,
+    message: string,
+    public readonly retriable: boolean,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "HardwareWalletConnectionError";
+  }
+}
+
+function getWebUsb(): LedgerUsb | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  return (navigator as WebUsbNavigator).usb;
+}
+
+export async function isLedgerWebUsbSupported(): Promise<boolean> {
+  return Boolean(getWebUsb());
 }
 
 export async function detectLedgerSupport(): Promise<boolean> {
-  return isWebHidSupported();
+  return isLedgerWebUsbSupported();
 }
 
 export async function detectTrezorSupport(): Promise<boolean> {
@@ -35,21 +84,72 @@ export async function connectHardwareWallet(
   kind: Exclude<HardwareWalletKind, "freighter">,
 ): Promise<HardwareWalletSession> {
   if (kind === "ledger") {
-    if (!(await detectLedgerSupport())) {
-      throw new Error(
-        "Ledger WebHID is not available in this browser. Use Chrome or Edge with a USB-connected device.",
+    const usb = getWebUsb();
+    if (!usb) {
+      throw new HardwareWalletConnectionError(
+        "unsupported",
+        "Ledger WebUSB is not available in this browser. Use Chrome or Edge with a USB-connected device.",
+        false,
       );
     }
-    const devices = await navigator.hid!.requestDevice({
-      filters: [{ vendorId: 0x2c97 }],
-    });
-    if (!devices.length) {
-      throw new Error("No Ledger device selected.");
+
+    let device: LedgerUsbDevice;
+    try {
+      device = await usb.requestDevice({
+        filters: [{ vendorId: LEDGER_VENDOR_ID }],
+      });
+    } catch (error) {
+      const errorName = error instanceof DOMException ? error.name : "";
+      if (errorName === "NotFoundError") {
+        throw new HardwareWalletConnectionError(
+          "device_not_selected",
+          "No Ledger device selected.",
+          true,
+          error,
+        );
+      }
+      if (errorName === "SecurityError") {
+        throw new HardwareWalletConnectionError(
+          "permission_denied",
+          "Ledger USB permission was denied by the browser.",
+          true,
+          error,
+        );
+      }
+      throw new HardwareWalletConnectionError(
+        "device_unavailable",
+        "Unable to request Ledger USB access.",
+        true,
+        error,
+      );
     }
+
+    try {
+      if (!device.opened) {
+        await device.open();
+      }
+      if (!device.configuration) {
+        await device.selectConfiguration(1);
+      }
+      await device.claimInterface(LEDGER_INTERFACE_NUMBER);
+    } catch (error) {
+      throw new HardwareWalletConnectionError(
+        "device_unavailable",
+        "Ledger device is unavailable or already claimed by another app.",
+        true,
+        error,
+      );
+    }
+
     return {
       kind: "ledger",
-      address: "G_LEDGER_PLACEHOLDER",
-      transport: "webhid",
+      address: device.productName || "Ledger device",
+      transport: "webusb",
+      device: {
+        productName: device.productName,
+        serialNumber: device.serialNumber,
+        vendorId: device.vendorId ?? LEDGER_VENDOR_ID,
+      },
     };
   }
 

--- a/frontend/docs/ledger-webusb-bridge.md
+++ b/frontend/docs/ledger-webusb-bridge.md
@@ -1,0 +1,16 @@
+# Ledger WebUSB Bridge
+
+The hardware wallet adapter uses the browser WebUSB API for Ledger devices. It requests only Ledger USB devices with vendor ID `0x2c97`, opens the selected device, selects configuration `1` when needed, and claims interface `0` before returning a session to the wallet UI.
+
+## Failure Handling
+
+- Unsupported browsers return an `unsupported` error and should keep the Ledger action disabled.
+- Browser cancellation returns `device_not_selected` and is safe to retry.
+- Browser permission failures return `permission_denied` and are safe to retry after the user grants access.
+- Open, configuration, or interface claim failures return `device_unavailable`, which covers disconnected devices, busy devices, and transport interruptions.
+
+All Ledger connection failures are represented by `HardwareWalletConnectionError` with a stable `code` and `retriable` flag so UI and telemetry can respond without parsing message text.
+
+## Security Boundary
+
+The bridge does not persist USB device handles, device serial numbers beyond the active session object, or private key material. Signing remains device-bound; the browser bridge only establishes transport and exposes a typed session for downstream transaction flows.

--- a/frontend/src/components/wallet/HardwareWalletPanel.tsx
+++ b/frontend/src/components/wallet/HardwareWalletPanel.tsx
@@ -59,7 +59,7 @@ export function HardwareWalletPanel({ onSessionChange }: Props) {
     >
       <h2 className="text-lg font-semibold text-neutral-100">Hardware wallet</h2>
       <p className="mt-1 text-sm text-neutral-400">
-        Sign batched task registrations with Ledger (WebHID) or Trezor Connect.
+        Sign batched task registrations with Ledger WebUSB or Trezor Connect.
       </p>
 
       <div className="mt-4 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- Added a Ledger WebUSB bridge that requests Ledger devices by vendor ID, opens/configures the selected device, and claims the USB interface before returning a typed hardware wallet session.
- Added stable hardware wallet connection error codes with retriable metadata for unsupported browsers, cancellation, permission denial, and device availability failures.
- Updated wallet UI copy and documented the WebUSB bridge behavior and security boundary.

## Verification
- npx jest app/lib/__tests__/hardwareWallet.test.ts --runInBand --watchman=false
- npx eslint app/lib/hardwareWallet.ts app/lib/__tests__/hardwareWallet.test.ts src/components/wallet/HardwareWalletPanel.tsx
- git diff --check

Closes #565