### PR TITLE
Add cross-chain state proof verifier

### DIFF
--- a/frontend/app/cross-chain/__tests__/StateProofVerifierPanel.test.tsx
+++ b/frontend/app/cross-chain/__tests__/StateProofVerifierPanel.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { StateProofVerifierPanel } from "../components/StateProofVerifierPanel";
+import { MOCK_BRIDGE_EVENTS, MOCK_TASKS } from "../useCrossChainTasks";
+
+const settledEvent = {
+  id: "be-settled",
+  taskId: "cct-1",
+  fromNetwork: "soroban" as const,
+  toNetwork: "ethereum" as const,
+  eventType: "settled" as const,
+  timestamp: "2026-06-29T11:55:00.000Z",
+};
+
+const validProof = {
+  proofId: "proof-1",
+  taskId: "cct-1",
+  sourceNetwork: "soroban",
+  targetNetwork: "ethereum",
+  sourceTxHash: "0xabc1",
+  stateRoot: "0x987654",
+  bridgeEventId: "be-settled",
+  observedAt: "2026-06-29T11:55:30.000Z",
+  secret: "hide-me",
+};
+
+function renderPanel() {
+  render(
+    <StateProofVerifierPanel
+      tasks={MOCK_TASKS}
+      bridgeEvents={[...MOCK_BRIDGE_EVENTS, settledEvent]}
+      now={new Date("2026-06-29T12:00:00.000Z")}
+    />,
+  );
+}
+
+describe("StateProofVerifierPanel", () => {
+  it("verifies a matching cross-chain state proof", () => {
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText("Cross-chain task"), {
+      target: { value: "cct-1" },
+    });
+    fireEvent.change(screen.getByLabelText("State proof JSON"), {
+      target: { value: JSON.stringify(validProof) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify state proof" }));
+
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(screen.getByText(/matches the selected task/i)).toBeInTheDocument();
+  });
+
+  it("shows retry guidance for malformed JSON", () => {
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText("State proof JSON"), {
+      target: { value: "{invalid" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify state proof" }));
+
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+    expect(screen.getByText("invalid_json")).toBeInTheDocument();
+    expect(screen.getByText(/request a fresh proof package/i)).toBeInTheDocument();
+  });
+
+  it("blocks a proof for a different selected task", () => {
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText("Cross-chain task"), {
+      target: { value: "cct-2" },
+    });
+    fireEvent.change(screen.getByLabelText("State proof JSON"), {
+      target: { value: JSON.stringify(validProof) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify state proof" }));
+
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+    expect(screen.getByText("task_mismatch")).toBeInTheDocument();
+    expect(screen.getByText(/manual review/i)).toBeInTheDocument();
+  });
+
+  it("redacts secret fields in the audit preview", () => {
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText("Cross-chain task"), {
+      target: { value: "cct-1" },
+    });
+    fireEvent.change(screen.getByLabelText("State proof JSON"), {
+      target: { value: JSON.stringify(validProof) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify state proof" }));
+
+    const auditPreview = screen.getByLabelText("Audit preview JSON");
+
+    expect(auditPreview).toHaveTextContent('"secret": "[redacted]"');
+    expect(auditPreview).not.toHaveTextContent("hide-me");
+  });
+});

--- a/frontend/app/cross-chain/__tests__/stateProofVerifier.test.ts
+++ b/frontend/app/cross-chain/__tests__/stateProofVerifier.test.ts
@@ -1,0 +1,108 @@
+import { MOCK_BRIDGE_EVENTS, MOCK_TASKS } from "../useCrossChainTasks";
+import { verifyStateProof } from "../stateProofVerifier";
+
+const now = new Date("2026-06-29T12:00:00.000Z");
+
+const settledEvent = {
+  id: "be-settled",
+  taskId: "cct-1",
+  fromNetwork: "soroban" as const,
+  toNetwork: "ethereum" as const,
+  eventType: "settled" as const,
+  timestamp: "2026-06-29T11:55:00.000Z",
+};
+
+const validProof = {
+  proofId: "proof-1",
+  taskId: "cct-1",
+  sourceNetwork: "soroban",
+  targetNetwork: "ethereum",
+  sourceTxHash: "0xabc1",
+  stateRoot: "0x987654",
+  bridgeEventId: "be-settled",
+  observedAt: "2026-06-29T11:55:30.000Z",
+  signer: "GVERIFIER123",
+  secret: "do-not-log",
+};
+
+describe("verifyStateProof", () => {
+  it("accepts a proof that matches a known task and settled bridge event", () => {
+    const result = verifyStateProof({
+      rawProof: JSON.stringify(validProof),
+      tasks: MOCK_TASKS,
+      bridgeEvents: [...MOCK_BRIDGE_EVENTS, settledEvent],
+      now,
+    });
+
+    expect(result.status).toBe("verified");
+    expect(result.code).toBe("verified");
+    expect(result.audit.taskId).toBe("cct-1");
+    expect(result.audit.redactedProof).toMatchObject({
+      proofId: "proof-1",
+      taskId: "cct-1",
+      secret: "[redacted]",
+    });
+  });
+
+  it("rejects malformed proof JSON without throwing", () => {
+    const result = verifyStateProof({
+      rawProof: "{not-json",
+      tasks: MOCK_TASKS,
+      bridgeEvents: MOCK_BRIDGE_EVENTS,
+      now,
+    });
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      code: "invalid_json",
+      retriable: true,
+    });
+  });
+
+  it("blocks a proof whose task does not match the selected task", () => {
+    const result = verifyStateProof({
+      rawProof: JSON.stringify({ ...validProof, taskId: "cct-2" }),
+      selectedTaskId: "cct-1",
+      tasks: MOCK_TASKS,
+      bridgeEvents: [...MOCK_BRIDGE_EVENTS, settledEvent],
+      now,
+    });
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      code: "task_mismatch",
+      retriable: false,
+    });
+  });
+
+  it("blocks proofs for networks not configured on the task", () => {
+    const result = verifyStateProof({
+      rawProof: JSON.stringify({ ...validProof, targetNetwork: "base" }),
+      tasks: MOCK_TASKS,
+      bridgeEvents: [...MOCK_BRIDGE_EVENTS, settledEvent],
+      now,
+    });
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      code: "network_mismatch",
+      retriable: false,
+    });
+  });
+
+  it("marks stale proofs as fallback results", () => {
+    const result = verifyStateProof({
+      rawProof: JSON.stringify({ ...validProof, observedAt: "2026-06-29T09:30:00.000Z" }),
+      tasks: MOCK_TASKS,
+      bridgeEvents: [...MOCK_BRIDGE_EVENTS, settledEvent],
+      now,
+      maxProofAgeMs: 30 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      status: "fallback",
+      code: "stale_proof",
+      retriable: true,
+    });
+  });
+});

--- a/frontend/app/cross-chain/components/CrossChainTaskManager.tsx
+++ b/frontend/app/cross-chain/components/CrossChainTaskManager.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import { useCrossChainTasks } from '../useCrossChainTasks';
 import { CrossChainTaskRow } from './CrossChainTaskRow';
 import { NETWORKS, type NetworkId, type CrossChainTaskStatus } from '../types';
+import { StateProofVerifierPanel } from './StateProofVerifierPanel';
 
 const STATUS_FILTERS: Array<CrossChainTaskStatus | 'all'> = ['all', 'active', 'paused', 'completed', 'failed'];
 
@@ -17,6 +18,7 @@ const BRIDGE_EVENT_LABELS = {
 export function CrossChainTaskManager() {
   const {
     tasks,
+    allTasks,
     bridgeEvents,
     networkFilter,
     statusFilter,
@@ -166,6 +168,8 @@ export function CrossChainTaskManager() {
             </div>
           )}
         </section>
+
+        <StateProofVerifierPanel tasks={allTasks} bridgeEvents={bridgeEvents} />
       </div>
     </div>
   );

--- a/frontend/app/cross-chain/components/StateProofVerifierPanel.tsx
+++ b/frontend/app/cross-chain/components/StateProofVerifierPanel.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import type { BridgeEvent, CrossChainTask } from "../types";
+import {
+  verifyStateProof,
+  type StateProofVerificationResult,
+} from "../stateProofVerifier";
+
+type StateProofVerifierPanelProps = {
+  tasks: CrossChainTask[];
+  bridgeEvents: BridgeEvent[];
+  now?: Date;
+};
+
+const EMPTY_PROOF = `{
+  "proofId": "proof-...",
+  "taskId": "cct-1",
+  "sourceNetwork": "soroban",
+  "targetNetwork": "ethereum",
+  "sourceTxHash": "0x...",
+  "stateRoot": "0x...",
+  "bridgeEventId": "be-...",
+  "observedAt": "2026-06-29T12:00:00.000Z"
+}`;
+
+const STATUS_LABELS: Record<StateProofVerificationResult["status"], string> = {
+  verified: "Verified",
+  blocked: "Blocked",
+  fallback: "Fallback",
+};
+
+const STATUS_STYLES: Record<StateProofVerificationResult["status"], string> = {
+  verified: "border-emerald-700 bg-emerald-950/40 text-emerald-200",
+  blocked: "border-red-800 bg-red-950/35 text-red-200",
+  fallback: "border-amber-700 bg-amber-950/35 text-amber-200",
+};
+
+function fallbackGuidance(result: StateProofVerificationResult): string {
+  if (result.retriable) {
+    return "Request a fresh proof package from the relayer and retry verification before approving cross-chain execution.";
+  }
+
+  return "Route this proof to manual review because it conflicts with the selected task configuration.";
+}
+
+export function StateProofVerifierPanel({
+  tasks,
+  bridgeEvents,
+  now,
+}: StateProofVerifierPanelProps) {
+  const [selectedTaskId, setSelectedTaskId] = useState(tasks[0]?.id ?? "");
+  const [rawProof, setRawProof] = useState(EMPTY_PROOF);
+  const [result, setResult] = useState<StateProofVerificationResult | null>(null);
+
+  const selectedTask = useMemo(
+    () => tasks.find((task) => task.id === selectedTaskId),
+    [selectedTaskId, tasks],
+  );
+
+  const handleVerify = () => {
+    setResult(
+      verifyStateProof({
+        rawProof,
+        selectedTaskId: selectedTaskId || undefined,
+        tasks,
+        bridgeEvents,
+        now,
+      }),
+    );
+  };
+
+  return (
+    <section
+      className="rounded-xl border border-neutral-800 bg-neutral-900 p-5"
+      aria-label="Cross-chain state proof verifier"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-neutral-100">
+            State Proof Verifier
+          </h2>
+          <p className="mt-1 max-w-2xl text-xs leading-5 text-neutral-400">
+            Validate a relayer proof against loaded task state, source chain confirmation,
+            and settled bridge events before accepting cross-chain execution.
+          </p>
+        </div>
+        <span className="rounded-full border border-neutral-700 px-3 py-1 text-xs text-neutral-400">
+          Local verification
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[0.85fr_1.15fr]">
+        <div className="space-y-4">
+          <label className="block text-xs font-medium text-neutral-300">
+            Cross-chain task
+            <select
+              aria-label="Cross-chain task"
+              value={selectedTaskId}
+              onChange={(event) => setSelectedTaskId(event.target.value)}
+              className="mt-2 w-full rounded-lg border border-neutral-700 bg-neutral-950 px-3 py-2 text-sm text-neutral-100"
+            >
+              {tasks.map((task) => (
+                <option key={task.id} value={task.id}>
+                  {task.title}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {selectedTask ? (
+            <div className="rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-3 text-xs text-neutral-400">
+              <p className="font-medium text-neutral-200">{selectedTask.id}</p>
+              <p className="mt-1">
+                Networks: {selectedTask.networks.join(" -> ")}
+              </p>
+              <p className="mt-1 capitalize">
+                Status: {selectedTask.overallStatus}
+              </p>
+            </div>
+          ) : (
+            <p className="rounded-lg border border-amber-800 bg-amber-950/30 px-3 py-2 text-xs text-amber-200">
+              No cross-chain task is available for proof verification.
+            </p>
+          )}
+        </div>
+
+        <label className="block text-xs font-medium text-neutral-300">
+          State proof JSON
+          <textarea
+            aria-label="State proof JSON"
+            value={rawProof}
+            onChange={(event) => setRawProof(event.target.value)}
+            rows={11}
+            spellCheck={false}
+            className="mt-2 min-h-56 w-full resize-y rounded-lg border border-neutral-700 bg-neutral-950 px-3 py-2 font-mono text-xs leading-5 text-neutral-100"
+          />
+        </label>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleVerify}
+          disabled={!rawProof.trim() || tasks.length === 0}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-neutral-700 disabled:text-neutral-500"
+        >
+          Verify state proof
+        </button>
+        <p className="text-xs text-neutral-500">
+          Proof JSON is evaluated in-browser and is not persisted.
+        </p>
+      </div>
+
+      {result ? (
+        <div className={`mt-5 rounded-xl border p-4 ${STATUS_STYLES[result.status]}`}>
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-sm font-semibold">{STATUS_LABELS[result.status]}</p>
+            <code className="rounded border border-current/30 px-2 py-0.5 text-xs">
+              {result.code}
+            </code>
+          </div>
+          <p className="mt-2 text-sm">{result.message}</p>
+          {result.status !== "verified" ? (
+            <p className="mt-2 text-xs">{fallbackGuidance(result)}</p>
+          ) : null}
+
+          <details className="mt-4">
+            <summary className="cursor-pointer text-xs font-semibold">
+              Audit preview
+            </summary>
+            <pre
+              aria-label="Audit preview JSON"
+              className="mt-2 max-h-60 overflow-auto rounded-lg bg-black/30 p-3 text-xs leading-5 text-neutral-100"
+            >
+              {JSON.stringify(result.audit.redactedProof, null, 2)}
+            </pre>
+          </details>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/app/cross-chain/stateProofVerifier.ts
+++ b/frontend/app/cross-chain/stateProofVerifier.ts
@@ -1,0 +1,238 @@
+import type { BridgeEvent, CrossChainTask, NetworkId } from "./types";
+
+const DEFAULT_MAX_PROOF_AGE_MS = 60 * 60 * 1000;
+const SENSITIVE_KEY_PATTERN = /(secret|private|seed|token|signature|credential|password)/i;
+
+export type StateProofStatus = "verified" | "blocked" | "fallback";
+
+export type StateProofCode =
+  | "verified"
+  | "invalid_json"
+  | "invalid_schema"
+  | "task_not_found"
+  | "task_mismatch"
+  | "network_mismatch"
+  | "source_not_confirmed"
+  | "bridge_event_missing"
+  | "bridge_event_unsettled"
+  | "stale_proof";
+
+export type StateProofPayload = {
+  proofId: string;
+  taskId: string;
+  sourceNetwork: NetworkId;
+  targetNetwork: NetworkId;
+  sourceTxHash: string;
+  stateRoot: string;
+  bridgeEventId: string;
+  observedAt: string;
+  signer?: string;
+  [key: string]: unknown;
+};
+
+export type StateProofAudit = {
+  taskId?: string;
+  bridgeEventId?: string;
+  sourceNetwork?: NetworkId;
+  targetNetwork?: NetworkId;
+  checkedAt: string;
+  redactedProof: Record<string, unknown>;
+};
+
+export type StateProofVerificationResult = {
+  status: StateProofStatus;
+  code: StateProofCode;
+  message: string;
+  retriable: boolean;
+  audit: StateProofAudit;
+};
+
+type VerifyStateProofInput = {
+  rawProof: string;
+  selectedTaskId?: string;
+  tasks: CrossChainTask[];
+  bridgeEvents: BridgeEvent[];
+  now?: Date;
+  maxProofAgeMs?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function redactProof(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) return {};
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key) ? "[redacted]" : entry,
+    ]),
+  );
+}
+
+function makeAudit(proof: unknown, now: Date): StateProofAudit {
+  const payload = isRecord(proof) ? proof : {};
+  return {
+    taskId: typeof payload.taskId === "string" ? payload.taskId : undefined,
+    bridgeEventId: typeof payload.bridgeEventId === "string" ? payload.bridgeEventId : undefined,
+    sourceNetwork: payload.sourceNetwork as NetworkId | undefined,
+    targetNetwork: payload.targetNetwork as NetworkId | undefined,
+    checkedAt: now.toISOString(),
+    redactedProof: redactProof(payload),
+  };
+}
+
+function result(
+  status: StateProofStatus,
+  code: StateProofCode,
+  message: string,
+  retriable: boolean,
+  audit: StateProofAudit,
+): StateProofVerificationResult {
+  return { status, code, message, retriable, audit };
+}
+
+function parsePayload(value: unknown): StateProofPayload | null {
+  if (!isRecord(value)) return null;
+
+  const requiredFields = [
+    "proofId",
+    "taskId",
+    "sourceNetwork",
+    "targetNetwork",
+    "sourceTxHash",
+    "stateRoot",
+    "bridgeEventId",
+    "observedAt",
+  ];
+
+  const hasRequiredShape = requiredFields.every((field) => typeof value[field] === "string");
+  if (!hasRequiredShape) return null;
+
+  return value as StateProofPayload;
+}
+
+export function verifyStateProof({
+  rawProof,
+  selectedTaskId,
+  tasks,
+  bridgeEvents,
+  now = new Date(),
+  maxProofAgeMs = DEFAULT_MAX_PROOF_AGE_MS,
+}: VerifyStateProofInput): StateProofVerificationResult {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(rawProof);
+  } catch {
+    return result(
+      "blocked",
+      "invalid_json",
+      "Proof payload is not valid JSON.",
+      true,
+      makeAudit({}, now),
+    );
+  }
+
+  const audit = makeAudit(parsed, now);
+  const payload = parsePayload(parsed);
+  if (!payload) {
+    return result(
+      "blocked",
+      "invalid_schema",
+      "Proof payload is missing required state proof fields.",
+      true,
+      audit,
+    );
+  }
+
+  if (selectedTaskId && payload.taskId !== selectedTaskId) {
+    return result(
+      "blocked",
+      "task_mismatch",
+      "Proof task ID does not match the selected cross-chain task.",
+      false,
+      audit,
+    );
+  }
+
+  const task = tasks.find((candidate) => candidate.id === payload.taskId);
+  if (!task) {
+    return result(
+      "blocked",
+      "task_not_found",
+      "Proof references a task that is not loaded in the workspace.",
+      true,
+      audit,
+    );
+  }
+
+  if (!task.networks.includes(payload.sourceNetwork) || !task.networks.includes(payload.targetNetwork)) {
+    return result(
+      "blocked",
+      "network_mismatch",
+      "Proof networks are not configured for the referenced task.",
+      false,
+      audit,
+    );
+  }
+
+  const sourceStatus = task.chainStatuses[payload.sourceNetwork];
+  if (sourceStatus?.status !== "confirmed" || sourceStatus.txHash !== payload.sourceTxHash) {
+    return result(
+      "fallback",
+      "source_not_confirmed",
+      "Source chain state is not confirmed with the supplied transaction hash.",
+      true,
+      audit,
+    );
+  }
+
+  const bridgeEvent = bridgeEvents.find(
+    (event) =>
+      event.id === payload.bridgeEventId &&
+      event.taskId === payload.taskId &&
+      event.fromNetwork === payload.sourceNetwork &&
+      event.toNetwork === payload.targetNetwork,
+  );
+
+  if (!bridgeEvent) {
+    return result(
+      "fallback",
+      "bridge_event_missing",
+      "No matching bridge event was found for this proof.",
+      true,
+      audit,
+    );
+  }
+
+  if (bridgeEvent.eventType !== "settled") {
+    return result(
+      "fallback",
+      "bridge_event_unsettled",
+      "Bridge event has not settled on the target network.",
+      true,
+      audit,
+    );
+  }
+
+  const observedAt = Date.parse(payload.observedAt);
+  if (!Number.isFinite(observedAt) || now.getTime() - observedAt > maxProofAgeMs) {
+    return result(
+      "fallback",
+      "stale_proof",
+      "Proof observation is outside the accepted freshness window.",
+      true,
+      audit,
+    );
+  }
+
+  return result(
+    "verified",
+    "verified",
+    "State proof matches the selected task, source transaction, and settled bridge event.",
+    false,
+    audit,
+  );
+}

--- a/frontend/docs/cross-chain-state-proof-verifier.md
+++ b/frontend/docs/cross-chain-state-proof-verifier.md
@@ -1,0 +1,37 @@
+# Cross-chain State Proof Verifier
+
+The cross-chain task manager includes a local state proof verifier for relayer proof packages. The verifier compares pasted proof JSON against the loaded task registry, the source chain confirmation status, and the bridge event log before the UI treats a proof as acceptable.
+
+## Proof Shape
+
+The verifier expects JSON with these fields:
+
+- `proofId`
+- `taskId`
+- `sourceNetwork`
+- `targetNetwork`
+- `sourceTxHash`
+- `stateRoot`
+- `bridgeEventId`
+- `observedAt`
+
+Optional metadata is accepted, but keys that look sensitive, such as `secret`, `privateKey`, `token`, `signature`, or `credential`, are redacted from the audit preview.
+
+## Result Codes
+
+- `verified`: task, networks, source transaction, settled bridge event, and freshness checks all passed.
+- `invalid_json`: payload could not be parsed.
+- `invalid_schema`: required proof fields are missing.
+- `task_not_found`: proof references a task that is not loaded.
+- `task_mismatch`: proof conflicts with the selected task.
+- `network_mismatch`: proof networks are not configured on the task.
+- `source_not_confirmed`: source chain status or transaction hash does not match.
+- `bridge_event_missing`: no matching bridge event exists.
+- `bridge_event_unsettled`: bridge event exists but has not settled.
+- `stale_proof`: proof observation is outside the accepted freshness window.
+
+## Security Review
+
+All proof input is treated as attacker-controlled. The verifier does not evaluate code, fetch remote URLs, persist proof payloads, or log raw sensitive fields. Result handling is based on stable codes instead of parsing human-readable messages.
+
+The browser-side verifier is a preflight and review surface, not a replacement for contract-level verification. Any blocked non-retriable proof should go to manual review. Retriable fallback results should request a fresh proof package from the relayer before cross-chain execution is approved.


### PR DESCRIPTION
## Summary
- Added a local cross-chain state proof verifier that validates proof JSON against loaded task state, source confirmation, bridge events, and freshness windows.
- Added a verifier panel to the cross-chain task manager with explicit verified, blocked, and fallback result states plus redacted audit output.
- Documented proof shape, result codes, fallback behavior, and security boundaries.

## Verification
- npx jest app/cross-chain/__tests__/stateProofVerifier.test.ts app/cross-chain/__tests__/StateProofVerifierPanel.test.tsx app/cross-chain/__tests__/useCrossChainTasks.test.ts --runInBand --watchman=false
- npx eslint app/cross-chain/stateProofVerifier.ts app/cross-chain/components/StateProofVerifierPanel.tsx app/cross-chain/components/CrossChainTaskManager.tsx app/cross-chain/__tests__/stateProofVerifier.test.ts app/cross-chain/__tests__/StateProofVerifierPanel.test.tsx
- git diff --check

Closes #560