### PR TITLE
Add optimistic transaction reconciler

### DIFF
--- a/frontend/components/__tests__/OptimisticTxReconcilerPanel.test.tsx
+++ b/frontend/components/__tests__/OptimisticTxReconcilerPanel.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { OptimisticTxReconcilerPanel } from "../transaction/OptimisticTxReconcilerPanel";
+import type {
+  OptimisticTransaction,
+  OptimisticTxAuditEvent,
+} from "@/src/lib/optimisticTxReconciler";
+
+const transactions: OptimisticTransaction[] = [
+  {
+    clientTxId: "client-1",
+    taskId: "task-1",
+    operation: "register_task",
+    state: "optimistic",
+    optimisticPayload: {},
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    clientTxId: "client-2",
+    taskId: "task-2",
+    operation: "update_task",
+    state: "conflict",
+    optimisticPayload: {},
+    createdAt: 1,
+    updatedAt: 2,
+    conflictKeys: ["intervalSec"],
+  },
+];
+
+const auditEvents: OptimisticTxAuditEvent[] = [
+  {
+    code: "conflict",
+    clientTxId: "client-2",
+    taskId: "task-2",
+    operation: "update_task",
+    retriable: false,
+    timestamp: 2,
+    message: "Server confirmation conflicted on: intervalSec.",
+    redactedPayload: { intervalSec: 60, secret: "[redacted]" },
+  },
+];
+
+describe("OptimisticTxReconcilerPanel", () => {
+  it("renders transaction state counts and active transaction rows", () => {
+    render(
+      <OptimisticTxReconcilerPanel
+        transactions={transactions}
+        auditEvents={auditEvents}
+      />,
+    );
+
+    expect(screen.getByText("Optimistic Transaction Reconciler")).toBeInTheDocument();
+    expect(screen.getAllByText("Optimistic").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Conflict").length).toBeGreaterThan(0);
+    expect(screen.getByText("task-1")).toBeInTheDocument();
+    expect(screen.getByText("client-2")).toBeInTheDocument();
+  });
+
+  it("shows the latest audit event without leaking sensitive values", () => {
+    render(
+      <OptimisticTxReconcilerPanel
+        transactions={transactions}
+        auditEvents={auditEvents}
+      />,
+    );
+
+    expect(screen.getByText(/Server confirmation conflicted/i)).toBeInTheDocument();
+    const latestAudit = screen.getByLabelText("Latest audit payload");
+    expect(latestAudit).toHaveTextContent('"secret": "[redacted]"');
+    expect(latestAudit).not.toHaveTextContent("do-not-log");
+  });
+
+  it("renders an empty state when no transactions are tracked", () => {
+    render(<OptimisticTxReconcilerPanel transactions={[]} auditEvents={[]} />);
+
+    expect(screen.getByText(/No optimistic transactions are being tracked/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/transaction/OptimisticTxReconcilerPanel.tsx
+++ b/frontend/components/transaction/OptimisticTxReconcilerPanel.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React from "react";
+import {
+  summarizeOptimisticTransactions,
+  type OptimisticTransaction,
+  type OptimisticTxAuditEvent,
+  type OptimisticTxState,
+} from "@/src/lib/optimisticTxReconciler";
+
+type OptimisticTxReconcilerPanelProps = {
+  transactions: OptimisticTransaction[];
+  auditEvents: OptimisticTxAuditEvent[];
+};
+
+const STATE_LABELS: Record<OptimisticTxState, string> = {
+  optimistic: "Optimistic",
+  confirmed: "Confirmed",
+  rolled_back: "Rolled back",
+  conflict: "Conflict",
+  stale: "Stale",
+};
+
+const STATE_STYLES: Record<OptimisticTxState, string> = {
+  optimistic: "text-sky-300 border-sky-800 bg-sky-950/40",
+  confirmed: "text-emerald-300 border-emerald-800 bg-emerald-950/35",
+  rolled_back: "text-red-300 border-red-800 bg-red-950/35",
+  conflict: "text-amber-300 border-amber-800 bg-amber-950/35",
+  stale: "text-violet-300 border-violet-800 bg-violet-950/35",
+};
+
+const SUMMARY_ORDER: OptimisticTxState[] = [
+  "optimistic",
+  "confirmed",
+  "rolled_back",
+  "conflict",
+  "stale",
+];
+
+export function OptimisticTxReconcilerPanel({
+  transactions,
+  auditEvents,
+}: OptimisticTxReconcilerPanelProps) {
+  const summary = summarizeOptimisticTransactions(transactions);
+  const latestAudit = auditEvents[0];
+
+  return (
+    <section
+      aria-label="Optimistic transaction reconciler"
+      className="rounded-lg border border-neutral-800 bg-neutral-950 p-4 text-neutral-100"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">Optimistic Transaction Reconciler</h2>
+          <p className="mt-1 max-w-2xl text-xs leading-5 text-neutral-400">
+            Tracks optimistic task mutations against server and on-chain confirmations.
+          </p>
+        </div>
+        <span className="rounded-full border border-neutral-700 px-3 py-1 text-xs text-neutral-400">
+          {transactions.length} tracked
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-5">
+        {SUMMARY_ORDER.map((state) => (
+          <div
+            key={state}
+            className={`rounded-md border px-3 py-2 ${STATE_STYLES[state]}`}
+          >
+            <p className="text-[11px] font-medium">{STATE_LABELS[state]}</p>
+            <p className="mt-1 text-lg font-semibold">{summary[state]}</p>
+          </div>
+        ))}
+      </div>
+
+      {transactions.length === 0 ? (
+        <p className="mt-4 rounded-md border border-neutral-800 bg-neutral-900 px-3 py-3 text-sm text-neutral-400">
+          No optimistic transactions are being tracked.
+        </p>
+      ) : (
+        <div className="mt-4 overflow-x-auto rounded-lg border border-neutral-800">
+          <table className="w-full text-left text-xs" aria-label="Tracked optimistic transactions">
+            <thead className="bg-neutral-900 text-neutral-400">
+              <tr>
+                <th className="px-3 py-2 font-medium">Client Tx</th>
+                <th className="px-3 py-2 font-medium">Task</th>
+                <th className="px-3 py-2 font-medium">Operation</th>
+                <th className="px-3 py-2 font-medium">State</th>
+              </tr>
+            </thead>
+            <tbody>
+              {transactions.map((transaction) => (
+                <tr key={transaction.clientTxId} className="border-t border-neutral-800">
+                  <td className="px-3 py-2 font-mono text-neutral-300">
+                    {transaction.clientTxId}
+                  </td>
+                  <td className="px-3 py-2 text-neutral-300">{transaction.taskId}</td>
+                  <td className="px-3 py-2 text-neutral-400">{transaction.operation}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`rounded border px-2 py-0.5 ${STATE_STYLES[transaction.state]}`}
+                    >
+                      {STATE_LABELS[transaction.state]}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {latestAudit ? (
+        <div className="mt-4 rounded-lg border border-neutral-800 bg-neutral-900 px-3 py-3">
+          <p className="text-xs font-semibold text-neutral-300">Latest audit event</p>
+          <p className="mt-1 text-sm text-neutral-200">{latestAudit.message}</p>
+          <pre
+            aria-label="Latest audit payload"
+            className="mt-2 overflow-auto rounded bg-black/30 p-2 text-xs text-neutral-300"
+          >
+            {JSON.stringify(latestAudit.redactedPayload, null, 2)}
+          </pre>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/docs/optimistic-transaction-reconciler.md
+++ b/frontend/docs/optimistic-transaction-reconciler.md
@@ -1,0 +1,25 @@
+# Optimistic Transaction Reconciler
+
+The optimistic transaction reconciler provides a shared state machine for frontend flows that update task state before the network or API has confirmed the transaction.
+
+## States
+
+- `optimistic`: local UI state has been applied and is waiting for confirmation.
+- `confirmed`: server or on-chain confirmation matched the tracked task, operation, and transaction hash.
+- `rolled_back`: confirmation failed and the caller should restore the rollback payload.
+- `conflict`: confirmation arrived, but authoritative fields listed in `compareKeys` did not match the optimistic payload.
+- `stale`: no confirmation arrived before the reconciliation window expired.
+
+## Matching Rules
+
+Confirmations are accepted only when they match the tracked `taskId` and `operation`. If both sides provide a transaction hash, the hashes must also match. Payload conflict checks are opt-in through `compareKeys`; transient UI fields such as `pending` status should not be treated as authoritative by default.
+
+## Security Review
+
+Confirmation data is treated as untrusted input. The reconciler does not execute payload content, does not fetch remote data, and does not expose raw sensitive fields in audit events. Keys that resemble secrets, credentials, tokens, signatures, private data, or XDR are redacted before audit output is returned to UI surfaces.
+
+`conflict` and `stale` states should be shown to users as review or retry states. They should not silently overwrite local task state because they indicate either a mismatch with authoritative data or a missing confirmation.
+
+## Integration
+
+Use `createOptimisticTransaction` when applying local state. Call `reconcileOptimisticTransactions` when server or on-chain confirmations arrive. React surfaces can use `useOptimisticTxReconciler` and render `OptimisticTxReconcilerPanel` to display state counts, tracked transactions, and redacted audit details.

--- a/frontend/src/hooks/__tests__/useOptimisticTxReconciler.test.tsx
+++ b/frontend/src/hooks/__tests__/useOptimisticTxReconciler.test.tsx
@@ -1,0 +1,92 @@
+import { act, renderHook } from "@testing-library/react";
+import { useOptimisticTxReconciler } from "../useOptimisticTxReconciler";
+
+const baseTime = Date.parse("2026-06-29T12:00:00.000Z");
+
+describe("useOptimisticTxReconciler", () => {
+  it("tracks optimistic transactions and reconciles confirmations", () => {
+    const { result } = renderHook(() =>
+      useOptimisticTxReconciler({ now: () => baseTime }),
+    );
+
+    act(() => {
+      result.current.trackOptimisticTransaction({
+        clientTxId: "client-1",
+        taskId: "task-1",
+        operation: "register_task",
+        txHash: "hash-1",
+        optimisticPayload: { status: "pending" },
+      });
+    });
+
+    expect(result.current.summary.optimistic).toBe(1);
+
+    act(() => {
+      result.current.reconcile([
+        {
+          taskId: "task-1",
+          operation: "register_task",
+          txHash: "hash-1",
+          status: "confirmed",
+          serverPayload: { status: "active" },
+          observedAt: baseTime + 1000,
+        },
+      ]);
+    });
+
+    expect(result.current.summary.confirmed).toBe(1);
+    expect(result.current.transactions[0].state).toBe("confirmed");
+    expect(result.current.auditEvents[0].code).toBe("confirmed");
+  });
+
+  it("marks stale transactions using the hook clock", () => {
+    let currentTime = baseTime;
+    const { result } = renderHook(() =>
+      useOptimisticTxReconciler({
+        now: () => currentTime,
+        staleAfterMs: 1000,
+      }),
+    );
+
+    act(() => {
+      result.current.trackOptimisticTransaction({
+        clientTxId: "client-2",
+        taskId: "task-2",
+        operation: "delete_task",
+        optimisticPayload: { deleted: true },
+      });
+    });
+
+    currentTime = baseTime + 5000;
+
+    act(() => {
+      result.current.reconcile([]);
+    });
+
+    expect(result.current.summary.stale).toBe(1);
+    expect(result.current.auditEvents[0]).toMatchObject({
+      code: "stale",
+      retriable: true,
+    });
+  });
+
+  it("clears reconciliation state", () => {
+    const { result } = renderHook(() =>
+      useOptimisticTxReconciler({ now: () => baseTime }),
+    );
+
+    act(() => {
+      result.current.trackOptimisticTransaction({
+        clientTxId: "client-3",
+        taskId: "task-3",
+        operation: "update_task",
+        optimisticPayload: { intervalSec: 60 },
+      });
+      result.current.clear();
+    });
+
+    expect(result.current.transactions).toEqual([]);
+    expect(result.current.auditEvents).toEqual([]);
+    expect(result.current.summary.optimistic).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useOptimisticTxReconciler.ts
+++ b/frontend/src/hooks/useOptimisticTxReconciler.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  createOptimisticTransaction,
+  reconcileOptimisticTransactions,
+  summarizeOptimisticTransactions,
+  type OptimisticTransaction,
+  type OptimisticTxAuditEvent,
+  type TransactionConfirmation,
+} from "@/src/lib/optimisticTxReconciler";
+
+type TrackOptimisticTransactionInput = Omit<
+  Parameters<typeof createOptimisticTransaction>[0],
+  "createdAt"
+> & {
+  createdAt?: number;
+};
+
+type UseOptimisticTxReconcilerOptions = {
+  staleAfterMs?: number;
+  now?: () => number;
+};
+
+export function useOptimisticTxReconciler({
+  staleAfterMs,
+  now = Date.now,
+}: UseOptimisticTxReconcilerOptions = {}) {
+  const [transactions, setTransactions] = useState<OptimisticTransaction[]>([]);
+  const [auditEvents, setAuditEvents] = useState<OptimisticTxAuditEvent[]>([]);
+
+  const trackOptimisticTransaction = useCallback(
+    (input: TrackOptimisticTransactionInput) => {
+      setTransactions((current) => [
+        createOptimisticTransaction({
+          ...input,
+          createdAt: input.createdAt ?? now(),
+        }),
+        ...current.filter((transaction) => transaction.clientTxId !== input.clientTxId),
+      ]);
+    },
+    [now],
+  );
+
+  const reconcile = useCallback(
+    (confirmations: TransactionConfirmation[]) => {
+      setTransactions((current) => {
+        const result = reconcileOptimisticTransactions({
+          transactions: current,
+          confirmations,
+          now: now(),
+          staleAfterMs,
+        });
+
+        if (result.auditEvents.length > 0) {
+          setAuditEvents((existing) => [...result.auditEvents, ...existing].slice(0, 100));
+        }
+
+        return result.transactions;
+      });
+    },
+    [now, staleAfterMs],
+  );
+
+  const clear = useCallback(() => {
+    setTransactions([]);
+    setAuditEvents([]);
+  }, []);
+
+  const summary = useMemo(
+    () => summarizeOptimisticTransactions(transactions),
+    [transactions],
+  );
+
+  return {
+    transactions,
+    auditEvents,
+    summary,
+    trackOptimisticTransaction,
+    reconcile,
+    clear,
+  };
+}

--- a/frontend/src/lib/__tests__/optimisticTxReconciler.test.ts
+++ b/frontend/src/lib/__tests__/optimisticTxReconciler.test.ts
@@ -1,0 +1,189 @@
+import {
+  createOptimisticTransaction,
+  reconcileOptimisticTransactions,
+  summarizeOptimisticTransactions,
+} from "../optimisticTxReconciler";
+
+const baseTime = Date.parse("2026-06-29T12:00:00.000Z");
+
+describe("optimisticTxReconciler", () => {
+  it("confirms a matching optimistic transaction with server state", () => {
+    const optimistic = createOptimisticTransaction({
+      clientTxId: "client-1",
+      taskId: "task-1",
+      operation: "register_task",
+      txHash: "hash-1",
+      optimisticPayload: {
+        status: "pending",
+        contract: "CABC",
+        secret: "hidden",
+      },
+      createdAt: baseTime,
+    });
+
+    const result = reconcileOptimisticTransactions({
+      transactions: [optimistic],
+      confirmations: [
+        {
+          taskId: "task-1",
+          operation: "register_task",
+          txHash: "hash-1",
+          status: "confirmed",
+          serverPayload: { status: "active", contract: "CABC" },
+          observedAt: baseTime + 1_000,
+        },
+      ],
+      now: baseTime + 1_000,
+    });
+
+    expect(result.transactions[0]).toMatchObject({
+      state: "confirmed",
+      confirmedPayload: { status: "active", contract: "CABC" },
+    });
+    expect(result.auditEvents[0]).toMatchObject({
+      code: "confirmed",
+      clientTxId: "client-1",
+      taskId: "task-1",
+      retriable: false,
+    });
+    expect(result.auditEvents[0].redactedPayload).toMatchObject({
+      status: "active",
+      contract: "CABC",
+    });
+  });
+
+  it("rolls back a failed transaction and redacts sensitive optimistic fields", () => {
+    const optimistic = createOptimisticTransaction({
+      clientTxId: "client-2",
+      taskId: "task-2",
+      operation: "update_task",
+      txHash: "hash-2",
+      optimisticPayload: {
+        intervalSec: 60,
+        privateKey: "do-not-log",
+      },
+      rollbackPayload: {
+        intervalSec: 300,
+      },
+      createdAt: baseTime,
+    });
+
+    const result = reconcileOptimisticTransactions({
+      transactions: [optimistic],
+      confirmations: [
+        {
+          taskId: "task-2",
+          operation: "update_task",
+          txHash: "hash-2",
+          status: "failed",
+          error: "tx_bad_seq",
+          observedAt: baseTime + 2_000,
+        },
+      ],
+      now: baseTime + 2_000,
+    });
+
+    expect(result.transactions[0]).toMatchObject({
+      state: "rolled_back",
+      rollbackPayload: { intervalSec: 300 },
+      error: "tx_bad_seq",
+    });
+    expect(result.auditEvents[0].redactedPayload).toMatchObject({
+      intervalSec: 300,
+    });
+    expect(JSON.stringify(result.auditEvents)).not.toContain("do-not-log");
+  });
+
+  it("detects conflicts when a confirmation does not match the optimistic payload", () => {
+    const optimistic = createOptimisticTransaction({
+      clientTxId: "client-3",
+      taskId: "task-3",
+      operation: "update_task",
+      txHash: "hash-3",
+      optimisticPayload: { intervalSec: 900 },
+      createdAt: baseTime,
+      compareKeys: ["intervalSec"],
+    });
+
+    const result = reconcileOptimisticTransactions({
+      transactions: [optimistic],
+      confirmations: [
+        {
+          taskId: "task-3",
+          operation: "update_task",
+          txHash: "hash-3",
+          status: "confirmed",
+          serverPayload: { intervalSec: 60 },
+          observedAt: baseTime + 3_000,
+        },
+      ],
+      now: baseTime + 3_000,
+    });
+
+    expect(result.transactions[0]).toMatchObject({
+      state: "conflict",
+      conflictKeys: ["intervalSec"],
+    });
+    expect(result.auditEvents[0]).toMatchObject({
+      code: "conflict",
+      retriable: false,
+    });
+  });
+
+  it("marks stale optimistic transactions for fallback review", () => {
+    const optimistic = createOptimisticTransaction({
+      clientTxId: "client-4",
+      taskId: "task-4",
+      operation: "delete_task",
+      txHash: "hash-4",
+      optimisticPayload: { deleted: true },
+      createdAt: baseTime,
+    });
+
+    const result = reconcileOptimisticTransactions({
+      transactions: [optimistic],
+      confirmations: [],
+      now: baseTime + 10 * 60 * 1000,
+      staleAfterMs: 5 * 60 * 1000,
+    });
+
+    expect(result.transactions[0]).toMatchObject({
+      state: "stale",
+      staleAt: baseTime + 10 * 60 * 1000,
+    });
+    expect(result.auditEvents[0]).toMatchObject({
+      code: "stale",
+      retriable: true,
+    });
+  });
+
+  it("summarizes reconciler health for UI surfaces", () => {
+    const transactions = [
+      createOptimisticTransaction({
+        clientTxId: "client-5",
+        taskId: "task-5",
+        operation: "register_task",
+        optimisticPayload: {},
+        createdAt: baseTime,
+      }),
+      {
+        ...createOptimisticTransaction({
+          clientTxId: "client-6",
+          taskId: "task-6",
+          operation: "update_task",
+          optimisticPayload: {},
+          createdAt: baseTime,
+        }),
+        state: "conflict" as const,
+      },
+    ];
+
+    expect(summarizeOptimisticTransactions(transactions)).toEqual({
+      optimistic: 1,
+      confirmed: 0,
+      rolled_back: 0,
+      conflict: 1,
+      stale: 0,
+    });
+  });
+});

--- a/frontend/src/lib/optimisticTxReconciler.ts
+++ b/frontend/src/lib/optimisticTxReconciler.ts
@@ -1,0 +1,286 @@
+export type OptimisticTxState =
+  | "optimistic"
+  | "confirmed"
+  | "rolled_back"
+  | "conflict"
+  | "stale";
+
+export type OptimisticTxOperation =
+  | "register_task"
+  | "update_task"
+  | "delete_task"
+  | "execute_task"
+  | "custom";
+
+export type OptimisticTxPayload = Record<string, unknown>;
+
+export type OptimisticTransaction = {
+  clientTxId: string;
+  taskId: string;
+  operation: OptimisticTxOperation;
+  state: OptimisticTxState;
+  txHash?: string;
+  optimisticPayload: OptimisticTxPayload;
+  rollbackPayload?: OptimisticTxPayload;
+  confirmedPayload?: OptimisticTxPayload;
+  compareKeys?: string[];
+  createdAt: number;
+  updatedAt: number;
+  confirmedAt?: number;
+  rolledBackAt?: number;
+  staleAt?: number;
+  error?: string;
+  conflictKeys?: string[];
+};
+
+export type TransactionConfirmation = {
+  taskId: string;
+  operation: OptimisticTxOperation;
+  txHash?: string;
+  status: "confirmed" | "failed";
+  serverPayload?: OptimisticTxPayload;
+  error?: string;
+  observedAt: number;
+};
+
+export type OptimisticTxAuditCode =
+  | "confirmed"
+  | "rolled_back"
+  | "conflict"
+  | "stale";
+
+export type OptimisticTxAuditEvent = {
+  code: OptimisticTxAuditCode;
+  clientTxId: string;
+  taskId: string;
+  operation: OptimisticTxOperation;
+  retriable: boolean;
+  timestamp: number;
+  message: string;
+  redactedPayload: OptimisticTxPayload;
+};
+
+export type ReconcileOptimisticTransactionsInput = {
+  transactions: OptimisticTransaction[];
+  confirmations: TransactionConfirmation[];
+  now?: number;
+  staleAfterMs?: number;
+};
+
+export type ReconcileOptimisticTransactionsResult = {
+  transactions: OptimisticTransaction[];
+  auditEvents: OptimisticTxAuditEvent[];
+};
+
+const DEFAULT_STALE_AFTER_MS = 5 * 60 * 1000;
+const SENSITIVE_KEY_PATTERN = /(secret|private|seed|token|signature|credential|password|xdr)/i;
+
+export function createOptimisticTransaction(input: {
+  clientTxId: string;
+  taskId: string;
+  operation: OptimisticTxOperation;
+  optimisticPayload: OptimisticTxPayload;
+  rollbackPayload?: OptimisticTxPayload;
+  txHash?: string;
+  compareKeys?: string[];
+  createdAt?: number;
+}): OptimisticTransaction {
+  const createdAt = input.createdAt ?? Date.now();
+  return {
+    clientTxId: input.clientTxId,
+    taskId: input.taskId,
+    operation: input.operation,
+    state: "optimistic",
+    txHash: input.txHash,
+    optimisticPayload: input.optimisticPayload,
+    rollbackPayload: input.rollbackPayload,
+    compareKeys: input.compareKeys,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+export function summarizeOptimisticTransactions(
+  transactions: OptimisticTransaction[],
+): Record<OptimisticTxState, number> {
+  return transactions.reduce<Record<OptimisticTxState, number>>(
+    (summary, transaction) => {
+      summary[transaction.state] += 1;
+      return summary;
+    },
+    {
+      optimistic: 0,
+      confirmed: 0,
+      rolled_back: 0,
+      conflict: 0,
+      stale: 0,
+    },
+  );
+}
+
+function redactPayload(payload: OptimisticTxPayload | undefined): OptimisticTxPayload {
+  if (!payload) return {};
+
+  return Object.fromEntries(
+    Object.entries(payload).map(([key, value]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key) ? "[redacted]" : value,
+    ]),
+  );
+}
+
+function confirmationMatchesTransaction(
+  transaction: OptimisticTransaction,
+  confirmation: TransactionConfirmation,
+): boolean {
+  if (transaction.taskId !== confirmation.taskId) return false;
+  if (transaction.operation !== confirmation.operation) return false;
+  if (transaction.txHash && confirmation.txHash && transaction.txHash !== confirmation.txHash) {
+    return false;
+  }
+  return true;
+}
+
+function getConflictKeys(
+  transaction: OptimisticTransaction,
+  serverPayload: OptimisticTxPayload | undefined,
+): string[] {
+  if (!serverPayload) return [];
+  const compareKeys = transaction.compareKeys ?? [];
+
+  return compareKeys.filter((key) => {
+    if (!(key in transaction.optimisticPayload) || !(key in serverPayload)) return false;
+    return transaction.optimisticPayload[key] !== serverPayload[key];
+  });
+}
+
+function makeAuditEvent(input: {
+  code: OptimisticTxAuditCode;
+  transaction: OptimisticTransaction;
+  retriable: boolean;
+  timestamp: number;
+  message: string;
+  payload?: OptimisticTxPayload;
+}): OptimisticTxAuditEvent {
+  return {
+    code: input.code,
+    clientTxId: input.transaction.clientTxId,
+    taskId: input.transaction.taskId,
+    operation: input.transaction.operation,
+    retriable: input.retriable,
+    timestamp: input.timestamp,
+    message: input.message,
+    redactedPayload: redactPayload(input.payload),
+  };
+}
+
+export function reconcileOptimisticTransactions({
+  transactions,
+  confirmations,
+  now = Date.now(),
+  staleAfterMs = DEFAULT_STALE_AFTER_MS,
+}: ReconcileOptimisticTransactionsInput): ReconcileOptimisticTransactionsResult {
+  const auditEvents: OptimisticTxAuditEvent[] = [];
+
+  const nextTransactions = transactions.map((transaction) => {
+    if (transaction.state !== "optimistic" && transaction.state !== "stale") {
+      return transaction;
+    }
+
+    const confirmation = confirmations.find((candidate) =>
+      confirmationMatchesTransaction(transaction, candidate),
+    );
+
+    if (confirmation?.status === "failed") {
+      const rolledBack: OptimisticTransaction = {
+        ...transaction,
+        state: "rolled_back",
+        error: confirmation.error,
+        updatedAt: confirmation.observedAt,
+        rolledBackAt: confirmation.observedAt,
+      };
+      auditEvents.push(
+        makeAuditEvent({
+          code: "rolled_back",
+          transaction: rolledBack,
+          retriable: true,
+          timestamp: confirmation.observedAt,
+          message: confirmation.error ?? "Optimistic transaction failed and was rolled back.",
+          payload: transaction.rollbackPayload ?? transaction.optimisticPayload,
+        }),
+      );
+      return rolledBack;
+    }
+
+    if (confirmation?.status === "confirmed") {
+      const conflictKeys = getConflictKeys(transaction, confirmation.serverPayload);
+      if (conflictKeys.length > 0) {
+        const conflicted: OptimisticTransaction = {
+          ...transaction,
+          state: "conflict",
+          confirmedPayload: confirmation.serverPayload,
+          conflictKeys,
+          updatedAt: confirmation.observedAt,
+          confirmedAt: confirmation.observedAt,
+        };
+        auditEvents.push(
+          makeAuditEvent({
+            code: "conflict",
+            transaction: conflicted,
+            retriable: false,
+            timestamp: confirmation.observedAt,
+            message: `Server confirmation conflicted on: ${conflictKeys.join(", ")}.`,
+            payload: confirmation.serverPayload,
+          }),
+        );
+        return conflicted;
+      }
+
+      const confirmed: OptimisticTransaction = {
+        ...transaction,
+        state: "confirmed",
+        confirmedPayload: confirmation.serverPayload,
+        updatedAt: confirmation.observedAt,
+        confirmedAt: confirmation.observedAt,
+      };
+      auditEvents.push(
+        makeAuditEvent({
+          code: "confirmed",
+          transaction: confirmed,
+          retriable: false,
+          timestamp: confirmation.observedAt,
+          message: "Optimistic transaction matched confirmed server state.",
+          payload: confirmation.serverPayload ?? transaction.optimisticPayload,
+        }),
+      );
+      return confirmed;
+    }
+
+    if (transaction.state === "optimistic" && now - transaction.createdAt > staleAfterMs) {
+      const stale: OptimisticTransaction = {
+        ...transaction,
+        state: "stale",
+        updatedAt: now,
+        staleAt: now,
+      };
+      auditEvents.push(
+        makeAuditEvent({
+          code: "stale",
+          transaction: stale,
+          retriable: true,
+          timestamp: now,
+          message: "Optimistic transaction exceeded the reconciliation window.",
+          payload: transaction.optimisticPayload,
+        }),
+      );
+      return stale;
+    }
+
+    return transaction;
+  });
+
+  return {
+    transactions: nextTransactions,
+    auditEvents,
+  };
+}


### PR DESCRIPTION
## Summary
- Added a reusable optimistic transaction reconciler with states for optimistic, confirmed, rolled back, conflict, and stale transactions.
- Added a React hook and status panel for tracking reconciliation state, summaries, and redacted audit events.
- Documented matching rules, fallback states, integration guidance, and security boundaries.

## Verification
- npx jest src/lib/__tests__/optimisticTxReconciler.test.ts src/hooks/__tests__/useOptimisticTxReconciler.test.tsx components/__tests__/OptimisticTxReconcilerPanel.test.tsx --runInBand --watchman=false
- npx eslint src/lib/optimisticTxReconciler.ts src/lib/__tests__/optimisticTxReconciler.test.ts src/hooks/useOptimisticTxReconciler.ts src/hooks/__tests__/useOptimisticTxReconciler.test.tsx components/transaction/OptimisticTxReconcilerPanel.tsx components/__tests__/OptimisticTxReconcilerPanel.test.tsx
- git diff --check

Closes #558