### PR TITLE
feat(keeper,indexer,docs): add alerting, PostgreSQL schema, contributing guide, and graceful shutdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,53 @@
 # Contributing to SoroTask
 
-Thanks for contributing to SoroTask. This project is split into three parts:
+Thanks for contributing to SoroTask. This project is split into four parts:
 
-- `contract` (Rust/Soroban smart contract)
-- `keeper` (Node.js off-chain bot)
-- `frontend` (Next.js dashboard)
+- `contract` — Rust/Soroban smart contract
+- `keeper` — Node.js off-chain automation bot
+- `frontend` — Next.js dashboard
+- `indexer` — Node.js event indexer
 
-## Contribution Flow
+---
 
-1. Fork the repository.
-2. Create a branch from `main`:
-   - `feat/<short-description>` for features
-   - `fix/<short-description>` for bug fixes
-   - `docs/<short-description>` for documentation
-3. Make focused changes in the relevant package(s).
-4. Run formatting/lint checks before opening a PR.
-5. Open a Pull Request using the PR template.
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Getting the Code](#getting-the-code)
+3. [Local Setup](#local-setup)
+4. [Development Workflow](#development-workflow)
+5. [Code Style and Quality Checks](#code-style-and-quality-checks)
+6. [Commit Message Conventions](#commit-message-conventions)
+7. [Automated CI Requirements](#automated-ci-requirements)
+8. [Pull Request Expectations](#pull-request-expectations)
+9. [Reporting Bugs and Requesting Features](#reporting-bugs-and-requesting-features)
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Install |
+|------|----------------|---------|
+| Node.js | 18 | https://nodejs.org |
+| npm | 9 | bundled with Node.js |
+| Rust | stable | `rustup toolchain install stable` |
+| `wasm32-unknown-unknown` target | — | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI (`stellar`) | latest | https://developers.stellar.org/docs/tools/stellar-cli |
+| Docker (optional) | 24+ | https://docs.docker.com/get-docker/ |
+
+---
+
+## Getting the Code
+
+```bash
+# Fork the repository on GitHub, then clone your fork
+git clone https://github.com/<your-username>/SoroTask.git
+cd SoroTask
+
+# Add upstream so you can pull future changes
+git remote add upstream https://github.com/SoroLabs/SoroTask.git
+```
+
+---
 
 ## Local Setup
 
@@ -24,6 +56,7 @@ Thanks for contributing to SoroTask. This project is split into three parts:
 ```bash
 cd contract
 cargo build --target wasm32-unknown-unknown --release
+cargo test
 ```
 
 ### Keeper
@@ -31,26 +64,91 @@ cargo build --target wasm32-unknown-unknown --release
 ```bash
 cd keeper
 npm install
+cp .env.example .env   # then fill in your RPC URL and keypair
 node index.js
 ```
+
+Key environment variables (see `keeper/src/config.js` for all options):
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `RPC_URL` | Soroban RPC endpoint | testnet URL |
+| `CONTRACT_ID` | Deployed contract address | — |
+| `SECRET_KEY` | Keeper signing keypair | — |
+| `ALERT_WEBHOOK_URL` | Slack or Discord webhook for failure alerts | — |
+| `ALERT_CONSECUTIVE_FAILURE_THRESHOLD` | Alert after this many consecutive failures | `3` |
+| `ALERT_RPC_DOWN_THRESHOLD_MS` | Alert if RPC is down this long (ms) | `300000` |
 
 ### Frontend
 
 ```bash
 cd frontend
 npm install
-npm run dev
+npm run dev        # starts on http://localhost:3000
 ```
+
+### Indexer
+
+```bash
+cd indexer
+npm install
+node src/index.js
+```
+
+To run against a PostgreSQL database instead of SQLite, apply the migrations first:
+
+```bash
+psql -U <user> -d <database> -f indexer/migrations/001_initial_schema.sql
+```
+
+---
+
+## Development Workflow
+
+1. **Sync with upstream** before starting any work:
+
+   ```bash
+   git fetch upstream
+   git rebase upstream/main
+   ```
+
+2. **Create a branch** from `main` using the naming convention below:
+
+   | Type | Branch pattern | Example |
+   |------|---------------|---------|
+   | Feature | `feat/<short-description>` | `feat/keeper-alerts` |
+   | Bug fix | `fix/<short-description>` | `fix/rpc-retry-overflow` |
+   | Documentation | `docs/<short-description>` | `docs/contributing-guide` |
+   | Chore | `chore/<short-description>` | `chore/update-deps` |
+
+   When a branch addresses multiple issues, include all issue numbers:
+
+   ```bash
+   git checkout -b feat/671-684-add-task-filters
+   ```
+
+3. **Make focused changes** in the relevant package(s). Keep unrelated refactors out of the PR.
+
+4. **Run quality checks locally** (see [Code Style and Quality Checks](#code-style-and-quality-checks)).
+
+5. **Commit** using Conventional Commits (see [Commit Message Conventions](#commit-message-conventions)).
+
+6. **Open a Pull Request** against `main`, filling in the PR template.
+
+---
 
 ## Code Style and Quality Checks
 
-Run the checks for the part(s) you changed.
+Run the checks for every package you touched before opening a PR.
 
 ### Rust (contract)
 
 ```bash
 cd contract
-cargo fmt --all
+cargo fmt --all           # format
+cargo clippy --all-targets -- -D warnings   # lint (must be warning-free)
+cargo test                # unit tests
+cargo build --target wasm32-unknown-unknown --release   # wasm build
 ```
 
 ### Keeper (Node.js)
@@ -58,82 +156,160 @@ cargo fmt --all
 ```bash
 cd keeper
 npm install
-npm run lint
-npm test
+npm run lint              # ESLint
+npm test                  # Jest — must hit ≥70 % coverage
 ```
 
-### JavaScript/TypeScript (frontend)
+To run a single test file during development:
+
+```bash
+npm test -- --testPathPattern=src/__tests__/executor.test.js
+```
+
+### Frontend (TypeScript / Next.js)
 
 ```bash
 cd frontend
 npm install
-npm run lint
+npm run lint              # ESLint + TypeScript
+npm run build             # must succeed with no type errors
 ```
 
-If you changed both Rust and frontend code, run both checks.
+### Indexer (Node.js)
+
+```bash
+cd indexer
+npm install
+npm test
+```
+
+---
+
+## Commit Message Conventions
+
+SoroTask follows **Conventional Commits** (https://www.conventionalcommits.org).
+Automated releases parse commit messages to determine the version bump and
+populate the changelog — please follow this format precisely.
+
+### Format
+
+```
+<type>(<scope>): <short summary>
+
+[optional body — explain WHY, not what]
+
+[optional footer — BREAKING CHANGE, Closes #n]
+```
+
+### Types
+
+| Type | When to use | Release bump |
+|------|------------|-------------|
+| `feat` | New user-visible feature | minor |
+| `fix` | Bug fix | patch |
+| `docs` | Documentation only | none |
+| `refactor` | Code change that is not a fix or feature | none |
+| `test` | Adding or fixing tests | none |
+| `chore` | Build process, dependency updates, tooling | none |
+| `perf` | Performance improvement | patch |
+| `ci` | CI/CD configuration | none |
+
+Append `!` or add `BREAKING CHANGE:` in the footer to trigger a **major** release.
+
+### Scopes
+
+Use the package name where the change lives:
+
+`frontend` · `keeper` · `contract` · `indexer` · `docs` · `ci`
+
+### Examples
+
+```text
+feat(keeper): add webhook alerting for consecutive task failures
+
+fix(indexer): handle missing task_id in legacy v0 events
+
+docs(contributing): expand development workflow and commit conventions
+
+feat(keeper)!: replace sqlite3 with pg driver
+
+BREAKING CHANGE: DATABASE_URL must now point to a PostgreSQL instance
+```
+
+### Linking issues
+
+Reference the related GitHub issue in the commit footer so it appears in the
+changelog and auto-closes on merge:
+
+```text
+feat(indexer): add initial PostgreSQL migration
+
+Closes #675
+```
+
+---
 
 ## Automated CI Requirements
 
-All pull requests must pass the following automated checks before they can be merged:
+All pull requests must pass the following checks before merging.
 
-### Keeper Service (`keeper/**`)
-- **Lint**: ESLint validation of all JavaScript files
-- **Test**: Jest test suite with minimum 70% code coverage
-- **Docker**: Dockerfile successfully builds without errors
+### Keeper (`keeper/**`)
+
+- **Lint** — ESLint with no errors or warnings
+- **Test** — Jest test suite; minimum **70 % code coverage**
+- **Docker** — `docker build` succeeds
 
 ### Contract (`contract/**`)
-- **Formatting**: Rust code formatted with `cargo fmt`
-- **Linting**: Rust code passes `cargo clippy` checks
-- **Tests**: All Rust unit tests pass
-- **Build**: WebAssembly compilation succeeds
 
-These checks run automatically on every pull request. You can verify locally before pushing:
+- **Format** — `cargo fmt --check`
+- **Lint** — `cargo clippy` with no warnings
+- **Test** — all Rust unit tests pass
+- **Build** — WebAssembly compilation succeeds
+
+### Frontend (`frontend/**`)
+
+- **Lint** — ESLint and TypeScript type-check
+- **Build** — `next build` succeeds
+
+You can verify all checks locally before pushing:
 
 ```bash
-# For Keeper changes
+# Keeper
 cd keeper && npm run lint && npm test
 
-# For Contract changes
-cd contract && cargo fmt --all && cargo test && cargo clippy --all-targets
+# Contract
+cd contract && cargo fmt --check && cargo clippy --all-targets && cargo test && \
+  cargo build --target wasm32-unknown-unknown --release
+
+# Frontend
+cd frontend && npm run lint && npm run build
 ```
+
+---
 
 ## Pull Request Expectations
 
 Every PR should:
 
-- Have a clear title and summary.
-- Explain what changed and why.
-- Link related issue(s) when applicable.
-- Include testing notes (what was run and results).
-- Keep scope focused; avoid unrelated refactors.
-- Include screenshots or short recordings for frontend UI changes.
+- Have a clear, concise title that follows Conventional Commits format.
+- Include a summary explaining **what** changed and **why**.
+- Link every related issue with `Closes #<n>` in the PR body.
+- Include testing notes — what commands were run and their results.
+- Keep scope focused; extract unrelated changes into a separate PR.
+- Include screenshots or short recordings for any frontend UI changes.
+- Pass all automated CI checks.
 
-## Commit Guidance
-
-- Use small, reviewable commits.
-- Use Conventional Commits so automated releases can determine version bumps and changelog entries.
-- Write clear commit messages describing intent.
-- Keep each commit logically coherent.
-
-Examples:
-
-```text
-feat(frontend): add wallet connection guard
-fix(keeper): retry failed task polling
-chore(contract): update soroban-sdk
-```
-
-Version bump behavior:
-
-- `fix:` triggers a patch release.
-- `feat:` triggers a minor release.
-- `!` or `BREAKING CHANGE:` triggers a major release.
+---
 
 ## Reporting Bugs and Requesting Features
 
-When opening an issue, include:
+When opening an issue, please include:
 
-- What you expected to happen.
-- What actually happened.
-- Steps to reproduce.
-- Environment details (OS, runtime/tool versions) when relevant.
+- **Expected behavior** — what should have happened.
+- **Actual behavior** — what actually happened.
+- **Steps to reproduce** — minimal reproduction steps.
+- **Environment** — OS, Node.js version, Rust version, browser (if frontend).
+- **Logs** — relevant error output or screenshots.
+
+For feature requests, describe the problem you are trying to solve and the
+proposed solution. The maintainers may suggest an alternative approach.

--- a/indexer/migrations/001_initial_schema.sql
+++ b/indexer/migrations/001_initial_schema.sql
@@ -1,0 +1,82 @@
+-- Migration: 001_initial_schema
+-- Creates the initial PostgreSQL schema for the SoroTask indexer.
+
+CREATE TABLE IF NOT EXISTS users (
+    id          BIGSERIAL PRIMARY KEY,
+    address     TEXT        NOT NULL UNIQUE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_address ON users (address);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id             BIGINT      PRIMARY KEY,
+    creator_address     TEXT        NOT NULL REFERENCES users (address) ON UPDATE CASCADE,
+    target              TEXT        NOT NULL,
+    function_name       TEXT        NOT NULL,
+    args_json           JSONB,
+    resolver            TEXT,
+    interval_seconds    BIGINT      NOT NULL,
+    last_run_ledger     BIGINT      NOT NULL DEFAULT 0,
+    gas_balance         NUMERIC(38) NOT NULL DEFAULT 0,
+    whitelist_json      JSONB,
+    is_active           BOOLEAN     NOT NULL DEFAULT TRUE,
+    blocked_by_json     JSONB,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_reconciled_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_creator ON tasks (creator_address);
+CREATE INDEX IF NOT EXISTS idx_tasks_is_active ON tasks (is_active);
+
+CREATE TABLE IF NOT EXISTS executions (
+    id              BIGSERIAL   PRIMARY KEY,
+    task_id         BIGINT      NOT NULL REFERENCES tasks (task_id) ON DELETE CASCADE,
+    keeper_address  TEXT        NOT NULL,
+    tx_hash         TEXT,
+    status          TEXT        NOT NULL CHECK (status IN ('SUCCESS', 'FAILED', 'TIMEOUT', 'SKIPPED')),
+    fee_paid        NUMERIC(38) NOT NULL DEFAULT 0,
+    ledger_sequence BIGINT,
+    error_message   TEXT,
+    executed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_executions_task_id ON executions (task_id);
+CREATE INDEX IF NOT EXISTS idx_executions_keeper ON executions (keeper_address);
+CREATE INDEX IF NOT EXISTS idx_executions_status ON executions (status);
+CREATE INDEX IF NOT EXISTS idx_executions_executed_at ON executions (executed_at DESC);
+
+CREATE TABLE IF NOT EXISTS events (
+    id              BIGSERIAL   PRIMARY KEY,
+    ledger_sequence BIGINT      NOT NULL,
+    contract_id     TEXT        NOT NULL,
+    event_name      TEXT        NOT NULL,
+    task_id         BIGINT,
+    data_json       JSONB       NOT NULL,
+    processed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (ledger_sequence, contract_id, event_name, task_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_task_id ON events (task_id);
+CREATE INDEX IF NOT EXISTS idx_events_event_name ON events (event_name);
+CREATE INDEX IF NOT EXISTS idx_events_ledger ON events (ledger_sequence);
+
+CREATE TABLE IF NOT EXISTS reconciliation_logs (
+    id          BIGSERIAL   PRIMARY KEY,
+    task_id     BIGINT,
+    status      TEXT        NOT NULL,
+    details     JSONB,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reconciliation_task_id ON reconciliation_logs (task_id);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version     TEXT        PRIMARY KEY,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO schema_migrations (version) VALUES ('001_initial_schema')
+    ON CONFLICT (version) DO NOTHING;

--- a/keeper/index.js
+++ b/keeper/index.js
@@ -29,6 +29,7 @@ const { WebhookAuthProtocol, InMemoryReplayStore } = require("./src/webhookAuth"
 const { WebhookTriggerHandler } = require("./src/webhookTrigger");
 const { MultiRegionRPCClient } = require("./src/disasterRecovery");
 const { KeeperP2PNetwork } = require("./src/p2pNetwork");
+const { KeeperAlertManager } = require("./src/keeperAlerts");
 
 // Create root logger for the main module
 const logger = createLogger("keeper");
@@ -156,6 +157,9 @@ async function main() {
   }
   metricsServer.setFailoverStateProvider(() => failoverClient.getStateSnapshot());
   const server = failoverClient.getServerFacade();
+
+  const alertManager = new KeeperAlertManager();
+  alertManager.startRpcMonitor(() => server.getLatestLedger());
 
   // Perform startup validation to fail fast on configuration errors
   const validator = new StartupValidator(
@@ -294,6 +298,7 @@ async function main() {
         });
       }
     }
+    alertManager.recordSuccess();
     shutdownManager.completeTask(taskId);
     metricsServer.publishTaskEvent("queue-success", taskId);
   });
@@ -322,6 +327,7 @@ async function main() {
         shardLabel: shardConfig.shardLabel,
       },
     });
+    alertManager.recordFailure({ taskId, error: err.message });
     shutdownManager.failTask(taskId, err);
     poller.invalidateCache(taskId);
     metricsServer.publishTaskEvent("queue-failed", taskId, { error: err.message });
@@ -584,6 +590,10 @@ async function main() {
         logger.error("Periodic reconciliation error", { error: err.message });
       }
     }
+  });
+
+  shutdownManager.registerResource("alert-manager", async () => {
+    alertManager.stopRpcMonitor();
   });
 
   // Register SLA monitor cleanup

--- a/keeper/src/keeperAlerts.js
+++ b/keeper/src/keeperAlerts.js
@@ -1,0 +1,208 @@
+'use strict';
+
+/**
+ * keeperAlerts.js - Webhook alerting for persistent keeper failures
+ *
+ * Triggers Slack or Discord alerts when:
+ * - X consecutive task executions fail
+ * - RPC connection is down for more than 5 minutes
+ */
+
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
+const { createLogger } = require('./logger');
+
+const logger = createLogger('keeper-alerts');
+
+const DEFAULT_CONSECUTIVE_FAILURE_THRESHOLD = parseInt(
+  process.env.ALERT_CONSECUTIVE_FAILURE_THRESHOLD || '3',
+  10,
+);
+const DEFAULT_RPC_DOWN_THRESHOLD_MS = parseInt(
+  process.env.ALERT_RPC_DOWN_THRESHOLD_MS || String(5 * 60 * 1000),
+  10,
+);
+
+function buildSlackPayload(message, details = {}) {
+  return JSON.stringify({
+    text: `*SoroTask Keeper Alert*\n${message}`,
+    attachments: Object.keys(details).length
+      ? [
+          {
+            color: '#ff0000',
+            fields: Object.entries(details).map(([k, v]) => ({
+              title: k,
+              value: String(v),
+              short: true,
+            })),
+          },
+        ]
+      : undefined,
+  });
+}
+
+function buildDiscordPayload(message, details = {}) {
+  const fields = Object.entries(details).map(([name, value]) => ({
+    name,
+    value: String(value),
+    inline: true,
+  }));
+  return JSON.stringify({
+    embeds: [
+      {
+        title: 'SoroTask Keeper Alert',
+        description: message,
+        color: 0xff0000,
+        fields: fields.length ? fields : undefined,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+}
+
+function postWebhook(webhookUrl, body) {
+  return new Promise((resolve, reject) => {
+    let parsed;
+    try {
+      parsed = new URL(webhookUrl);
+    } catch {
+      return reject(new Error(`Invalid webhook URL: ${webhookUrl}`));
+    }
+
+    const protocol = parsed.protocol === 'https:' ? https : http;
+    const data = Buffer.from(body, 'utf8');
+    const options = {
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': data.length,
+      },
+    };
+
+    const req = protocol.request(options, (res) => {
+      res.resume();
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        resolve();
+      } else {
+        reject(new Error(`Webhook responded with status ${res.statusCode}`));
+      }
+    });
+
+    req.on('error', reject);
+    req.setTimeout(5000, () => {
+      req.destroy(new Error('Webhook request timed out'));
+    });
+    req.write(data);
+    req.end();
+  });
+}
+
+function isDiscordUrl(url) {
+  return url.includes('discord.com/api/webhooks') || url.includes('discordapp.com/api/webhooks');
+}
+
+async function sendAlert(webhookUrl, message, details = {}) {
+  if (!webhookUrl) return;
+  const body = isDiscordUrl(webhookUrl)
+    ? buildDiscordPayload(message, details)
+    : buildSlackPayload(message, details);
+  try {
+    await postWebhook(webhookUrl, body);
+    logger.info('Alert sent', { message });
+  } catch (err) {
+    logger.error('Failed to send alert', { error: err.message, webhookUrl });
+  }
+}
+
+class KeeperAlertManager {
+  constructor(options = {}) {
+    this.webhookUrl =
+      options.webhookUrl ||
+      process.env.ALERT_WEBHOOK_URL ||
+      process.env.SLACK_WEBHOOK_URL ||
+      process.env.DISCORD_WEBHOOK_URL ||
+      null;
+
+    this.consecutiveFailureThreshold =
+      options.consecutiveFailureThreshold ?? DEFAULT_CONSECUTIVE_FAILURE_THRESHOLD;
+
+    this.rpcDownThresholdMs =
+      options.rpcDownThresholdMs ?? DEFAULT_RPC_DOWN_THRESHOLD_MS;
+
+    this._consecutiveFailures = 0;
+    this._rpcDownSince = null;
+    this._rpcAlertSent = false;
+    this._rpcCheckInterval = null;
+  }
+
+  recordSuccess() {
+    this._consecutiveFailures = 0;
+  }
+
+  async recordFailure(details = {}) {
+    this._consecutiveFailures += 1;
+    logger.warn('Task execution failure recorded', {
+      consecutiveFailures: this._consecutiveFailures,
+      threshold: this.consecutiveFailureThreshold,
+    });
+
+    if (this._consecutiveFailures >= this.consecutiveFailureThreshold) {
+      await sendAlert(
+        this.webhookUrl,
+        `${this._consecutiveFailures} consecutive task execution failures detected.`,
+        { consecutiveFailures: this._consecutiveFailures, ...details },
+      );
+    }
+  }
+
+  recordRpcUp() {
+    if (this._rpcDownSince !== null) {
+      logger.info('RPC connection restored');
+    }
+    this._rpcDownSince = null;
+    this._rpcAlertSent = false;
+  }
+
+  async recordRpcDown() {
+    if (this._rpcDownSince === null) {
+      this._rpcDownSince = Date.now();
+      logger.warn('RPC connection down, monitoring for alert threshold', {
+        thresholdMs: this.rpcDownThresholdMs,
+      });
+    }
+
+    const downMs = Date.now() - this._rpcDownSince;
+    if (!this._rpcAlertSent && downMs >= this.rpcDownThresholdMs) {
+      this._rpcAlertSent = true;
+      await sendAlert(
+        this.webhookUrl,
+        `RPC connection has been down for ${Math.round(downMs / 1000)}s (threshold: ${Math.round(this.rpcDownThresholdMs / 1000)}s).`,
+        { downSeconds: Math.round(downMs / 1000) },
+      );
+    }
+  }
+
+  startRpcMonitor(rpcCheckFn, intervalMs = 30000) {
+    this._rpcCheckInterval = setInterval(async () => {
+      try {
+        await rpcCheckFn();
+        this.recordRpcUp();
+      } catch {
+        await this.recordRpcDown();
+      }
+    }, intervalMs);
+  }
+
+  stopRpcMonitor() {
+    if (this._rpcCheckInterval) {
+      clearInterval(this._rpcCheckInterval);
+      this._rpcCheckInterval = null;
+    }
+  }
+}
+
+module.exports = { KeeperAlertManager, sendAlert };


### PR DESCRIPTION
## Summary

Closes #693
Closes #675
Closes #673
Closes #672

### #693 — Keeper: Add alerting for persistent failures
- Adds `keeper/src/keeperAlerts.js` with `KeeperAlertManager` class
- Sends Slack or Discord webhook alerts (auto-detected by URL) when consecutive task failures hit a configurable threshold (default: 3) or when the RPC connection has been down for more than 5 minutes (default)
- Wired into `keeper/index.js`: `queue:task:success` resets the counter; `queue:task:failed` increments it and fires alerts; an RPC health-check interval polls `server.getLatestLedger()` every 30 s
- Registered with `GracefulShutdownManager` so the RPC monitor is stopped cleanly on exit
- Configurable via environment variables: `ALERT_WEBHOOK_URL`, `ALERT_CONSECUTIVE_FAILURE_THRESHOLD`, `ALERT_RPC_DOWN_THRESHOLD_MS`

### #675 — Indexer: Setup basic PostgreSQL schema
- Adds `indexer/migrations/001_initial_schema.sql` with tables: `users`, `tasks`, `executions`, `events`, `reconciliation_logs`, and `schema_migrations`
- All foreign keys, check constraints, and indexes included
- Apply with: `psql -U <user> -d <database> -f indexer/migrations/001_initial_schema.sql`

### #673 — Docs: Create a detailed contributing guide
- Rewrites `CONTRIBUTING.md` with: prerequisites table, step-by-step local setup for all four packages, full development workflow (sync → branch → change → check → commit → PR), per-package quality check commands, detailed Conventional Commits reference with types/scopes/examples/version-bump table, and expanded PR expectations

### #672 — Keeper: Graceful shutdown handling
- `GracefulShutdownManager` in `keeper/src/gracefulShutdown.js` was already fully implemented and wired into `keeper/index.js` (signal handlers, drain phase, force-exit timeout, resource registry). No additional code changes needed.

## Test plan
- [ ] `cd keeper && npm run lint && npm test` passes
- [ ] `cd indexer && npm test` passes
- [ ] Apply `indexer/migrations/001_initial_schema.sql` to a local Postgres instance and verify all tables/indexes are created
- [ ] Set `ALERT_WEBHOOK_URL` to a Discord or Slack webhook and trigger 3+ consecutive task failures to confirm alert delivery
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub
