### PR TITLE
feat(frontend): integrate stellar wallet kit and context provider

### DIFF
--- a/frontend/components/WalletConnectionHub.tsx
+++ b/frontend/components/WalletConnectionHub.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useStellarWallet } from '../context/StellarWalletContext';
+import { WalletNetwork } from '@stellar/wallet-kit';
+
+export const WalletConnectionHub: React.FC = () => {
+  const {
+    address,
+    walletId,
+    network,
+    isConnected,
+    connectWallet,
+    disconnectWallet,
+    switchNetwork,
+  } = useStellarWallet();
+
+  const truncateAddress = (addr: string) =>
+    `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+
+  return (
+    <div className="flex items-center gap-4 p-4 border rounded-lg bg-card text-card-foreground shadow-sm">
+      {/* Network Selector */}
+      <select
+        value={network}
+        onChange={(e) => switchNetwork(e.target.value as WalletNetwork)}
+        className="px-3 py-1.5 text-sm font-medium border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <option value={WalletNetwork.TESTNET}>Testnet</option>
+        <option value={WalletNetwork.PUBLIC}>Mainnet</option>
+      </select>
+
+      {/* Wallet Action Button */}
+      {isConnected && address ? (
+        <div className="flex items-center gap-3">
+          <div className="text-right">
+            <span className="block text-xs font-semibold capitalize text-muted-foreground">
+              {walletId ?? 'Wallet'}
+            </span>
+            <span className="font-mono text-sm font-medium">
+              {truncateAddress(address)}
+            </span>
+          </div>
+          <button
+            onClick={disconnectWallet}
+            className="px-3 py-1.5 text-sm font-medium text-destructive border border-destructive/30 hover:bg-destructive/10 rounded-md transition-colors"
+          >
+            Disconnect
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={connectWallet}
+          className="px-4 py-2 text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 rounded-md shadow transition-colors"
+        >
+          Connect Wallet
+        </button>
+      )}
+    </div>
+  );
+};

--- a/frontend/components/__tests__/WalletConnectionHub.spec.tsx
+++ b/frontend/components/__tests__/WalletConnectionHub.spec.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WalletConnectionHub } from '../WalletConnectionHub';
+import { useStellarWallet } from '../../context/StellarWalletContext';
+import { WalletNetwork } from '@stellar/wallet-kit';
+
+jest.mock('../../context/StellarWalletContext');
+
+describe('WalletConnectionHub', () => {
+  const mockConnectWallet = jest.fn();
+  const mockDisconnectWallet = jest.fn();
+  const mockSwitchNetwork = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders Connect Wallet button when disconnected', () => {
+    (useStellarWallet as jest.Mock).mockReturnValue({
+      address: null,
+      walletId: null,
+      network: WalletNetwork.TESTNET,
+      isConnected: false,
+      connectWallet: mockConnectWallet,
+      disconnectWallet: mockDisconnectWallet,
+      switchNetwork: mockSwitchNetwork,
+    });
+
+    render(<WalletConnectionHub />);
+
+    const connectBtn = screen.getByRole('button', { name: /connect wallet/i });
+    expect(connectBtn).toBeInTheDocument();
+
+    fireEvent.click(connectBtn);
+    expect(mockConnectWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders truncated address and Disconnect button when connected', () => {
+    (useStellarWallet as jest.Mock).mockReturnValue({
+      address: 'GBRPYHIL2CI3FNQ4BXLFMNDLF2C3KCJPO
+      walletId: 'freighter',
+      network: WalletNetwork.TESTNET,
+      isConnected: true,
+      connectWallet: mockConnectWallet,
+      disconnectWallet: mockDisconnectWallet,
+      switchNetwork: mockSwitchNetwork,
+    });
+
+    render(<WalletConnectionHub />);
+
+    expect(screen.getByText('freighter')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/context/StellarWalletContext.tsx
+++ b/frontend/context/StellarWalletContext.tsx
@@ -1,0 +1,161 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  ReactNode,
+} from 'react';
+import {
+  StellarWalletsKit,
+  WalletNetwork,
+  ALLOW_ALL_MODULES,
+  FREIGHTER_ID,
+  ALBEDO_ID,
+  XBULL_ID,
+  LOBSTR_ID,
+} from '@stellar/wallet-kit';
+
+interface WalletState {
+  address: string | null;
+  walletId: string | null;
+  network: WalletNetwork;
+  isConnected: boolean;
+}
+
+interface StellarWalletContextType extends WalletState {
+  connectWallet: () => Promise<void>;
+  disconnectWallet: () => Promise<void>;
+  switchNetwork: (network: WalletNetwork) => void;
+  kit: StellarWalletsKit | null;
+}
+
+const STORAGE_KEY = 'stellar_wallet_session';
+
+const StellarWalletContext = createContext<StellarWalletContextType | undefined>(
+  undefined,
+);
+
+export const StellarWalletProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [network, setNetwork] = useState<WalletNetwork>(WalletNetwork.TESTNET);
+  const [walletState, setWalletState] = useState<WalletState>({
+    address: null,
+    walletId: null,
+    network: WalletNetwork.TESTNET,
+    isConnected: false,
+  });
+  const [kit, setKit] = useState<StellarWalletsKit | null>(null);
+
+  // Initialize StellarWalletsKit instance
+  useEffect(() => {
+    const walletKit = new StellarWalletsKit({
+      network,
+      selectedWalletId: FREIGHTER_ID,
+      modules: ALLOW_ALL_MODULES,
+    });
+
+    setKit(walletKit);
+  }, [network]);
+
+  // Restore persisted session on mount
+  useEffect(() => {
+    if (!kit) return;
+
+    const savedSession = localStorage.getItem(STORAGE_KEY);
+    if (savedSession) {
+      try {
+        const { address, walletId, savedNetwork } = JSON.parse(savedSession);
+        if (address && walletId) {
+          kit.setWallet(walletId);
+          setWalletState({
+            address,
+            walletId,
+            network: savedNetwork || WalletNetwork.TESTNET,
+            isConnected: true,
+          });
+        }
+      } catch (err) {
+        console.error('Failed to restore wallet session:', err);
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+  }, [kit]);
+
+  const connectWallet = useCallback(async () => {
+    if (!kit) return;
+
+    try {
+      await kit.openModal({
+        onWalletSelected: async (option) => {
+          kit.setWallet(option.id);
+          const { address } = await kit.getAddress();
+
+          const newState = {
+            address,
+            walletId: option.id,
+            network,
+            isConnected: true,
+          };
+
+          setWalletState(newState);
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+        },
+      });
+    } catch (error) {
+      console.error('Error connecting to wallet:', error);
+    }
+  }, [kit, network]);
+
+  const disconnectWallet = useCallback(async () => {
+    if (kit) {
+      await kit.disconnect();
+    }
+    setWalletState({
+      address: null,
+      walletId: null,
+      network,
+      isConnected: false,
+    });
+    localStorage.removeItem(STORAGE_KEY);
+  }, [kit, network]);
+
+  const switchNetwork = useCallback(
+    (newNetwork: WalletNetwork) => {
+      setNetwork(newNetwork);
+      setWalletState((prev) => {
+        const updated = { ...prev, network: newNetwork };
+        if (prev.isConnected) {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+        }
+        return updated;
+      });
+    },
+    [],
+  );
+
+  return (
+    <StellarWalletContext.Provider
+      value={{
+        ...walletState,
+        connectWallet,
+        disconnectWallet,
+        switchNetwork,
+        kit,
+      }}
+    >
+      {children}
+    </StellarWalletContext.Provider>
+  );
+};
+
+export const useStellarWallet = () => {
+  const context = useContext(StellarWalletContext);
+  if (!context) {
+    throw new Error(
+      'useStellarWallet must be used within a StellarWalletProvider',
+    );
+  }
+  return context;
+};


### PR DESCRIPTION
# 🎯 Overview & Context
Resolves **#932** by integrating `@stellar/wallet-kit` to support multi-wallet authentication across Freighter, Albedo, xBull, and Lobstr. 

Previously, user access was restricted exclusively to Freighter. This PR introduces a central `StellarWalletProvider` context, session persistence via `localStorage`, network toggle (Testnet/Mainnet), and a responsive UI connection hub component.

closes #932 

## 🛠️ Key Changes
* **`frontend/context/StellarWalletContext.tsx`**:
  * Configured `StellarWalletsKit` with `ALLOW_ALL_MODULES` for multi-wallet modal integration.
  * Implemented session persistence and automatic recovery on load.
  * Added network state management (`Testnet` vs `Public/Mainnet`).
* **`frontend/components/WalletConnectionHub.tsx`**:
  * Created UI wrapper containing network selection drop-down and connection action buttons.
* **`frontend/components/__tests__/WalletConnectionHub.spec.tsx`**:
  * Added React Testing Library test suite for wallet state interactions.

---

## 🧪 Verification & Acceptance Criteria
- [x] **Wallet Selection:** Clicking "Connect Wallet" opens `@stellar/wallet-kit` modal displaying Freighter, Albedo, xBull, and Lobstr options.
- [x] **Session Persistence:** Refreshing the browser retains connected wallet state and active public key.
- [x] **Network Switching:** Toggling network updates provider state and re-initializes kit options.
- [x] **Disconnection:** Disconnecting clears local session storage and resets UI state.