### PR TITLE
feat: Merkle event proofs, WebSocket streaming, ZK metrics, and DB read-replica routing

### DIFF
--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -16,7 +16,8 @@
         "graphql": "^15.10.2",
         "jsonwebtoken": "^9.0.3",
         "node-addon-api": "^8.9.0",
-        "sqlite3": "^6.0.1"
+        "sqlite3": "^6.0.1",
+        "ws": "^8.21.1"
       },
       "devDependencies": {
         "jest": "^30.4.2",
@@ -7565,6 +7566,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xss": {

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -18,7 +18,8 @@
     "graphql": "^15.10.2",
     "jsonwebtoken": "^9.0.3",
     "node-addon-api": "^8.9.0",
-    "sqlite3": "^6.0.1"
+    "sqlite3": "^6.0.1",
+    "ws": "^8.21.1"
   },
   "devDependencies": {
     "jest": "^30.4.2",

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -4,10 +4,43 @@ const cors = require('cors');
 const { typeDefs } = require('./graphql/schema');
 const { resolvers } = require('./graphql/resolvers');
 const { createContext } = require('./graphql/auth');
+const dbHelpers = require('./graphql/db');
+const { ensureSchema, buildMerkleProofResponse } = require('./merkleStore');
+
+/**
+ * Register REST routes that live alongside the GraphQL endpoint.
+ * Exposed separately so it can be mounted on a bare Express app in tests.
+ */
+function registerRestRoutes(app, deps = dbHelpers) {
+  // Issue #863: cryptographic Merkle inclusion proofs for a ledger's events.
+  //   GET /events/:ledger/merkle-proof            -> full leaf set + root
+  //   GET /events/:ledger/merkle-proof?eventId=N  -> inclusion proof for event N
+  app.get('/events/:ledger/merkle-proof', async (req, res) => {
+    const ledger = Number(req.params.ledger);
+    if (!Number.isInteger(ledger)) {
+      return res.status(400).json({ error: 'ledger must be an integer' });
+    }
+    try {
+      const { status, body } = await buildMerkleProofResponse(
+        deps,
+        ledger,
+        req.query.eventId,
+      );
+      return res.status(status).json(body);
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
+  });
+  return app;
+}
 
 async function startApiServer(port = 4000) {
   const app = express();
   app.use(cors());
+  app.use(express.json());
+
+  await ensureSchema(dbHelpers);
+  registerRestRoutes(app);
 
   const server = new ApolloServer({
     typeDefs,
@@ -28,4 +61,4 @@ async function startApiServer(port = 4000) {
   });
 }
 
-module.exports = { startApiServer };
+module.exports = { startApiServer, registerRestRoutes };

--- a/indexer/src/dbRouter.js
+++ b/indexer/src/dbRouter.js
@@ -1,0 +1,100 @@
+"use strict";
+
+/**
+ * Database read-replica load balancer / read-write splitter (issue #862).
+ *
+ * IMPORTANT DB-ENGINE REALITY: the indexer currently uses sqlite3 -- an
+ * embedded, single-file database (see indexer/src/index.js and
+ * indexer/src/graphql/db.js). SQLite has no concept of network read replicas
+ * the way PostgreSQL does, so building "replica routing" against SQLite alone
+ * would be fake for the actual engine. What is genuinely useful and real,
+ * regardless of engine, is a read/write-splitting *router*:
+ *
+ *   - writes (event ingestion) are pinned to the PRIMARY connection;
+ *   - reads (GraphQL resolvers, REST GETs) round-robin across N configured
+ *     read connections;
+ *   - if no read connections are configured, reads fall back to the primary,
+ *     so existing single-DB (single-file SQLite) deployments keep working
+ *     unchanged.
+ *
+ * The router is engine-agnostic: each "connection" is any object exposing
+ * queryAll / queryGet / queryRun. In today's SQLite deployment the replica
+ * list is empty and everything correctly falls back to primary. If the indexer
+ * is later moved to Postgres, `createConnection` can be pointed at pg pools and
+ * DATABASE_READ_REPLICA_URLS will fan reads across real replicas with no
+ * changes to the call sites.
+ */
+
+/**
+ * @typedef {Object} DbConnection
+ * @property {(sql:string, params?:any[]) => Promise<any[]>} queryAll
+ * @property {(sql:string, params?:any[]) => Promise<any>}   queryGet
+ * @property {(sql:string, params?:any[]) => Promise<any>}   queryRun
+ */
+
+class DbRouter {
+  /**
+   * @param {{ primary: DbConnection, replicas?: DbConnection[] }} opts
+   */
+  constructor({ primary, replicas = [] }) {
+    if (!primary) throw new Error("DbRouter requires a primary connection");
+    this.primary = primary;
+    this.replicas = replicas.filter(Boolean);
+    this._rr = 0;
+  }
+
+  /** @returns {boolean} */
+  hasReplicas() {
+    return this.replicas.length > 0;
+  }
+
+  /**
+   * Pick a connection for READ queries: round-robin across replicas, or the
+   * primary if none are configured.
+   * @returns {DbConnection}
+   */
+  getReadConnection() {
+    if (this.replicas.length === 0) return this.primary;
+    const conn = this.replicas[this._rr % this.replicas.length];
+    this._rr = (this._rr + 1) % this.replicas.length;
+    return conn;
+  }
+
+  /**
+   * Pick the connection for WRITE queries: always the primary.
+   * @returns {DbConnection}
+   */
+  getWriteConnection() {
+    return this.primary;
+  }
+
+  // Read paths -> read connection (replica or primary fallback).
+  queryAll(sql, params = []) {
+    return this.getReadConnection().queryAll(sql, params);
+  }
+
+  queryGet(sql, params = []) {
+    return this.getReadConnection().queryGet(sql, params);
+  }
+
+  // Write path -> primary only.
+  queryRun(sql, params = []) {
+    return this.getWriteConnection().queryRun(sql, params);
+  }
+}
+
+/**
+ * Parse a comma-separated list of replica connection strings from the
+ * environment (empty/undefined -> []).
+ * @param {string|undefined} raw
+ * @returns {string[]}
+ */
+function parseReplicaUrls(raw) {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+module.exports = { DbRouter, parseReplicaUrls };

--- a/indexer/src/graphql/db.js
+++ b/indexer/src/graphql/db.js
@@ -1,41 +1,59 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const { DbRouter, parseReplicaUrls } = require('../dbRouter');
 
 // Connect to the same DB file as the indexer
 const DB_FILE = process.env.DB_FILE || path.resolve(__dirname, '../../indexer.db');
-const db = new sqlite3.Database(DB_FILE);
 
-// Helper function to query the DB with Promises
-function queryAll(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    db.all(sql, params, (err, rows) => {
-      if (err) reject(err);
-      else resolve(rows);
-    });
-  });
+/**
+ * Wrap a sqlite3.Database in the { queryAll, queryGet, queryRun } connection
+ * interface the DbRouter expects.
+ * @param {import('sqlite3').Database} database
+ */
+function wrapConnection(database) {
+  return {
+    _db: database,
+    queryAll(sql, params = []) {
+      return new Promise((resolve, reject) => {
+        database.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)));
+      });
+    },
+    queryGet(sql, params = []) {
+      return new Promise((resolve, reject) => {
+        database.get(sql, params, (err, row) => (err ? reject(err) : resolve(row)));
+      });
+    },
+    queryRun(sql, params = []) {
+      return new Promise((resolve, reject) => {
+        database.run(sql, params, function (err) { return err ? reject(err) : resolve(this); });
+      });
+    },
+  };
 }
 
-function queryGet(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    db.get(sql, params, (err, row) => {
-      if (err) reject(err);
-      else resolve(row);
-    });
-  });
-}
+// Primary connection (writes + read fallback).
+const primaryDb = new sqlite3.Database(DB_FILE);
+const primary = wrapConnection(primaryDb);
 
-function queryRun(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    db.run(sql, params, function(err) {
-      if (err) reject(err);
-      else resolve(this);
-    });
-  });
-}
+// Issue #862: read replicas configured via DATABASE_READ_REPLICA_URLS
+// (comma-separated). For SQLite these are additional file paths (typically
+// read-only replicas synced out of band); the list is normally empty, in which
+// case reads fall back to the primary and behaviour is unchanged. Replicas are
+// opened read-only so a misrouted write fails loudly instead of diverging.
+const replicaPaths = parseReplicaUrls(process.env.DATABASE_READ_REPLICA_URLS);
+const replicas = replicaPaths.map((p) =>
+  wrapConnection(new sqlite3.Database(p, sqlite3.OPEN_READONLY)),
+);
 
+const router = new DbRouter({ primary, replicas });
+
+// Backwards-compatible exports: reads go through the router (replica or primary
+// fallback); writes go to the primary. `db` remains the raw primary handle for
+// any legacy callers that use it directly.
 module.exports = {
-  db,
-  queryAll,
-  queryGet,
-  queryRun
+  db: primaryDb,
+  router,
+  queryAll: (sql, params = []) => router.queryAll(sql, params),
+  queryGet: (sql, params = []) => router.queryGet(sql, params),
+  queryRun: (sql, params = []) => router.queryRun(sql, params),
 };

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -7,6 +7,7 @@ const {
 } = require("./reconciliation");
 const { runStaleTaskCleanup } = require("./staleTasks");
 const { startApiServer } = require("./api");
+const { computeAndStoreLedgerMerkle } = require("./merkleStore");
 
 // Configuration
 const RPC_URL = "https://soroban-testnet.stellar.org"; // Change as needed
@@ -67,6 +68,20 @@ const db = new sqlite3.Database(DB_FILE, (err) => {
     `);
   }
 });
+
+// Promise-style adapters over the callback `db` so shared modules (merkleStore)
+// can run against the indexer's live database connection.
+const dbDeps = {
+  queryAll: (sql, params = []) =>
+    new Promise((resolve, reject) =>
+      db.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)))),
+  queryGet: (sql, params = []) =>
+    new Promise((resolve, reject) =>
+      db.get(sql, params, (err, row) => (err ? reject(err) : resolve(row)))),
+  queryRun: (sql, params = []) =>
+    new Promise((resolve, reject) =>
+      db.run(sql, params, function (err) { return err ? reject(err) : resolve(this); })),
+};
 
 // Helper to store cursor (last processed paging token)
 let cursor = "0"; // Start from 0; will be updated to latest ledger on first poll
@@ -370,9 +385,21 @@ async function poll() {
       limit: 200,
     });
 
+    const touchedLedgers = new Set();
     for (const event of response.events) {
       await handleEvent(event);
+      touchedLedgers.add(event.ledgerSequence);
       cursor = event.ledger.toString(); // Update cursor to the last event's ledger
+    }
+
+    // Issue #863: (re)compute and persist a Merkle root over each ledger's
+    // event set once that ledger's events have been ingested.
+    for (const ledger of touchedLedgers) {
+      try {
+        await computeAndStoreLedgerMerkle(dbDeps, ledger);
+      } catch (merkleErr) {
+        console.error(`Error computing Merkle root for ledger ${ledger}:`, merkleErr.message);
+      }
     }
 
     // In production, persist cursor to storage (e.g., file, database) here

--- a/indexer/src/index.js
+++ b/indexer/src/index.js
@@ -8,6 +8,7 @@ const {
 const { runStaleTaskCleanup } = require("./staleTasks");
 const { startApiServer } = require("./api");
 const { computeAndStoreLedgerMerkle } = require("./merkleStore");
+const { broadcastEvent } = require("./wsServer");
 
 // Configuration
 const RPC_URL = "https://soroban-testnet.stellar.org"; // Change as needed
@@ -153,6 +154,14 @@ async function handleEvent(event) {
         console.error("Error inserting event:", err.message);
       } else {
         console.log(`Stored event: ${name} for task ${taskId} at ledger ${event.ledgerSequence}`);
+        // Issue #861: push newly-ingested events to subscribed WebSocket clients.
+        broadcastEvent({
+          ledger_sequence: event.ledgerSequence,
+          contract_id: CONTRACT_ID,
+          event_name: name,
+          task_id: taskId,
+          data: JSON.parse(dataJson),
+        });
       }
     }
   );
@@ -472,7 +481,15 @@ Options:
 if (!handleCLI()) {
   // Start polling
   console.log("Starting event indexer...");
-  startApiServer(4000).catch(console.error);
+  const { createWsServer } = require("./wsServer");
+  startApiServer(4000)
+    .then((httpServer) => {
+      // Issue #861: attach the real-time WebSocket streaming server to the
+      // same HTTP server, served at ws://<host>:4000/ws.
+      createWsServer({ server: httpServer, path: "/ws" });
+      console.log("🔌 WebSocket event stream ready at ws://localhost:4000/ws");
+    })
+    .catch(console.error);
   setInterval(poll, POLL_INTERVAL_MS);
   poll(); // Initial call
 

--- a/indexer/src/merkle.js
+++ b/indexer/src/merkle.js
@@ -1,0 +1,145 @@
+"use strict";
+
+/**
+ * Cryptographic Merkle tree over a ledger's indexed event records (issue #863).
+ *
+ * This is a minimal, dependency-free, sorted-pair SHA-256 Merkle tree. We only
+ * build tree construction / proof logic on top of Node's built-in
+ * `crypto.createHash('sha256')` -- no crypto primitives are reinvented here.
+ *
+ * Sorted-pair hashing (each internal node hashes the two children in ascending
+ * byte order, `sha256(min(a,b) || max(a,b))`) is used so that inclusion proofs
+ * are position-independent: a verifier does not need to know whether each
+ * sibling was a left or right child. This matches the `sortPairs` option of the
+ * popular `merkletreejs` library.
+ */
+
+const crypto = require("crypto");
+
+function sha256(buf) {
+  return crypto.createHash("sha256").update(buf).digest();
+}
+
+/**
+ * Canonically serialize an event record into a stable string so that the same
+ * logical event always hashes to the same leaf regardless of key ordering.
+ * @param {object} event
+ * @returns {string}
+ */
+function canonicalizeEvent(event) {
+  return JSON.stringify({
+    ledger_sequence: event.ledger_sequence,
+    contract_id: event.contract_id,
+    event_name: event.event_name,
+    task_id: event.task_id,
+    data_json: event.data_json,
+  });
+}
+
+/**
+ * Hash a single event record into its leaf (hex-encoded).
+ * @param {object} event
+ * @returns {string} hex digest
+ */
+function hashEvent(event) {
+  return sha256(Buffer.from(canonicalizeEvent(event), "utf8")).toString("hex");
+}
+
+/**
+ * Combine two hex node hashes into their parent using sorted-pair hashing.
+ * @param {string} a hex
+ * @param {string} b hex
+ * @returns {string} hex
+ */
+function hashPair(a, b) {
+  const bufA = Buffer.from(a, "hex");
+  const bufB = Buffer.from(b, "hex");
+  const [lo, hi] = Buffer.compare(bufA, bufB) <= 0 ? [bufA, bufB] : [bufB, bufA];
+  return sha256(Buffer.concat([lo, hi])).toString("hex");
+}
+
+/**
+ * Build a Merkle tree from an ordered list of leaf hashes (hex).
+ * Returns the layers (layer[0] === leaves) and the root.
+ * For an odd node count at a layer, the last node is promoted (duplicated up).
+ * @param {string[]} leaves hex leaf hashes
+ * @returns {{ layers: string[][], root: string|null, leaves: string[] }}
+ */
+function buildTreeFromLeaves(leaves) {
+  if (!Array.isArray(leaves) || leaves.length === 0) {
+    return { layers: [[]], root: null, leaves: [] };
+  }
+  const layers = [leaves.slice()];
+  while (layers[layers.length - 1].length > 1) {
+    const current = layers[layers.length - 1];
+    const next = [];
+    for (let i = 0; i < current.length; i += 2) {
+      if (i + 1 < current.length) {
+        next.push(hashPair(current[i], current[i + 1]));
+      } else {
+        // Odd one out: promote unchanged.
+        next.push(current[i]);
+      }
+    }
+    layers.push(next);
+  }
+  return { layers, root: layers[layers.length - 1][0], leaves: layers[0] };
+}
+
+/**
+ * Build a Merkle tree from an ordered list of event records.
+ * @param {object[]} events
+ * @returns {{ layers: string[][], root: string|null, leaves: string[] }}
+ */
+function buildEventTree(events) {
+  return buildTreeFromLeaves((events || []).map(hashEvent));
+}
+
+/**
+ * Produce an inclusion proof (ordered list of sibling hex hashes) for the leaf
+ * at `index` within a built tree.
+ * @param {{ layers: string[][] }} tree
+ * @param {number} index leaf index in layer 0
+ * @returns {string[]} sibling hashes from leaf level upward
+ */
+function getProof(tree, index) {
+  const proof = [];
+  let idx = index;
+  for (let layer = 0; layer < tree.layers.length - 1; layer++) {
+    const nodes = tree.layers[layer];
+    const isRight = idx % 2 === 1;
+    const siblingIdx = isRight ? idx - 1 : idx + 1;
+    if (siblingIdx < nodes.length) {
+      proof.push(nodes[siblingIdx]);
+    }
+    // If there is no sibling (odd promotion), nothing is added for this layer.
+    idx = Math.floor(idx / 2);
+  }
+  return proof;
+}
+
+/**
+ * Verify that `leaf` combined with `proof` reproduces `root`.
+ * @param {string} leaf hex leaf hash
+ * @param {string[]} proof sibling hashes (from getProof)
+ * @param {string} root hex root hash
+ * @returns {boolean}
+ */
+function verifyProof(leaf, proof, root) {
+  let computed = leaf;
+  for (const sibling of proof) {
+    computed = hashPair(computed, sibling);
+  }
+  return computed === root;
+}
+
+module.exports = {
+  sha256,
+  canonicalizeEvent,
+  hashEvent,
+  hashPair,
+  buildTreeFromLeaves,
+  buildEventTree,
+  getProof,
+  verifyProof,
+};

--- a/indexer/src/merkleStore.js
+++ b/indexer/src/merkleStore.js
@@ -1,0 +1,139 @@
+"use strict";
+
+/**
+ * Persistence + request helpers for per-ledger Merkle roots (issue #863).
+ *
+ * The indexer stores parsed events in the SQLite `events` table (see
+ * indexer/src/index.js). For each ledger sequence we build a Merkle tree over
+ * that ledger's event records and persist the root hash in a `merkle_roots`
+ * table keyed by ledger_sequence, so the root can be published / anchored and
+ * later inclusion proofs can be verified against it.
+ *
+ * The dependencies (queryAll/queryGet/queryRun) are injected so this module is
+ * trivially testable against an in-memory SQLite database.
+ */
+
+const { buildEventTree, hashEvent, getProof } = require("./merkle");
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS merkle_roots (
+    ledger_sequence INTEGER PRIMARY KEY,
+    root TEXT NOT NULL,
+    leaf_count INTEGER NOT NULL,
+    computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )
+`;
+
+async function ensureSchema({ queryRun }) {
+  await queryRun(CREATE_TABLE_SQL);
+}
+
+/**
+ * Load the ordered event records for a ledger. Ordering by `id` (insertion
+ * order) makes leaf ordering deterministic.
+ */
+async function getLedgerEvents({ queryAll }, ledger) {
+  return queryAll(
+    "SELECT id, ledger_sequence, contract_id, event_name, task_id, data_json FROM events WHERE ledger_sequence = ? ORDER BY id ASC",
+    [ledger],
+  );
+}
+
+/**
+ * Compute the Merkle tree for a ledger's events and persist the root.
+ * @returns {Promise<{ledger:number, root:string|null, leafCount:number}>}
+ */
+async function computeAndStoreLedgerMerkle(deps, ledger) {
+  await ensureSchema(deps);
+  const events = await getLedgerEvents(deps, ledger);
+  const tree = buildEventTree(events);
+  if (tree.root) {
+    await deps.queryRun(
+      `INSERT INTO merkle_roots (ledger_sequence, root, leaf_count, computed_at)
+       VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+       ON CONFLICT(ledger_sequence) DO UPDATE SET
+         root = excluded.root,
+         leaf_count = excluded.leaf_count,
+         computed_at = CURRENT_TIMESTAMP`,
+      [ledger, tree.root, events.length],
+    );
+  }
+  return { ledger, root: tree.root, leafCount: events.length };
+}
+
+async function getStoredRoot({ queryGet }, ledger) {
+  return queryGet(
+    "SELECT ledger_sequence, root, leaf_count, computed_at FROM merkle_roots WHERE ledger_sequence = ?",
+    [ledger],
+  );
+}
+
+/**
+ * Build the response payload for GET /events/:ledger/merkle-proof.
+ *
+ * Response shape:
+ *  - Without ?eventId: returns the ledger's full leaf set + root (and stored
+ *    root, if any) so a caller can reconstruct/verify the whole tree.
+ *  - With ?eventId=<events.id>: returns an inclusion proof for that single
+ *    event leaf: { leaf, proof: [...siblingHashes], root, index }.
+ *
+ * @returns {Promise<{status:number, body:object}>}
+ */
+async function buildMerkleProofResponse(deps, ledger, eventId) {
+  const events = await getLedgerEvents(deps, ledger);
+  if (events.length === 0) {
+    return {
+      status: 404,
+      body: { error: `No events indexed for ledger ${ledger}` },
+    };
+  }
+
+  const tree = buildEventTree(events);
+  const stored = await getStoredRoot(deps, ledger);
+
+  if (eventId === undefined || eventId === null || eventId === "") {
+    return {
+      status: 200,
+      body: {
+        ledger_sequence: ledger,
+        root: tree.root,
+        storedRoot: stored ? stored.root : null,
+        leafCount: events.length,
+        leaves: events.map((event) => ({ id: event.id, leaf: hashEvent(event) })),
+      },
+    };
+  }
+
+  const targetId = Number(eventId);
+  const index = events.findIndex((event) => Number(event.id) === targetId);
+  if (index === -1) {
+    return {
+      status: 404,
+      body: { error: `Event ${eventId} not found in ledger ${ledger}` },
+    };
+  }
+
+  const leaf = hashEvent(events[index]);
+  const proof = getProof(tree, index);
+  return {
+    status: 200,
+    body: {
+      ledger_sequence: ledger,
+      eventId: targetId,
+      index,
+      leaf,
+      proof,
+      root: tree.root,
+      storedRoot: stored ? stored.root : null,
+    },
+  };
+}
+
+module.exports = {
+  CREATE_TABLE_SQL,
+  ensureSchema,
+  getLedgerEvents,
+  computeAndStoreLedgerMerkle,
+  getStoredRoot,
+  buildMerkleProofResponse,
+};

--- a/indexer/src/wsServer.js
+++ b/indexer/src/wsServer.js
@@ -1,0 +1,175 @@
+"use strict";
+
+/**
+ * Real-time WebSocket event streaming server (issue #861).
+ *
+ * Clients connect and subscribe to topics using prefix/wildcard patterns:
+ *   task:*        -> all task-scoped events
+ *   keeper:*      -> all keeper-scoped events
+ *   contract:*    -> all contract-scoped events
+ *   task:5        -> events for task 5 (exact)
+ *   task:5:*      -> events for task 5 (prefix)
+ *
+ * As events are ingested by the polling pipeline (indexer/src/index.js), they
+ * are handed to `broadcastEvent`, which pushes them to every connected client
+ * whose subscriptions match. This is a simple in-process pub/sub keyed by topic
+ * prefix -- intentionally not a distributed message bus.
+ *
+ * Client protocol (JSON text frames):
+ *   -> { "action": "subscribe",   "topic": "task:*" }
+ *   -> { "action": "unsubscribe", "topic": "task:*" }
+ *   <- { "type": "subscribed",   "topic": "task:*" }
+ *   <- { "type": "event", "topic": "task:5:TaskRegistered", "event": { ... } }
+ */
+
+const { WebSocketServer } = require("ws");
+
+// Module-level singleton so the ingestion pipeline can broadcast without
+// threading the server instance through every call site.
+let activeServer = null;
+
+/**
+ * Derive the set of topics an event belongs to.
+ * @param {{event_name:string, task_id?:number, contract_id?:string, data?:object}} event
+ * @returns {string[]}
+ */
+function eventTopics(event) {
+  const topics = [];
+  const name = event.event_name;
+
+  if (name === "KeeperPaid") {
+    const keeper = event.data && event.data.keeper;
+    if (keeper) topics.push(`keeper:${keeper}`);
+    topics.push(`keeper:${name}`);
+  }
+
+  if (event.task_id !== undefined && event.task_id !== null && !Number.isNaN(event.task_id)) {
+    topics.push(`task:${event.task_id}`);
+    topics.push(`task:${event.task_id}:${name}`);
+  }
+
+  if (event.contract_id) {
+    topics.push(`contract:${event.contract_id}`);
+    topics.push(`contract:${event.contract_id}:${name}`);
+  }
+
+  return [...new Set(topics)];
+}
+
+/**
+ * Does a subscription pattern match a concrete topic?
+ * `foo:*` matches any topic beginning with `foo:`; otherwise exact match.
+ * @param {string} pattern
+ * @param {string} topic
+ * @returns {boolean}
+ */
+function topicMatches(pattern, topic) {
+  if (pattern === "*") return true;
+  if (pattern.endsWith("*")) {
+    return topic.startsWith(pattern.slice(0, -1));
+  }
+  return pattern === topic;
+}
+
+/**
+ * True if any of the client's subscription patterns matches any of the event's
+ * topics.
+ * @param {Set<string>} subscriptions
+ * @param {string[]} topics
+ * @returns {string|null} the first matching topic, or null
+ */
+function firstMatchingTopic(subscriptions, topics) {
+  for (const topic of topics) {
+    for (const pattern of subscriptions) {
+      if (topicMatches(pattern, topic)) return topic;
+    }
+  }
+  return null;
+}
+
+/**
+ * Create and attach a WebSocket server.
+ * @param {object} opts
+ * @param {import('http').Server} [opts.server] existing HTTP server to attach to
+ * @param {number} [opts.port] port to listen on if no server is provided
+ * @param {string} [opts.path] WS path (default '/ws')
+ * @returns {{ wss: import('ws').WebSocketServer, broadcast: Function, close: Function }}
+ */
+function createWsServer(opts = {}) {
+  const path = opts.path || "/ws";
+  const wssOptions = opts.server ? { server: opts.server, path } : { port: opts.port, path };
+  const wss = new WebSocketServer(wssOptions);
+
+  wss.on("connection", (socket) => {
+    socket._subscriptions = new Set();
+
+    socket.send(JSON.stringify({ type: "welcome", topics: ["task:*", "keeper:*", "contract:*"] }));
+
+    socket.on("message", (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch (_err) {
+        socket.send(JSON.stringify({ type: "error", message: "Invalid JSON" }));
+        return;
+      }
+
+      if (msg.action === "subscribe" && typeof msg.topic === "string") {
+        socket._subscriptions.add(msg.topic);
+        socket.send(JSON.stringify({ type: "subscribed", topic: msg.topic }));
+      } else if (msg.action === "unsubscribe" && typeof msg.topic === "string") {
+        socket._subscriptions.delete(msg.topic);
+        socket.send(JSON.stringify({ type: "unsubscribed", topic: msg.topic }));
+      } else {
+        socket.send(JSON.stringify({ type: "error", message: "Unknown action" }));
+      }
+    });
+  });
+
+  const server = {
+    wss,
+    broadcast(event) {
+      const topics = eventTopics(event);
+      for (const socket of wss.clients) {
+        if (socket.readyState !== socket.OPEN) continue;
+        const matched = firstMatchingTopic(socket._subscriptions || new Set(), topics);
+        if (matched) {
+          socket.send(JSON.stringify({ type: "event", topic: matched, event }));
+        }
+      }
+    },
+    close() {
+      return new Promise((resolve) => wss.close(() => resolve()));
+    },
+  };
+
+  activeServer = server;
+  return server;
+}
+
+/**
+ * Broadcast an event through the active WebSocket server (no-op if none).
+ * Called by the ingestion pipeline.
+ * @param {object} event
+ */
+function broadcastEvent(event) {
+  if (activeServer) activeServer.broadcast(event);
+}
+
+function getActiveServer() {
+  return activeServer;
+}
+
+function _resetForTests() {
+  activeServer = null;
+}
+
+module.exports = {
+  createWsServer,
+  broadcastEvent,
+  getActiveServer,
+  eventTopics,
+  topicMatches,
+  firstMatchingTopic,
+  _resetForTests,
+};

--- a/indexer/test/dbRouter.test.js
+++ b/indexer/test/dbRouter.test.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { DbRouter, parseReplicaUrls } = require("../src/dbRouter");
+
+function mockConn(name) {
+  const calls = { reads: 0, writes: 0 };
+  return {
+    name,
+    calls,
+    queryAll: async () => { calls.reads += 1; return [{ from: name }]; },
+    queryGet: async () => { calls.reads += 1; return { from: name }; },
+    queryRun: async () => { calls.writes += 1; return { from: name }; },
+  };
+}
+
+test("parseReplicaUrls handles empty and comma-separated values", () => {
+  assert.deepEqual(parseReplicaUrls(undefined), []);
+  assert.deepEqual(parseReplicaUrls(""), []);
+  assert.deepEqual(parseReplicaUrls("a.db, b.db ,, c.db"), ["a.db", "b.db", "c.db"]);
+});
+
+test("with replicas configured: reads round-robin across replicas, writes go to primary", async () => {
+  const primary = mockConn("primary");
+  const r1 = mockConn("r1");
+  const r2 = mockConn("r2");
+  const router = new DbRouter({ primary, replicas: [r1, r2] });
+
+  assert.equal(router.hasReplicas(), true);
+
+  // Six reads should distribute evenly across the two replicas, none to primary.
+  const results = [];
+  for (let i = 0; i < 6; i++) {
+    results.push((await router.queryAll("SELECT 1"))[0].from);
+  }
+  assert.deepEqual(results, ["r1", "r2", "r1", "r2", "r1", "r2"]);
+  assert.equal(r1.calls.reads, 3);
+  assert.equal(r2.calls.reads, 3);
+  assert.equal(primary.calls.reads, 0);
+
+  // Writes always hit the primary, never the replicas.
+  await router.queryRun("INSERT INTO t VALUES (1)");
+  await router.queryRun("INSERT INTO t VALUES (2)");
+  assert.equal(primary.calls.writes, 2);
+  assert.equal(r1.calls.writes, 0);
+  assert.equal(r2.calls.writes, 0);
+});
+
+test("with no replicas: reads and writes all fall back to primary", async () => {
+  const primary = mockConn("primary");
+  const router = new DbRouter({ primary, replicas: [] });
+
+  assert.equal(router.hasReplicas(), false);
+
+  const readRow = await router.queryGet("SELECT 1");
+  assert.equal(readRow.from, "primary");
+  await router.queryRun("INSERT INTO t VALUES (1)");
+
+  assert.equal(primary.calls.reads, 1);
+  assert.equal(primary.calls.writes, 1);
+});
+
+test("getReadConnection / getWriteConnection selection", () => {
+  const primary = mockConn("primary");
+  const r1 = mockConn("r1");
+  const router = new DbRouter({ primary, replicas: [r1] });
+  assert.equal(router.getWriteConnection().name, "primary");
+  assert.equal(router.getReadConnection().name, "r1");
+});

--- a/indexer/test/merkle.test.js
+++ b/indexer/test/merkle.test.js
@@ -1,0 +1,109 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const sqlite3 = require("sqlite3").verbose();
+
+const {
+  buildEventTree,
+  hashEvent,
+  getProof,
+  verifyProof,
+} = require("../src/merkle");
+const {
+  ensureSchema,
+  computeAndStoreLedgerMerkle,
+  getStoredRoot,
+  buildMerkleProofResponse,
+} = require("../src/merkleStore");
+
+function makeEvents(ledger) {
+  return [
+    { id: 1, ledger_sequence: ledger, contract_id: "C1", event_name: "TaskRegistered", task_id: 1, data_json: '{"creator":"A"}' },
+    { id: 2, ledger_sequence: ledger, contract_id: "C1", event_name: "KeeperPaid", task_id: 1, data_json: '{"keeper":"K","fee":"10"}' },
+    { id: 3, ledger_sequence: ledger, contract_id: "C1", event_name: "GasDeposited", task_id: 2, data_json: '{"address":"A","amount":"5"}' },
+    { id: 4, ledger_sequence: ledger, contract_id: "C1", event_name: "TaskPaused", task_id: 2, data_json: '{"creator":"A"}' },
+    { id: 5, ledger_sequence: ledger, contract_id: "C1", event_name: "TaskResumed", task_id: 2, data_json: '{"creator":"A"}' },
+  ];
+}
+
+test("merkle: a computed proof validates against the root for every leaf", () => {
+  const events = makeEvents(100);
+  const tree = buildEventTree(events);
+  assert.ok(tree.root, "tree has a root");
+
+  for (let i = 0; i < events.length; i++) {
+    const leaf = hashEvent(events[i]);
+    const proof = getProof(tree, i);
+    assert.equal(verifyProof(leaf, proof, tree.root), true, `leaf ${i} proof validates`);
+  }
+});
+
+test("merkle: tampering with an event invalidates the proof", () => {
+  const events = makeEvents(100);
+  const tree = buildEventTree(events);
+
+  const index = 2;
+  const proof = getProof(tree, index);
+
+  // Tamper: change the event's data.
+  const tampered = { ...events[index], data_json: '{"address":"A","amount":"999999"}' };
+  const tamperedLeaf = hashEvent(tampered);
+
+  assert.equal(verifyProof(tamperedLeaf, proof, tree.root), false);
+});
+
+function makeDbDeps() {
+  const db = new sqlite3.Database(":memory:");
+  return {
+    queryAll: (sql, p = []) => new Promise((res, rej) => db.all(sql, p, (e, r) => (e ? rej(e) : res(r)))),
+    queryGet: (sql, p = []) => new Promise((res, rej) => db.get(sql, p, (e, r) => (e ? rej(e) : res(r)))),
+    queryRun: (sql, p = []) => new Promise((res, rej) => db.run(sql, p, function (e) { return e ? rej(e) : res(this); })),
+    _db: db,
+  };
+}
+
+test("merkleStore: computes, stores, and serves a proof that validates against the stored root", async () => {
+  const deps = makeDbDeps();
+  await deps.queryRun(`CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ledger_sequence INTEGER, contract_id TEXT, event_name TEXT, task_id INTEGER, data_json TEXT)`);
+  await ensureSchema(deps);
+
+  for (const ev of makeEvents(200)) {
+    await deps.queryRun(
+      "INSERT INTO events (ledger_sequence, contract_id, event_name, task_id, data_json) VALUES (?,?,?,?,?)",
+      [ev.ledger_sequence, ev.contract_id, ev.event_name, ev.task_id, ev.data_json],
+    );
+  }
+
+  const stored = await computeAndStoreLedgerMerkle(deps, 200);
+  assert.ok(stored.root);
+  assert.equal(stored.leafCount, 5);
+
+  const persisted = await getStoredRoot(deps, 200);
+  assert.equal(persisted.root, stored.root);
+
+  // Proof for a specific event id validates against the STORED root.
+  const { status, body } = await buildMerkleProofResponse(deps, 200, 3);
+  assert.equal(status, 200);
+  assert.equal(body.storedRoot, persisted.root);
+  assert.equal(verifyProof(body.leaf, body.proof, body.storedRoot), true);
+
+  // Full-tree response shape (no eventId).
+  const full = await buildMerkleProofResponse(deps, 200, undefined);
+  assert.equal(full.status, 200);
+  assert.equal(full.body.leaves.length, 5);
+  assert.equal(full.body.root, persisted.root);
+});
+
+test("merkleStore: 404 for a ledger with no indexed events", async () => {
+  const deps = makeDbDeps();
+  await deps.queryRun(`CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ledger_sequence INTEGER, contract_id TEXT, event_name TEXT, task_id INTEGER, data_json TEXT)`);
+  await ensureSchema(deps);
+
+  const { status } = await buildMerkleProofResponse(deps, 999, undefined);
+  assert.equal(status, 404);
+});

--- a/indexer/test/wsServer.test.js
+++ b/indexer/test/wsServer.test.js
@@ -1,0 +1,104 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const WebSocket = require("ws");
+
+const {
+  createWsServer,
+  broadcastEvent,
+  eventTopics,
+  topicMatches,
+  _resetForTests,
+} = require("../src/wsServer");
+
+test("topicMatches: wildcard prefix and exact matching", () => {
+  assert.equal(topicMatches("task:*", "task:5:TaskRegistered"), true);
+  assert.equal(topicMatches("task:*", "keeper:K"), false);
+  assert.equal(topicMatches("task:5", "task:5"), true);
+  assert.equal(topicMatches("task:5", "task:6"), false);
+  assert.equal(topicMatches("*", "anything"), true);
+});
+
+test("eventTopics: derives task/keeper/contract topics", () => {
+  const topics = eventTopics({
+    event_name: "KeeperPaid",
+    task_id: 7,
+    contract_id: "C1",
+    data: { keeper: "GKEEPER" },
+  });
+  assert.ok(topics.includes("keeper:GKEEPER"));
+  assert.ok(topics.includes("task:7"));
+  assert.ok(topics.includes("contract:C1"));
+});
+
+function connect(port) {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    ws.on("open", () => resolve(ws));
+  });
+}
+
+function nextEvent(ws, timeoutMs = 500) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === "event") {
+        clearTimeout(timer);
+        resolve(msg);
+      }
+    });
+  });
+}
+
+function subscribe(ws, topic) {
+  return new Promise((resolve) => {
+    const handler = (raw) => {
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === "subscribed" && msg.topic === topic) {
+        ws.off("message", handler);
+        resolve();
+      }
+    };
+    ws.on("message", handler);
+    ws.send(JSON.stringify({ action: "subscribe", topic }));
+  });
+}
+
+test("ws: subscriber receives a matching event; non-matching subscriber does not", async () => {
+  _resetForTests();
+  const server = createWsServer({ port: 0, path: "/ws" });
+  const port = server.wss.address().port;
+
+  const matching = await connect(port);
+  const nonMatching = await connect(port);
+
+  await subscribe(matching, "task:*");
+  await subscribe(nonMatching, "keeper:*");
+
+  const matchingRecv = nextEvent(matching);
+  const nonMatchingRecv = nextEvent(nonMatching);
+
+  // Ingest a task-scoped event.
+  broadcastEvent({
+    ledger_sequence: 10,
+    contract_id: "C1",
+    event_name: "TaskRegistered",
+    task_id: 42,
+    data: { creator: "A" },
+  });
+
+  const got = await matchingRecv;
+  assert.ok(got, "matching subscriber received an event");
+  assert.equal(got.event.task_id, 42);
+  assert.equal(got.event.event_name, "TaskRegistered");
+  assert.ok(got.topic.startsWith("task:"));
+
+  const none = await nonMatchingRecv;
+  assert.equal(none, null, "non-matching subscriber received nothing");
+
+  matching.close();
+  nonMatching.close();
+  await server.close();
+});

--- a/zk-proof-service/alerts.yml
+++ b/zk-proof-service/alerts.yml
@@ -1,0 +1,46 @@
+# Prometheus alerting rules for the SoroTask ZK proof service (issue #860).
+#
+# These reference the metrics exported at GET /metrics:
+#   zk_worker_pool_active, zk_worker_pool_capacity,
+#   zk_proof_duration_ms, zk_queue_wait_ms
+#
+# NOTE: This file is an ops/infra deliverable. It is provided in standard
+# Prometheus alerting-rule format, but actually wiring it into a live
+# Prometheus + Alertmanager deployment (rule_files, routing, receivers) and an
+# autoscaler is an operational task that cannot be verified by an application
+# code change alone. Load it via prometheus.yml `rule_files:`.
+groups:
+  - name: zk-proof-service
+    rules:
+      - alert: ZkWorkerPoolSaturated
+        # All workers busy for a sustained period -> scale the pool out.
+        expr: (zk_worker_pool_active >= zk_worker_pool_capacity) and (zk_worker_pool_capacity > 0)
+        for: 2m
+        labels:
+          severity: warning
+          service: zk-proof-service
+        annotations:
+          summary: "ZK worker pool saturated"
+          description: "All {{ $value }} workers have been busy for 2m. Consider scaling out."
+
+      - alert: ZkQueueWaitHigh
+        # p95 queue-wait latency is high -> requests are backing up.
+        expr: histogram_quantile(0.95, sum(rate(zk_queue_wait_ms_bucket[5m])) by (le)) > 250
+        for: 5m
+        labels:
+          severity: warning
+          service: zk-proof-service
+        annotations:
+          summary: "ZK proof queue wait p95 high"
+          description: "p95 queue wait > 250ms over 5m; add capacity."
+
+      - alert: ZkProofDurationHigh
+        # p95 proof generation is slow -> possible resource pressure.
+        expr: histogram_quantile(0.95, sum(rate(zk_proof_duration_ms_bucket[5m])) by (le)) > 5000
+        for: 5m
+        labels:
+          severity: critical
+          service: zk-proof-service
+        annotations:
+          summary: "ZK proof generation p95 latency high"
+          description: "p95 proof generation > 5s over 5m."

--- a/zk-proof-service/lib/metrics.js
+++ b/zk-proof-service/lib/metrics.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Prometheus metrics for the ZK proof service (issue #860).
+ *
+ * Reality note: the current ZKProofService uses a lightweight in-memory worker
+ * pool (see index.js) with no real backlog queue -- generateProof acquires an
+ * idle worker synchronously and rejects with "Worker pool at capacity" when
+ * none is free. These metrics are therefore wired to the ACTUAL execution path
+ * in server.js (per-request timing + the worker pool's own status counters)
+ * rather than to an invented distributed queue:
+ *
+ *   zk_worker_pool_active   (gauge)     active workers in the pool
+ *   zk_worker_pool_capacity (gauge)     total workers in the pool
+ *   zk_proof_duration_ms    (histogram) wall time of generateProof()
+ *   zk_queue_wait_ms        (histogram) time a request waited before a worker
+ *                                       began executing it (queue-wait proxy)
+ *
+ * A dedicated Registry is used (not the global default) so tests can create
+ * isolated instances without metric-name collisions.
+ */
+
+const client = require('prom-client');
+
+function createMetrics() {
+  const registry = new client.Registry();
+
+  const workerPoolActive = new client.Gauge({
+    name: 'zk_worker_pool_active',
+    help: 'Number of active (busy) workers in the ZK proof worker pool',
+    registers: [registry],
+  });
+
+  const workerPoolCapacity = new client.Gauge({
+    name: 'zk_worker_pool_capacity',
+    help: 'Total number of workers configured in the ZK proof worker pool',
+    registers: [registry],
+  });
+
+  const proofDurationMs = new client.Histogram({
+    name: 'zk_proof_duration_ms',
+    help: 'Duration of ZK proof generation in milliseconds',
+    buckets: [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+    registers: [registry],
+  });
+
+  const queueWaitMs = new client.Histogram({
+    name: 'zk_queue_wait_ms',
+    help: 'Time a proof request waited before a worker began executing it (ms)',
+    buckets: [1, 5, 10, 25, 50, 100, 250, 500, 1000],
+    registers: [registry],
+  });
+
+  return {
+    registry,
+    workerPoolActive,
+    workerPoolCapacity,
+    proofDurationMs,
+    queueWaitMs,
+  };
+}
+
+module.exports = { createMetrics, client };

--- a/zk-proof-service/package-lock.json
+++ b/zk-proof-service/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "jest": "^30.4.2",
@@ -47,6 +48,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -511,29 +513,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1012,6 +991,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -1740,6 +1728,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -1807,6 +1801,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -4351,6 +4346,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4962,6 +4970,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/zk-proof-service/package.json
+++ b/zk-proof-service/package.json
@@ -14,7 +14,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "jest": "^30.4.2",

--- a/zk-proof-service/server.js
+++ b/zk-proof-service/server.js
@@ -1,8 +1,12 @@
 const express = require('express');
 const { ZKProofService } = require('./index');
 const { hashTaskCondition, serializeProof, checkConstraint } = require('./lib/helpers');
+const { createMetrics } = require('./lib/metrics');
 
 const SERVICE_VERSION = '1.0.0';
+// Queue-depth safety threshold: when the number of in-flight proof requests
+// exceeds this, /health reports 503 so an orchestrator can shed load / scale.
+const DEFAULT_QUEUE_DEPTH_THRESHOLD = 50;
 
 function sendError(res, status, code, message, details) {
   const payload = { error: { code, message } };
@@ -52,6 +56,14 @@ function createApp(zkService, options = {}) {
   const apiToken = options.apiToken ?? process.env.ZK_PROOF_API_TOKEN;
   const version = options.version ?? SERVICE_VERSION;
   const startTime = options.startTime ?? Date.now();
+  const metrics = options.metrics ?? createMetrics();
+  const queueDepthThreshold =
+    options.queueDepthThreshold ??
+    (Number(process.env.ZK_QUEUE_DEPTH_THRESHOLD) || DEFAULT_QUEUE_DEPTH_THRESHOLD);
+
+  // In-flight proof requests -- the real concurrency signal / "queue depth"
+  // for this service (there is no separate backlog queue; see lib/metrics.js).
+  let inFlight = 0;
 
   app.use(express.json({ limit: '1mb' }));
 
@@ -64,19 +76,41 @@ function createApp(zkService, options = {}) {
     return next();
   }
 
+  // Reflect current worker-pool status into the gauges.
+  function syncPoolGauges() {
+    const pool = zkService.getWorkerPoolStatus();
+    metrics.workerPoolActive.set(pool.activeWorkers);
+    metrics.workerPoolCapacity.set(pool.totalWorkers);
+    return pool;
+  }
+
   app.get('/health', (_req, res) => {
-    const workerPool = zkService.getWorkerPoolStatus();
+    const workerPool = syncPoolGauges();
     let status = 'unavailable';
     if (zkService.isReady && workerPool.totalWorkers > 0) {
       status = workerPool.activeWorkers === workerPool.totalWorkers ? 'degraded' : 'healthy';
     }
-    const httpStatus = status === 'unavailable' ? 503 : 200;
+    // Issue #860: report 503 when queue depth exceeds the safety threshold.
+    const queueOverloaded = inFlight > queueDepthThreshold;
+    if (queueOverloaded && status !== 'unavailable') {
+      status = 'overloaded';
+    }
+    const httpStatus = status === 'unavailable' || status === 'overloaded' ? 503 : 200;
     res.status(httpStatus).json({
       status,
       version,
       workerPool,
+      queueDepth: inFlight,
+      queueDepthThreshold,
       uptimeSeconds: Math.floor((Date.now() - startTime) / 1000),
     });
+  });
+
+  // Issue #860: Prometheus scrape endpoint.
+  app.get('/metrics', async (_req, res) => {
+    syncPoolGauges();
+    res.set('Content-Type', metrics.registry.contentType);
+    res.end(await metrics.registry.metrics());
   });
 
   app.post('/generate-proof', authenticate, async (req, res) => {
@@ -107,8 +141,15 @@ function createApp(zkService, options = {}) {
       );
     }
 
+    // queue-wait proxy: time from request receipt until the worker begins work.
+    metrics.queueWaitMs.observe(Date.now() - startedAt);
+
+    inFlight += 1;
+    const genStart = Date.now();
     try {
       const rawProof = await zkService.generateProof(taskCondition, clientData);
+      metrics.proofDurationMs.observe(Date.now() - genStart);
+      syncPoolGauges();
       const conditionHash = hashTaskCondition(taskCondition);
       const proof = {
         pi_a: rawProof.pi_a,
@@ -135,6 +176,9 @@ function createApp(zkService, options = {}) {
         return sendError(res, 400, 'INVALID_INPUT', error.message);
       }
       return sendError(res, 500, 'PROOF_GENERATION_FAILED', error.message);
+    } finally {
+      inFlight -= 1;
+      syncPoolGauges();
     }
   });
 

--- a/zk-proof-service/server.test.js
+++ b/zk-proof-service/server.test.js
@@ -37,4 +37,55 @@ describe('server', () => {
     expect(response.status).toBe(503);
     expect(response.body.status).toBe('unavailable');
   });
+
+  test('GET /health reports queue depth and threshold', async () => {
+    const app = createApp(zkService, { queueDepthThreshold: 50 });
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.queueDepth).toBe(0);
+    expect(response.body.queueDepthThreshold).toBe(50);
+  });
+
+  test('GET /health returns 503 overloaded when queue depth exceeds threshold', async () => {
+    // A negative threshold forces the overload branch deterministically:
+    // inFlight (0) > -1, exercising the 503 queue-depth safety path.
+    const app = createApp(zkService, { queueDepthThreshold: -1 });
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(503);
+    expect(response.body.status).toBe('overloaded');
+  });
+
+  test('GET /metrics exposes the ZK Prometheus metrics', async () => {
+    const app = createApp(zkService);
+    const response = await request(app).get('/metrics');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/text\/plain/);
+    expect(response.text).toContain('zk_worker_pool_active');
+    expect(response.text).toContain('zk_worker_pool_capacity');
+    expect(response.text).toContain('zk_proof_duration_ms');
+    expect(response.text).toContain('zk_queue_wait_ms');
+    // Capacity gauge reflects the configured worker count (2).
+    expect(response.text).toMatch(/zk_worker_pool_capacity\s+2/);
+  });
+
+  test('POST /generate-proof records proof duration in metrics', async () => {
+    const metrics = require('./lib/metrics').createMetrics();
+    const app = createApp(zkService, { metrics });
+
+    const res = await request(app)
+      .post('/generate-proof')
+      .send({
+        taskId: 1,
+        circuitId: 'liquidity-threshold-v1',
+        taskCondition: { type: 'liquidity-threshold', params: { minLiquidity: 10 } },
+        clientData: { witness: { actualLiquidity: 100 } },
+      });
+
+    expect(res.status).toBe(200);
+    const scrape = await metrics.registry.metrics();
+    expect(scrape).toMatch(/zk_proof_duration_ms_count\s+1/);
+  });
 });


### PR DESCRIPTION
## Summary

The indexer uses **SQLite** (not Postgres), and `zk-proof-service` had **no real backlog queue** before this PR — both realities are reflected in the scoping below rather than papering over them.

- **#863 — Merkle tree event verification.** `indexer/src/merkle.js` is a dependency-free sorted-pair SHA-256 Merkle tree (construction/proof/verify over `crypto.createHash`). `indexer/src/merkleStore.js` adds a `merkle_roots` table keyed by `ledger_sequence`, (re)computed per ledger in the existing poll loop after ingestion. New endpoint `GET /events/:ledger/merkle-proof` — no query param returns `{root, storedRoot, leafCount, leaves:[{id,leaf}]}`; `?eventId=<events.id>` returns `{leaf, proof:[...siblings], root, storedRoot, index}` for verifying a specific event's inclusion. Tests confirm a valid proof verifies against the stored root and that tampering with an event invalidates it.
- **#861 — Real-time WebSocket event streaming.** `indexer/src/wsServer.js` adds an in-process pub/sub WebSocket server (`ws` package) attached to the existing API HTTP server at `ws://<host>:4000/ws`, with prefix/wildcard topic subscriptions (`task:*`, `keeper:*`, `contract:*`, or an exact id like `task:5`). Protocol: client sends `{action: "subscribe"|"unsubscribe", topic}`; server replies with `{type: "subscribed"|...}` and pushes `{type: "event", topic, event}` as events are ingested. Tests confirm a `task:*` subscriber receives a task event and a `keeper:*` subscriber does not.
- **#860 — ZK proof service Prometheus metrics.** `zk-proof-service/lib/metrics.js` (prom-client, dedicated Registry) exports `zk_worker_pool_active`/`zk_worker_pool_capacity` (gauges) and `zk_proof_duration_ms`/`zk_queue_wait_ms` (histograms). New `GET /metrics` (Prometheus text format). `GET /health` now reports `queueDepth`/`queueDepthThreshold` and returns 503 `"overloaded"` once in-flight requests exceed `ZK_QUEUE_DEPTH_THRESHOLD` (default 50). Added `zk-proof-service/alerts.yml` with 3 standard Prometheus alerting rules (pool saturated, queue-wait p95, proof-duration p95) — wiring this into a live Prometheus/Alertmanager + autoscaler is an infra deployment step outside a code-only change. **Scope note:** the existing worker pool has no backlog queue (synchronous acquire, rejects at capacity), so "queue depth" metrics are wired to in-flight-request counts against the real pool, not a fabricated queue.
- **#862 — Database read-replica load balancer.** `indexer/src/dbRouter.js` is an engine-agnostic read/write splitter: writes pinned to primary, reads round-robined across configured replicas, with primary fallback when none are configured (so existing single-DB deployments are unaffected by default). `graphql/db.js` routes all resolver + the new Merkle REST route's reads through it; writes go through `queryRun` to primary. Replicas configured via `DATABASE_READ_REPLICA_URLS` (comma-separated, empty by default). **Scope note:** since the indexer runs SQLite rather than Postgres, there's no real network-replica topology to route against today — this ships a correct, tested read/write splitter that's ready to point at real Postgres replicas if/when the indexer migrates, rather than fake replica-routing logic for an engine that has none.

## Test results
- `zk-proof-service`: **17/17 pass** (`npm test`).
- `indexer`: **16/18** (`node --test`) — the 2 failures are pre-existing and unrelated (a jest-style test file picked up by `node --test`, and a date-sensitive `staleTasks` test); all 15 new tests added by this PR pass.
- Dependencies added with `--legacy-peer-deps` due to a pre-existing apollo/express peer conflict in the repo: `ws` (indexer), `prom-client` (zk-proof-service).

Closes #863, #861, #860, #862

## Test plan
- [ ] `npm test` in both `indexer/` and `zk-proof-service/` (already verified locally, see above)
- [ ] Manually connect a WebSocket client to `/ws`, subscribe to `task:*`, and confirm live events arrive as they're ingested
- [ ] Fetch `GET /events/:ledger/merkle-proof?eventId=<id>` and independently verify the returned proof against the stored root
- [ ] Scrape `GET /metrics` on zk-proof-service and confirm the 4 new metrics appear; trigger the 503 path by exceeding `ZK_QUEUE_DEPTH_THRESHOLD`
- [ ] Confirm indexer behavior is unchanged when `DATABASE_READ_REPLICA_URLS` is unset