### PR TITLE
feat: database read-replica load balancer / read-write splitter (closes #862)

### DIFF
--- a/indexer/src/dbRouter.js
+++ b/indexer/src/dbRouter.js
@@ -1,0 +1,100 @@
+"use strict";
+
+/**
+ * Database read-replica load balancer / read-write splitter (issue #862).
+ *
+ * IMPORTANT DB-ENGINE REALITY: the indexer currently uses sqlite3 -- an
+ * embedded, single-file database (see indexer/src/index.js and
+ * indexer/src/graphql/db.js). SQLite has no concept of network read replicas
+ * the way PostgreSQL does, so building "replica routing" against SQLite alone
+ * would be fake for the actual engine. What is genuinely useful and real,
+ * regardless of engine, is a read/write-splitting *router*:
+ *
+ *   - writes (event ingestion) are pinned to the PRIMARY connection;
+ *   - reads (GraphQL resolvers, REST GETs) round-robin across N configured
+ *     read connections;
+ *   - if no read connections are configured, reads fall back to the primary,
+ *     so existing single-DB (single-file SQLite) deployments keep working
+ *     unchanged.
+ *
+ * The router is engine-agnostic: each "connection" is any object exposing
+ * queryAll / queryGet / queryRun. In today's SQLite deployment the replica
+ * list is empty and everything correctly falls back to primary. If the indexer
+ * is later moved to Postgres, `createConnection` can be pointed at pg pools and
+ * DATABASE_READ_REPLICA_URLS will fan reads across real replicas with no
+ * changes to the call sites.
+ */
+
+/**
+ * @typedef {Object} DbConnection
+ * @property {(sql:string, params?:any[]) => Promise<any[]>} queryAll
+ * @property {(sql:string, params?:any[]) => Promise<any>}   queryGet
+ * @property {(sql:string, params?:any[]) => Promise<any>}   queryRun
+ */
+
+class DbRouter {
+  /**
+   * @param {{ primary: DbConnection, replicas?: DbConnection[] }} opts
+   */
+  constructor({ primary, replicas = [] }) {
+    if (!primary) throw new Error("DbRouter requires a primary connection");
+    this.primary = primary;
+    this.replicas = replicas.filter(Boolean);
+    this._rr = 0;
+  }
+
+  /** @returns {boolean} */
+  hasReplicas() {
+    return this.replicas.length > 0;
+  }
+
+  /**
+   * Pick a connection for READ queries: round-robin across replicas, or the
+   * primary if none are configured.
+   * @returns {DbConnection}
+   */
+  getReadConnection() {
+    if (this.replicas.length === 0) return this.primary;
+    const conn = this.replicas[this._rr % this.replicas.length];
+    this._rr = (this._rr + 1) % this.replicas.length;
+    return conn;
+  }
+
+  /**
+   * Pick the connection for WRITE queries: always the primary.
+   * @returns {DbConnection}
+   */
+  getWriteConnection() {
+    return this.primary;
+  }
+
+  // Read paths -> read connection (replica or primary fallback).
+  queryAll(sql, params = []) {
+    return this.getReadConnection().queryAll(sql, params);
+  }
+
+  queryGet(sql, params = []) {
+    return this.getReadConnection().queryGet(sql, params);
+  }
+
+  // Write path -> primary only.
+  queryRun(sql, params = []) {
+    return this.getWriteConnection().queryRun(sql, params);
+  }
+}
+
+/**
+ * Parse a comma-separated list of replica connection strings from the
+ * environment (empty/undefined -> []).
+ * @param {string|undefined} raw
+ * @returns {string[]}
+ */
+function parseReplicaUrls(raw) {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+module.exports = { DbRouter, parseReplicaUrls };

--- a/indexer/src/graphql/db.js
+++ b/indexer/src/graphql/db.js
@@ -1,41 +1,59 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const { DbRouter, parseReplicaUrls } = require('../dbRouter');
 
 // Connect to the same DB file as the indexer
 const DB_FILE = process.env.DB_FILE || path.resolve(__dirname, '../../indexer.db');
-const db = new sqlite3.Database(DB_FILE);
 
-// Helper function to query the DB with Promises
-function queryAll(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    db.all(sql, params, (err, rows) => {
-      if (err) reject(err);
-      else resolve(rows);
-    });
-  });
+/**
+ * Wrap a sqlite3.Database in the { queryAll, queryGet, queryRun } connection
+ * interface the DbRouter expects.
+ * @param {import('sqlite3').Database} database
+ */
+function wrapConnection(database) {
+  return {
+    _db: database,
+    queryAll(sql, params = []) {
+      return new Promise((resolve, reject) => {
+        database.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)));
+      });
+    },
+    queryGet(sql, params = []) {
+      return new Promise((resolve, reject) => {
+        database.get(sql, params, (err, row) => (err ? reject(err) : resolve(row)));
+      });
+    },
+    queryRun(sql, params = []) {
+      return new Promise((resolve, reject) => {
+        database.run(sql, params, function (err) { return err ? reject(err) : resolve(this); });
+      });
+    },
+  };
 }
 
-function queryGet(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    db.get(sql, params, (err, row) => {
-      if (err) reject(err);
-      else resolve(row);
-    });
-  });
-}
+// Primary connection (writes + read fallback).
+const primaryDb = new sqlite3.Database(DB_FILE);
+const primary = wrapConnection(primaryDb);
 
-function queryRun(sql, params = []) {
-  return new Promise((resolve, reject) => {
-    db.run(sql, params, function(err) {
-      if (err) reject(err);
-      else resolve(this);
-    });
-  });
-}
+// Issue #862: read replicas configured via DATABASE_READ_REPLICA_URLS
+// (comma-separated). For SQLite these are additional file paths (typically
+// read-only replicas synced out of band); the list is normally empty, in which
+// case reads fall back to the primary and behaviour is unchanged. Replicas are
+// opened read-only so a misrouted write fails loudly instead of diverging.
+const replicaPaths = parseReplicaUrls(process.env.DATABASE_READ_REPLICA_URLS);
+const replicas = replicaPaths.map((p) =>
+  wrapConnection(new sqlite3.Database(p, sqlite3.OPEN_READONLY)),
+);
 
+const router = new DbRouter({ primary, replicas });
+
+// Backwards-compatible exports: reads go through the router (replica or primary
+// fallback); writes go to the primary. `db` remains the raw primary handle for
+// any legacy callers that use it directly.
 module.exports = {
-  db,
-  queryAll,
-  queryGet,
-  queryRun
+  db: primaryDb,
+  router,
+  queryAll: (sql, params = []) => router.queryAll(sql, params),
+  queryGet: (sql, params = []) => router.queryGet(sql, params),
+  queryRun: (sql, params = []) => router.queryRun(sql, params),
 };

--- a/indexer/test/dbRouter.test.js
+++ b/indexer/test/dbRouter.test.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { DbRouter, parseReplicaUrls } = require("../src/dbRouter");
+
+function mockConn(name) {
+  const calls = { reads: 0, writes: 0 };
+  return {
+    name,
+    calls,
+    queryAll: async () => { calls.reads += 1; return [{ from: name }]; },
+    queryGet: async () => { calls.reads += 1; return { from: name }; },
+    queryRun: async () => { calls.writes += 1; return { from: name }; },
+  };
+}
+
+test("parseReplicaUrls handles empty and comma-separated values", () => {
+  assert.deepEqual(parseReplicaUrls(undefined), []);
+  assert.deepEqual(parseReplicaUrls(""), []);
+  assert.deepEqual(parseReplicaUrls("a.db, b.db ,, c.db"), ["a.db", "b.db", "c.db"]);
+});
+
+test("with replicas configured: reads round-robin across replicas, writes go to primary", async () => {
+  const primary = mockConn("primary");
+  const r1 = mockConn("r1");
+  const r2 = mockConn("r2");
+  const router = new DbRouter({ primary, replicas: [r1, r2] });
+
+  assert.equal(router.hasReplicas(), true);
+
+  // Six reads should distribute evenly across the two replicas, none to primary.
+  const results = [];
+  for (let i = 0; i < 6; i++) {
+    results.push((await router.queryAll("SELECT 1"))[0].from);
+  }
+  assert.deepEqual(results, ["r1", "r2", "r1", "r2", "r1", "r2"]);
+  assert.equal(r1.calls.reads, 3);
+  assert.equal(r2.calls.reads, 3);
+  assert.equal(primary.calls.reads, 0);
+
+  // Writes always hit the primary, never the replicas.
+  await router.queryRun("INSERT INTO t VALUES (1)");
+  await router.queryRun("INSERT INTO t VALUES (2)");
+  assert.equal(primary.calls.writes, 2);
+  assert.equal(r1.calls.writes, 0);
+  assert.equal(r2.calls.writes, 0);
+});
+
+test("with no replicas: reads and writes all fall back to primary", async () => {
+  const primary = mockConn("primary");
+  const router = new DbRouter({ primary, replicas: [] });
+
+  assert.equal(router.hasReplicas(), false);
+
+  const readRow = await router.queryGet("SELECT 1");
+  assert.equal(readRow.from, "primary");
+  await router.queryRun("INSERT INTO t VALUES (1)");
+
+  assert.equal(primary.calls.reads, 1);
+  assert.equal(primary.calls.writes, 1);
+});
+
+test("getReadConnection / getWriteConnection selection", () => {
+  const primary = mockConn("primary");
+  const r1 = mockConn("r1");
+  const router = new DbRouter({ primary, replicas: [r1] });
+  assert.equal(router.getWriteConnection().name, "primary");
+  assert.equal(router.getReadConnection().name, "r1");
+});


### PR DESCRIPTION
Split out of #957 per request. Closes #862.