### PR TITLE
feat: OpenAPI v3 docs, task simulation workbench, DnD reorder board, state management refactor

### DIFF
--- a/frontend/app/tasks/page.tsx
+++ b/frontend/app/tasks/page.tsx
@@ -5,6 +5,7 @@ import { useTasks } from "@/src/hooks/tasks";
 import { useLayoutStore } from "@/src/store/layoutStore";
 import SplitPaneLayout from "@/src/components/layout/SplitPaneLayout";
 import TaskCardWithSelection from "@/components/TaskCardWithSelection";
+import TaskSimulationWorkbench from "@/components/TaskSimulationWorkbench";
 import type { TaskFilters } from "@/src/lib/query/keys";
 import { createPerformanceMonitor, afterNextPaint } from "@/src/lib/frontend-performance";
 
@@ -200,6 +201,10 @@ function TasksPageContent() {
             </div>
           </div>
         )}
+      </div>
+      {/* #872 Simulation Workbench — mounted in the detail panel */}
+      <div className="mt-6 px-6 pb-6">
+        <TaskSimulationWorkbench />
       </div>
     </SplitPaneLayout>
   );

--- a/frontend/components/TaskSimulationWorkbench.tsx
+++ b/frontend/components/TaskSimulationWorkbench.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+/**
+ * #872 — Interactive Task Simulation Workbench
+ *
+ * Allows users to override task state fields in-browser and get an estimated
+ * gas cost for executing the task in that state. No network calls are made —
+ * all estimation is performed client-side using the same heuristics the Keeper
+ * uses off-chain.
+ */
+
+import { useState, useCallback } from "react";
+import MarkdownEditor from "./MarkdownEditor";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type TaskState = "pending" | "active" | "paused" | "completed" | "failed";
+
+interface SimulationInputs {
+  taskId: string;
+  target: string;
+  functionName: string;
+  interval: number;
+  gasBalance: number;
+  stateOverride: TaskState;
+  argsJson: string;
+  /** Rich markdown instructions shown to keepers executing this task */
+  instructions: string;
+}
+
+interface SimulationResult {
+  estimatedGas: number;
+  estimatedFeeXLM: string;
+  canExecute: boolean;
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Gas estimation heuristic
+// ---------------------------------------------------------------------------
+
+const BASE_GAS_UNITS = 100_000;
+const ARG_GAS_PER_BYTE = 50;
+const STATE_MULTIPLIERS: Record<TaskState, number> = {
+  pending: 1.0,
+  active: 1.0,
+  paused: 0.0,
+  completed: 0.0,
+  failed: 1.2, // retry overhead
+};
+const XLM_PER_GAS_UNIT = 0.000_000_1;
+
+function estimateGas(inputs: SimulationInputs): SimulationResult {
+  const warnings: string[] = [];
+
+  const multiplier = STATE_MULTIPLIERS[inputs.stateOverride];
+
+  if (multiplier === 0) {
+    return {
+      estimatedGas: 0,
+      estimatedFeeXLM: "0.0000000",
+      canExecute: false,
+      warnings: [`Task in state "${inputs.stateOverride}" cannot be executed.`],
+    };
+  }
+
+  let argsBytes = 0;
+  try {
+    const parsed = JSON.parse(inputs.argsJson || "[]");
+    argsBytes = JSON.stringify(parsed).length;
+  } catch {
+    warnings.push("args_json is not valid JSON — using 0 bytes for estimation.");
+  }
+
+  const rawGas = Math.round(
+    (BASE_GAS_UNITS + argsBytes * ARG_GAS_PER_BYTE) * multiplier
+  );
+
+  const feeXLM = rawGas * XLM_PER_GAS_UNIT;
+
+  if (inputs.gasBalance < feeXLM) {
+    warnings.push(
+      `Gas balance (${inputs.gasBalance} XLM) is insufficient for estimated fee (${feeXLM.toFixed(7)} XLM).`
+    );
+  }
+
+  if (inputs.interval < 60) {
+    warnings.push("Interval below 60 s — high execution frequency may exhaust gas quickly.");
+  }
+
+  return {
+    estimatedGas: rawGas,
+    estimatedFeeXLM: feeXLM.toFixed(7),
+    canExecute: inputs.gasBalance >= feeXLM,
+    warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const TASK_STATES: TaskState[] = ["pending", "active", "paused", "completed", "failed"];
+
+const DEFAULT_INPUTS: SimulationInputs = {
+  taskId: "task-001",
+  target: "CC3XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  functionName: "execute",
+  interval: 3600,
+  gasBalance: 10,
+  stateOverride: "active",
+  argsJson: "[]",
+  instructions: "",
+};
+
+export default function TaskSimulationWorkbench() {
+  const [inputs, setInputs] = useState<SimulationInputs>(DEFAULT_INPUTS);
+  const [result, setResult] = useState<SimulationResult | null>(null);
+
+  const handleChange = useCallback(
+    <K extends keyof SimulationInputs>(key: K, value: SimulationInputs[K]) => {
+      setInputs((prev) => ({ ...prev, [key]: value }));
+      setResult(null);
+    },
+    []
+  );
+
+  const handleSimulate = useCallback(() => {
+    setResult(estimateGas(inputs));
+  }, [inputs]);
+
+  const handleReset = useCallback(() => {
+    setInputs(DEFAULT_INPUTS);
+    setResult(null);
+  }, []);
+
+  return (
+    <section
+      aria-label="Task Simulation Workbench"
+      className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 shadow-sm space-y-6"
+    >
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+          Task Simulation Workbench
+        </h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Override task state fields and estimate gas cost before submitting on-chain.
+        </p>
+      </header>
+
+      {/* Inputs */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Field label="Task ID">
+          <input
+            type="text"
+            value={inputs.taskId}
+            onChange={(e) => handleChange("taskId", e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Target Contract">
+          <input
+            type="text"
+            value={inputs.target}
+            onChange={(e) => handleChange("target", e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Function Name">
+          <input
+            type="text"
+            value={inputs.functionName}
+            onChange={(e) => handleChange("functionName", e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Interval (seconds)">
+          <input
+            type="number"
+            min={1}
+            value={inputs.interval}
+            onChange={(e) => handleChange("interval", Number(e.target.value))}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="Gas Balance (XLM)">
+          <input
+            type="number"
+            min={0}
+            step={0.1}
+            value={inputs.gasBalance}
+            onChange={(e) => handleChange("gasBalance", Number(e.target.value))}
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="State Override">
+          <select
+            value={inputs.stateOverride}
+            onChange={(e) =>
+              handleChange("stateOverride", e.target.value as TaskState)
+            }
+            className={inputCls}
+          >
+            {TASK_STATES.map((s) => (
+              <option key={s} value={s}>
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="args_json" className="sm:col-span-2">
+          <textarea
+            rows={3}
+            value={inputs.argsJson}
+            onChange={(e) => handleChange("argsJson", e.target.value)}
+            placeholder='e.g. ["arg1", 42]'
+            className={`${inputCls} resize-y font-mono text-xs`}
+          />
+        </Field>
+      </div>
+
+      {/* #877 — Rich Markdown & Code Snippet Editor for task instructions */}
+      <div className="mt-4">
+        <label className="block text-xs font-semibold text-neutral-400 mb-1 uppercase tracking-wide">
+          Task Instructions (Markdown)
+        </label>
+        <MarkdownEditor
+          value={inputs.instructions}
+          onChange={(v) => handleChange("instructions", v)}
+          label="Task instructions"
+          placeholder={
+            "Describe what the keeper should do.\n\nSupports **bold**, *italic*, `inline code`, and fenced code blocks:\n\n```js\nconsole.log('hello');\n```"
+          }
+          minHeight={160}
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        <button
+          onClick={handleSimulate}
+          className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        >
+          Simulate
+        </button>
+        <button
+          onClick={handleReset}
+          className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400"
+        >
+          Reset
+        </button>
+      </div>
+
+      {/* Result */}
+      {result && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`rounded-xl border p-4 space-y-3 ${
+            result.canExecute
+              ? "border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-950"
+              : "border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-950"
+          }`}
+        >
+          <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+            Simulation Result
+          </p>
+          <dl className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+            <Stat label="Estimated Gas" value={result.estimatedGas.toLocaleString()} />
+            <Stat label="Estimated Fee" value={`${result.estimatedFeeXLM} XLM`} />
+            <Stat
+              label="Can Execute"
+              value={result.canExecute ? "Yes" : "No"}
+              valueClass={result.canExecute ? "text-green-700 dark:text-green-400" : "text-red-700 dark:text-red-400"}
+            />
+          </dl>
+          {result.warnings.length > 0 && (
+            <ul className="space-y-1">
+              {result.warnings.map((w, i) => (
+                <li key={i} className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+                  <span aria-hidden>&#x26A0;</span>
+                  {w}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const inputCls =
+  "w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 " +
+  "px-3 py-2 text-sm text-gray-900 dark:text-gray-100 " +
+  "focus:outline-none focus:ring-2 focus:ring-indigo-500";
+
+function Field({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <label className={`flex flex-col gap-1 ${className}`}>
+      <span className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  valueClass = "text-gray-900 dark:text-gray-100",
+}: {
+  label: string;
+  value: string;
+  valueClass?: string;
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-500 dark:text-gray-400">{label}</dt>
+      <dd className={`font-semibold ${valueClass}`}>{value}</dd>
+    </div>
+  );
+}

--- a/frontend/components/board/TaskReorderBoard.tsx
+++ b/frontend/components/board/TaskReorderBoard.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+/**
+ * #878 — Drag-and-Drop Task Reordering Board
+ *
+ * A focused single-column reorder board powered by @dnd-kit/sortable.
+ * Keyboard accessibility:
+ *   - Tab / Shift-Tab to focus items
+ *   - Space / Enter    to pick up an item (announces "grabbed, position N of M")
+ *   - ArrowUp / ArrowDown to move the grabbed item
+ *   - Space / Enter    to drop at the current position
+ *   - Escape           to cancel and return to the original position
+ *
+ * Uses live-region announcements so screen readers convey position changes
+ * without relying on visual focus rings alone.
+ */
+
+import { useCallback, useId, useRef, useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReorderTask {
+  id: string;
+  title: string;
+  status?: string;
+  priority?: "low" | "medium" | "high";
+}
+
+interface TaskReorderBoardProps {
+  initialTasks?: ReorderTask[];
+  onOrderChange?: (orderedTasks: ReorderTask[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Announcement messages (a11y)
+// ---------------------------------------------------------------------------
+
+function buildAnnouncements(tasks: ReorderTask[]) {
+  return {
+    onDragStart({ active }: { active: { id: string | number } }) {
+      const idx = tasks.findIndex((t) => t.id === active.id);
+      const task = tasks[idx];
+      return task
+        ? `Grabbed "${task.title}", position ${idx + 1} of ${tasks.length}.`
+        : undefined;
+    },
+    onDragOver({ active, over }: { active: { id: string | number }; over: { id: string | number } | null }) {
+      if (!over) return undefined;
+      const overIdx = tasks.findIndex((t) => t.id === over.id);
+      return `Moving to position ${overIdx + 1} of ${tasks.length}.`;
+    },
+    onDragEnd({ active, over }: { active: { id: string | number }; over: { id: string | number } | null }) {
+      if (!over || active.id === over.id) return `Cancelled — item returned to original position.`;
+      const overIdx = tasks.findIndex((t) => t.id === over.id);
+      const task = tasks.find((t) => t.id === active.id);
+      return task
+        ? `Dropped "${task.title}" at position ${overIdx + 1} of ${tasks.length}.`
+        : undefined;
+    },
+    onDragCancel() {
+      return "Drag cancelled — item returned to original position.";
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default data
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TASKS: ReorderTask[] = [
+  { id: "rt-1", title: "Implement wallet connect", status: "Todo", priority: "high" },
+  { id: "rt-2", title: "Add rate limiter to GraphQL", status: "In Progress", priority: "high" },
+  { id: "rt-3", title: "Write keeper integration tests", status: "Todo", priority: "medium" },
+  { id: "rt-4", title: "Update OpenAPI spec", status: "Done", priority: "low" },
+  { id: "rt-5", title: "Fix staleTasks reconciler edge case", status: "Todo", priority: "medium" },
+];
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function TaskReorderBoard({
+  initialTasks = DEFAULT_TASKS,
+  onOrderChange,
+}: TaskReorderBoardProps) {
+  const [tasks, setTasks] = useState<ReorderTask[]>(initialTasks);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const announceRef = useRef<HTMLDivElement>(null);
+  const liveId = useId();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const announce = useCallback((msg: string | undefined) => {
+    if (!msg || !announceRef.current) return;
+    announceRef.current.textContent = msg;
+  }, []);
+
+  const handleDragStart = useCallback(
+    ({ active }: DragStartEvent) => {
+      setActiveId(String(active.id));
+      const idx = tasks.findIndex((t) => t.id === active.id);
+      const task = tasks[idx];
+      if (task) announce(`Grabbed "${task.title}", position ${idx + 1} of ${tasks.length}.`);
+    },
+    [tasks, announce]
+  );
+
+  const handleDragEnd = useCallback(
+    ({ active, over }: DragEndEvent) => {
+      setActiveId(null);
+      if (!over || active.id === over.id) {
+        announce("Drag cancelled — item returned to original position.");
+        return;
+      }
+      const oldIndex = tasks.findIndex((t) => t.id === active.id);
+      const newIndex = tasks.findIndex((t) => t.id === over.id);
+      const reordered = arrayMove(tasks, oldIndex, newIndex);
+      setTasks(reordered);
+      onOrderChange?.(reordered);
+      const task = tasks[oldIndex];
+      if (task) announce(`Dropped "${task.title}" at position ${newIndex + 1} of ${tasks.length}.`);
+    },
+    [tasks, onOrderChange, announce]
+  );
+
+  const activeTask = tasks.find((t) => t.id === activeId);
+
+  return (
+    <section aria-label="Task reorder board" className="space-y-4">
+      {/* Live region for screen reader announcements */}
+      <div
+        ref={announceRef}
+        id={liveId}
+        role="status"
+        aria-live="assertive"
+        aria-atomic="true"
+        className="sr-only"
+      />
+
+      <header>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Task Order
+        </h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Drag tasks to reorder, or focus an item and press{" "}
+          <kbd className="rounded border border-gray-300 dark:border-gray-600 px-1 font-mono text-xs">Space</kbd>{" "}
+          then{" "}
+          <kbd className="rounded border border-gray-300 dark:border-gray-600 px-1 font-mono text-xs">↑</kbd>{" "}
+          <kbd className="rounded border border-gray-300 dark:border-gray-600 px-1 font-mono text-xs">↓</kbd>{" "}
+          to move it with the keyboard.
+        </p>
+      </header>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => {
+          setActiveId(null);
+          announce("Drag cancelled — item returned to original position.");
+        }}
+        accessibility={{ announcements: buildAnnouncements(tasks) }}
+      >
+        <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+          <ol
+            aria-label="Reorderable task list"
+            className="space-y-2"
+            aria-describedby={liveId}
+          >
+            {tasks.map((task, index) => (
+              <SortableTaskRow
+                key={task.id}
+                task={task}
+                index={index}
+                total={tasks.length}
+                isGrabbed={task.id === activeId}
+              />
+            ))}
+          </ol>
+        </SortableContext>
+
+        <DragOverlay>
+          {activeTask && (
+            <div className="rounded-xl border-2 border-indigo-500 bg-white dark:bg-gray-800 px-4 py-3 shadow-2xl opacity-90">
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {activeTask.title}
+              </span>
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
+
+      {tasks.length === 0 && (
+        <p className="text-center text-sm text-gray-400 py-8">No tasks to reorder.</p>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SortableTaskRow
+// ---------------------------------------------------------------------------
+
+const PRIORITY_COLORS: Record<string, string> = {
+  high: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  medium: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  low: "bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400",
+};
+
+function SortableTaskRow({
+  task,
+  index,
+  total,
+  isGrabbed,
+}: {
+  task: ReorderTask;
+  index: number;
+  total: number;
+  isGrabbed: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: task.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      aria-label={`${task.title}, position ${index + 1} of ${total}`}
+      aria-grabbed={isGrabbed}
+      className={`flex items-center gap-3 rounded-xl border px-4 py-3 bg-white dark:bg-gray-800 select-none transition-shadow ${
+        isDragging
+          ? "opacity-40 shadow-none border-dashed border-indigo-400"
+          : "border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md"
+      }`}
+    >
+      {/* Drag handle */}
+      <button
+        {...listeners}
+        {...attributes}
+        aria-label={`Drag handle for "${task.title}"`}
+        className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded p-1"
+      >
+        <svg
+          aria-hidden="true"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <circle cx="5" cy="4" r="1.5" />
+          <circle cx="11" cy="4" r="1.5" />
+          <circle cx="5" cy="8" r="1.5" />
+          <circle cx="11" cy="8" r="1.5" />
+          <circle cx="5" cy="12" r="1.5" />
+          <circle cx="11" cy="12" r="1.5" />
+        </svg>
+      </button>
+
+      {/* Position badge */}
+      <span
+        aria-hidden="true"
+        className="flex-none w-6 text-center text-xs font-mono text-gray-400"
+      >
+        {index + 1}
+      </span>
+
+      {/* Title */}
+      <span className="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+        {task.title}
+      </span>
+
+      {/* Status */}
+      {task.status && (
+        <span className="flex-none text-xs text-gray-500 dark:text-gray-400">
+          {task.status}
+        </span>
+      )}
+
+      {/* Priority badge */}
+      {task.priority && (
+        <span
+          className={`flex-none rounded-full px-2 py-0.5 text-xs font-medium ${PRIORITY_COLORS[task.priority] ?? ""}`}
+        >
+          {task.priority}
+        </span>
+      )}
+    </li>
+  );
+}

--- a/frontend/store/useAppStore.ts
+++ b/frontend/store/useAppStore.ts
@@ -1,4 +1,45 @@
+/**
+ * #879 — Global State Management Refactoring
+ *
+ * Refactored from a single flat Zustand store into logically separated slices,
+ * each with explicit types, pure action creators, and deterministic ID
+ * generation (crypto.randomUUID where available, with a fallback).
+ *
+ * Slice separation keeps each domain independent so slices can be split into
+ * separate stores later without cascading changes across the app.
+ *
+ * Usage:
+ *   // Selector — only re-renders when walletAddress changes
+ *   const walletAddress = useAppStore((s) => s.walletAddress);
+ *
+ *   // Action — stable reference, will NOT cause re-renders by itself
+ *   const addTask = useAppStore((s) => s.addTask);
+ */
+
 import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function genId(prefix: string): string {
+  const rand =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : Math.random().toString(36).substring(2, 10);
+  return `${prefix}-${rand}`;
+}
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export type TaskStatus = 'active' | 'paused' | 'completed' | 'failed' | 'pending';
 
 export interface Task {
   id: string;
@@ -6,61 +47,157 @@ export interface Task {
   functionName: string;
   interval: number;
   gasBalance: number;
+  status: TaskStatus;
+  createdAt: string;
 }
+
+export type LogStatus = 'Success' | 'Failed' | 'Pending';
 
 export interface Log {
   id: string;
   taskId: string;
   target: string;
   keeper: string;
-  status: 'Success' | 'Failed' | 'Pending';
+  status: LogStatus;
   timestamp: string;
 }
 
-interface AppState {
-  // Wallet State
+// ---------------------------------------------------------------------------
+// Slice interfaces
+// ---------------------------------------------------------------------------
+
+interface WalletSlice {
   isWalletConnected: boolean;
   walletAddress: string | null;
-  connectWallet: () => void;
+  /** Connect with a real address or a mock address for development. */
+  connectWallet: (address?: string) => void;
   disconnectWallet: () => void;
-
-  // Task State
-  tasks: Task[];
-  addTask: (task: Omit<Task, 'id'>) => void;
-
-  // Log State
-  logs: Log[];
-  addLog: (log: Omit<Log, 'id' | 'timestamp'>) => void;
 }
 
-export const useAppStore = create<AppState>((set) => ({
-  // Wallet Slice
-  isWalletConnected: false,
-  walletAddress: null,
-  connectWallet: () => set({ isWalletConnected: true, walletAddress: 'GA32...XYZ9' }),
-  disconnectWallet: () => set({ isWalletConnected: false, walletAddress: null }),
+interface TaskSlice {
+  tasks: Task[];
+  /** Add a task and return its generated id. */
+  addTask: (task: Omit<Task, 'id' | 'createdAt'>) => string;
+  /** Update mutable fields on an existing task. Noop if the task is not found. */
+  updateTask: (id: string, patch: Partial<Omit<Task, 'id' | 'createdAt'>>) => void;
+  /** Remove a task by id. */
+  removeTask: (id: string) => void;
+  /** Convenience: reorder the tasks array (e.g. after drag-and-drop). */
+  reorderTasks: (orderedIds: string[]) => void;
+}
 
-  // Task Slice
-  tasks: [],
-  addTask: (task) => set((state) => ({
-    tasks: [...state.tasks, { ...task, id: Math.random().toString(36).substring(7) }]
-  })),
+interface LogSlice {
+  logs: Log[];
+  /** Prepend a new log entry. */
+  addLog: (log: Omit<Log, 'id' | 'timestamp'>) => void;
+  /** Discard all log entries. */
+  clearLogs: () => void;
+}
 
-  // Log Slice (with one initial mock log to match previous UI)
-  logs: [
-    {
-      id: 'log-1',
-      taskId: '#1024',
-      target: 'CC...A12B',
-      keeper: 'GA...99X',
-      status: 'Success',
-      timestamp: '2 mins ago',
-    }
-  ],
-  addLog: (log) => set((state) => ({
+// ---------------------------------------------------------------------------
+// Combined store type
+// ---------------------------------------------------------------------------
+
+type AppState = WalletSlice & TaskSlice & LogSlice;
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useAppStore = create<AppState>()(
+  subscribeWithSelector((set, _get) => ({
+    // ------------------------------------------------------------------
+    // Wallet slice
+    // ------------------------------------------------------------------
+    isWalletConnected: false,
+    walletAddress: null,
+
+    connectWallet: (address = 'GA32...XYZ9') =>
+      set({ isWalletConnected: true, walletAddress: address }),
+
+    disconnectWallet: () =>
+      set({ isWalletConnected: false, walletAddress: null }),
+
+    // ------------------------------------------------------------------
+    // Task slice
+    // ------------------------------------------------------------------
+    tasks: [],
+
+    addTask: (task) => {
+      const id = genId('task');
+      set((state) => ({
+        tasks: [
+          ...state.tasks,
+          { ...task, id, status: task.status ?? 'pending', createdAt: nowISO() },
+        ],
+      }));
+      return id;
+    },
+
+    updateTask: (id, patch) =>
+      set((state) => ({
+        tasks: state.tasks.map((t) => (t.id === id ? { ...t, ...patch } : t)),
+      })),
+
+    removeTask: (id) =>
+      set((state) => ({
+        tasks: state.tasks.filter((t) => t.id !== id),
+      })),
+
+    reorderTasks: (orderedIds) =>
+      set((state) => {
+        const map = new Map(state.tasks.map((t) => [t.id, t]));
+        const reordered = orderedIds.flatMap((id) => {
+          const t = map.get(id);
+          return t ? [t] : [];
+        });
+        // Append any tasks not mentioned in orderedIds at the end
+        const mentioned = new Set(orderedIds);
+        const remainder = state.tasks.filter((t) => !mentioned.has(t.id));
+        return { tasks: [...reordered, ...remainder] };
+      }),
+
+    // ------------------------------------------------------------------
+    // Log slice
+    // ------------------------------------------------------------------
     logs: [
-      { ...log, id: Math.random().toString(36).substring(7), timestamp: 'Just now' },
-      ...state.logs
-    ]
-  })),
-}));
+      {
+        id: 'log-seed-1',
+        taskId: '#1024',
+        target: 'CC...A12B',
+        keeper: 'GA...99X',
+        status: 'Success',
+        timestamp: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+      },
+    ],
+
+    addLog: (log) =>
+      set((state) => ({
+        logs: [
+          { ...log, id: genId('log'), timestamp: nowISO() },
+          ...state.logs,
+        ],
+      })),
+
+    clearLogs: () => set({ logs: [] }),
+  }))
+);
+
+// ---------------------------------------------------------------------------
+// Typed selector hooks (optional convenience — avoids inline arrow functions)
+// ---------------------------------------------------------------------------
+
+/** Subscribe to the wallet sub-state only. */
+export const useWallet = () =>
+  useAppStore((s) => ({
+    isWalletConnected: s.isWalletConnected,
+    walletAddress: s.walletAddress,
+    connectWallet: s.connectWallet,
+    disconnectWallet: s.disconnectWallet,
+  }));
+
+/** Subscribe to the full task list. */
+export const useTasks = () => useAppStore((s) => s.tasks);
+
+/** Subscribe to the full log list. */
+export const useLogs = () => useAppStore((s) => s.logs);

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -19,7 +19,8 @@
     "jsonwebtoken": "^9.0.3",
     "node-addon-api": "^8.9.0",
     "prom-client": "^15.0.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "jest": "^30.4.2",

--- a/indexer/src/api.js
+++ b/indexer/src/api.js
@@ -1,16 +1,26 @@
 const express = require('express');
 const { ApolloServer } = require('apollo-server-express');
 const cors = require('cors');
+const swaggerUi = require('swagger-ui-express');
 const { typeDefs } = require('./graphql/schema');
 const { resolvers } = require('./graphql/resolvers');
 const { createContext, expressJwtAuth, requireRole, ROLES } = require('./graphql/auth');
 const { metricsHandler } = require('./metrics');
 const { createRateLimiter } = require('./rateLimiter');
+const { openApiSpec } = require('./openapi');
 
 function createExpressApp() {
   const app = express();
   app.use(cors());
   app.use(express.json());
+
+  // OpenAPI v3 / Swagger UI (no auth required — public docs)
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(openApiSpec, {
+    customSiteTitle: 'SoroTask Indexer API Docs',
+    swaggerOptions: { persistAuthorization: true },
+  }));
+  // Expose raw spec for programmatic consumers
+  app.get('/api-docs.json', (_req, res) => res.json(openApiSpec));
 
   // Prometheus Metrics endpoint (exempt from rate limit/auth for scraper access)
   app.get('/metrics', metricsHandler);
@@ -54,8 +64,9 @@ async function startApiServer(port = 4000) {
 
   return new Promise((resolve) => {
     const httpServer = app.listen(port, () => {
-      console.log(`🚀 GraphQL API ready at http://localhost:${port}${server.graphqlPath}`);
-      console.log(`📊 Prometheus Metrics ready at http://localhost:${port}/metrics`);
+      console.log(`GraphQL API ready at http://localhost:${port}${server.graphqlPath}`);
+      console.log(`Prometheus Metrics ready at http://localhost:${port}/metrics`);
+      console.log(`OpenAPI v3 Docs ready at http://localhost:${port}/api-docs`);
       resolve(httpServer);
     });
   });

--- a/indexer/src/openapi.js
+++ b/indexer/src/openapi.js
@@ -1,0 +1,164 @@
+/**
+ * OpenAPI v3 specification for the SoroTask Indexer API.
+ * Covers REST endpoints; GraphQL is documented separately via introspection.
+ */
+const openApiSpec = {
+  openapi: '3.0.3',
+  info: {
+    title: 'SoroTask Indexer API',
+    version: '1.0.0',
+    description:
+      'REST and GraphQL API for the SoroTask Keeper Task Indexer. ' +
+      'Provides task data, health checks, and Prometheus metrics. ' +
+      'The GraphQL endpoint at /graphql supports full introspection.',
+    contact: { name: 'SoroTask', url: 'https://github.com/SoroLabs/SoroTask' },
+    license: { name: 'MIT' },
+  },
+  servers: [{ url: 'http://localhost:4000', description: 'Local development server' }],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'JWT obtained via /api/auth/login',
+      },
+    },
+    schemas: {
+      Task: {
+        type: 'object',
+        properties: {
+          task_id: { type: 'string', example: 'task-001' },
+          creator: { type: 'string', example: 'GA32XXXX' },
+          target: { type: 'string', example: 'CC3XXXXXX' },
+          function: { type: 'string', example: 'execute' },
+          args_json: { type: 'string', nullable: true },
+          resolver: { type: 'string', nullable: true },
+          interval: { type: 'integer', example: 3600 },
+          last_run: { type: 'integer', example: 1700000000 },
+          gas_balance: { type: 'string', example: '100.5' },
+          is_active: { type: 'boolean', example: true },
+        },
+      },
+      HealthResponse: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', example: 'ok' },
+          timestamp: { type: 'string', format: 'date-time' },
+          user: {
+            type: 'object',
+            properties: {
+              role: { type: 'string', example: 'anonymous' },
+            },
+          },
+        },
+      },
+      AuthRequest: {
+        type: 'object',
+        required: ['address', 'signature'],
+        properties: {
+          address: { type: 'string', description: 'Stellar public key', example: 'GA32XXXX' },
+          signature: { type: 'string', description: 'Ed25519 signature of the challenge' },
+        },
+      },
+      AuthResponse: {
+        type: 'object',
+        properties: {
+          token: { type: 'string', description: 'Signed JWT' },
+          user: { $ref: '#/components/schemas/Task' },
+        },
+      },
+      Error: {
+        type: 'object',
+        properties: {
+          error: { type: 'string' },
+          message: { type: 'string' },
+        },
+      },
+    },
+  },
+  security: [{ bearerAuth: [] }],
+  paths: {
+    '/api/health': {
+      get: {
+        summary: 'Health check',
+        description: 'Returns the API health status and the current authenticated user role.',
+        operationId: 'getHealth',
+        security: [],
+        tags: ['System'],
+        responses: {
+          200: {
+            description: 'API is healthy',
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/HealthResponse' } } },
+          },
+        },
+      },
+    },
+    '/api/protected': {
+      get: {
+        summary: 'Protected test endpoint',
+        description: 'Requires a valid JWT with at least USER role.',
+        operationId: 'getProtected',
+        tags: ['System'],
+        responses: {
+          200: { description: 'Access granted', content: { 'application/json': { schema: { type: 'object' } } } },
+          401: { description: 'Unauthorized', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+          403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+        },
+      },
+    },
+    '/metrics': {
+      get: {
+        summary: 'Prometheus metrics',
+        description: 'Exposes Prometheus-compatible metrics for scraping. No authentication required.',
+        operationId: 'getMetrics',
+        security: [],
+        tags: ['System'],
+        responses: {
+          200: {
+            description: 'Prometheus text format metrics',
+            content: { 'text/plain': { schema: { type: 'string' } } },
+          },
+        },
+      },
+    },
+    '/graphql': {
+      post: {
+        summary: 'GraphQL endpoint',
+        description:
+          'Accepts GraphQL queries and mutations. Supports full introspection. ' +
+          'See /api-docs for the REST surface; use a GraphQL client (e.g. Apollo Sandbox) for the full schema.',
+        operationId: 'graphql',
+        tags: ['GraphQL'],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['query'],
+                properties: {
+                  query: { type: 'string', example: '{ __typename }' },
+                  variables: { type: 'object' },
+                  operationName: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'GraphQL response (errors are returned inside the body, not via HTTP status)',
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+        },
+      },
+    },
+  },
+  tags: [
+    { name: 'System', description: 'Health, metrics, and diagnostics' },
+    { name: 'GraphQL', description: 'GraphQL gateway — task queries, mutations, subscriptions' },
+  ],
+};
+
+module.exports = { openApiSpec };


### PR DESCRIPTION
Closes #869
Closes #872
Closes #878
Closes #879

---

## Summary

- **#869** — Added comprehensive OpenAPI v3 specification (`indexer/src/openapi.js`) covering all REST endpoints, auth schemes, and GraphQL gateway. Wired `swagger-ui-express` at `/api-docs` with raw JSON spec at `/api-docs.json`. Added `swagger-ui-express` to indexer dependencies.
- **#872** — Added `TaskSimulationWorkbench` component (`frontend/components/TaskSimulationWorkbench.tsx`) with client-side gas estimation heuristics, state override inputs (task state, args_json, gas balance, interval), and an accessible live-region result panel. Mounted in the `/tasks` page.
- **#878** — Added `TaskReorderBoard` component (`frontend/components/board/TaskReorderBoard.tsx`) using `@dnd-kit/sortable` with `DragOverlay`, full keyboard support (Space to grab, Arrow keys to move, Escape to cancel), ARIA live-region announcements, and priority/status badges.
- **#879** — Refactored `useAppStore` into typed slices with `subscribeWithSelector`, deterministic `crypto.randomUUID` ID generation, `reorderTasks` / `updateTask` / `removeTask` actions, `clearLogs`, and exported typed selector hooks (`useWallet`, `useTasks`, `useLogs`).