### PR TITLE
feat(keeper): distributed cluster-wide RPC rate limiter (closes #849)

### DIFF
--- a/keeper/__tests__/distributedRateLimiter.test.js
+++ b/keeper/__tests__/distributedRateLimiter.test.js
@@ -1,0 +1,105 @@
+const RedisMock = require('ioredis-mock');
+const { DistributedRateLimiter } = require('../src/distributedRateLimiter');
+
+describe('DistributedRateLimiter (Issue #849)', () => {
+  describe('no-op passthrough when Redis is not configured', () => {
+    it('allows everything and reports disabled', async () => {
+      const limiter = new DistributedRateLimiter({ redisUrl: undefined, redis: null });
+      expect(limiter.isEnabled()).toBe(false);
+      for (let i = 0; i < 500; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        expect(await limiter.tryAcquire()).toBe(true);
+      }
+      expect(await limiter.acquire()).toBe(true);
+    });
+  });
+
+  describe('shared global budget across simulated processes', () => {
+    it('two processes sharing one Redis instance share/exhaust the same budget', async () => {
+      // A single shared mock Redis backing store, keyed by URL, simulates two
+      // separate keeper processes talking to the same Redis.
+      const shared = new RedisMock();
+      const processA = new DistributedRateLimiter({ redis: shared, limit: 10, windowMs: 100000 });
+      const processB = new DistributedRateLimiter({ redis: shared, limit: 10, windowMs: 100000 });
+
+      // Process A consumes 7 of the 10 global tokens.
+      let aGranted = 0;
+      for (let i = 0; i < 7; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await processA.tryAcquire()) aGranted++;
+      }
+      expect(aGranted).toBe(7);
+
+      // Process B may now only consume the remaining 3.
+      let bGranted = 0;
+      let bDenied = 0;
+      for (let i = 0; i < 10; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await processB.tryAcquire()) bGranted++;
+        else bDenied++;
+      }
+      expect(bGranted).toBe(3);
+      expect(bDenied).toBe(7);
+
+      // Budget fully exhausted for both now.
+      expect(await processA.tryAcquire()).toBe(false);
+      expect(await processB.tryAcquire()).toBe(false);
+    });
+
+    it('never lets concurrent acquires exceed the global limit', async () => {
+      const shared = new RedisMock();
+      const limit = 20;
+      const procs = [
+        new DistributedRateLimiter({ redis: shared, limit, windowMs: 100000 }),
+        new DistributedRateLimiter({ redis: shared, limit, windowMs: 100000 }),
+        new DistributedRateLimiter({ redis: shared, limit, windowMs: 100000 }),
+      ];
+      // 60 concurrent attempts across 3 "processes" against a budget of 20.
+      const attempts = [];
+      for (let i = 0; i < 60; i++) {
+        attempts.push(procs[i % 3].tryAcquire());
+      }
+      const results = await Promise.all(attempts);
+      const granted = results.filter(Boolean).length;
+      // Safety property: the cluster must NEVER grant more than the global limit.
+      // (ioredis-mock does not perfectly serialize concurrent Lua evals the way
+      // real single-threaded Redis does, so we assert the invariant, not equality.)
+      expect(granted).toBeGreaterThan(0);
+      expect(granted).toBeLessThanOrEqual(limit);
+    });
+  });
+
+  describe('window reset', () => {
+    it('resets the budget after the window rolls over', async () => {
+      const shared = new RedisMock();
+      const limiter = new DistributedRateLimiter({ redis: shared, limit: 3, windowMs: 1000 });
+
+      // Pin the clock inside window 1 so the key = floor(now/1000) is stable.
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+      // Exhaust window 1.
+      expect(await limiter.tryAcquire()).toBe(true);
+      expect(await limiter.tryAcquire()).toBe(true);
+      expect(await limiter.tryAcquire()).toBe(true);
+      expect(await limiter.tryAcquire()).toBe(false);
+
+      // Advance the clock past the window boundary → new key → fresh budget.
+      nowSpy.mockReturnValue(1_002_000);
+      expect(await limiter.tryAcquire()).toBe(true);
+      expect(await limiter.tryAcquire()).toBe(true);
+
+      nowSpy.mockRestore();
+    });
+  });
+
+  describe('fail-open on Redis error', () => {
+    it('returns allowed when the redis command throws', async () => {
+      const brokenRedis = {
+        consumeRateToken: async () => { throw new Error('connection refused'); },
+      };
+      const limiter = new DistributedRateLimiter({ redis: brokenRedis, limit: 5, windowMs: 1000 });
+      expect(limiter.isEnabled()).toBe(true);
+      expect(await limiter.tryAcquire()).toBe(true);
+    });
+  });
+});

--- a/keeper/package-lock.json
+++ b/keeper/package-lock.json
@@ -121,6 +121,7 @@
       "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^8.0.0",
         "@babel/generator": "^8.0.0",
@@ -4413,29 +4414,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -5165,6 +5143,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -5956,6 +5935,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6596,6 +6576,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7238,6 +7219,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8247,6 +8229,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
       "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -8413,6 +8396,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -8775,6 +8759,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -9283,6 +9268,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",

--- a/keeper/src/distributedRateLimiter.js
+++ b/keeper/src/distributedRateLimiter.js
@@ -1,0 +1,240 @@
+/**
+ * Distributed (cluster-wide) rate limiter for keeper RPC calls.
+ *
+ * ── Why this exists (Issue #849) ────────────────────────────────────────────
+ * `src/concurrency.js` (`createRateLimiter`) enforces concurrency + RPS limits,
+ * but purely *in-process*. When several keeper worker processes each run their
+ * own local limiter, they collectively exceed the real Stellar RPC rate limit
+ * because none of them can see the others' traffic.
+ *
+ * This module implements a Redis-backed sliding-window token bucket that every
+ * keeper process shares, so a single GLOBAL request budget (e.g. 100 req/sec
+ * across the whole cluster) is enforced no matter how many processes there are.
+ *
+ * ── Atomicity ───────────────────────────────────────────────────────────────
+ * A naive "GET the counter, decide in Node, then SET it" has a race: two
+ * processes can both read the same value and both decide they're under budget,
+ * double-spending the budget. To avoid this we run a small Lua script on the
+ * Redis server via `defineCommand`. Redis executes the script atomically, so
+ * the check-and-increment is a single indivisible operation — concurrent
+ * processes never double-spend.
+ *
+ * ── Sliding window ──────────────────────────────────────────────────────────
+ * The window is keyed by `floor(now / windowMs)`, giving a fresh counter key
+ * per window with a TTL slightly longer than the window. When the window rolls
+ * over the counter naturally resets (old key expires). This is a fixed-window
+ * counter (the classic, cheap distributed pattern); it is intentionally simple
+ * and pairs with the per-process limiter which smooths bursts within a window.
+ *
+ * ── Fallback / no-op mode (dev & single-instance) ───────────────────────────
+ * If REDIS_URL is not configured, this limiter becomes a NO-OP passthrough:
+ * every `acquire()` resolves as allowed immediately. This means single-instance
+ * or local-dev deployments are NOT forced to run Redis — they simply rely on
+ * the existing per-process `createRateLimiter`. The no-op mode is also used if
+ * a Redis command errors at runtime ("fail open"), so a Redis outage degrades
+ * to per-process limiting rather than halting the keeper.
+ */
+
+// The Lua script atomically implements a fixed-window counter.
+// KEYS[1] = window counter key
+// ARGV[1] = limit (max requests allowed in the window)
+// ARGV[2] = ttl in milliseconds (window length + small slack)
+// Returns: 1 if the request is allowed (counter incremented), 0 if over budget.
+const CONSUME_SCRIPT = `
+local current = tonumber(redis.call('get', KEYS[1]) or '0')
+if current < tonumber(ARGV[1]) then
+  local updated = redis.call('incr', KEYS[1])
+  if updated == 1 then
+    redis.call('pexpire', KEYS[1], tonumber(ARGV[2]))
+  end
+  return 1
+else
+  return 0
+end
+`;
+
+class DistributedRateLimiter {
+  /**
+   * @param {Object} options
+   * @param {import('ioredis').Redis} [options.redis] - A pre-built ioredis client
+   *   (or ioredis-mock). If omitted and redisUrl is set, one is created lazily.
+   * @param {string} [options.redisUrl=process.env.REDIS_URL] - Redis connection URL.
+   *   When falsy AND no redis client is supplied, the limiter is a no-op passthrough.
+   * @param {number} [options.limit=process.env.RPC_GLOBAL_RATE_LIMIT] - Max requests
+   *   allowed cluster-wide per window.
+   * @param {number} [options.windowMs=1000] - Sliding-window length in milliseconds.
+   * @param {string} [options.keyPrefix='keeper:rpc:rate'] - Redis key namespace.
+   * @param {Object} [options.logger]
+   */
+  constructor(options = {}) {
+    const {
+      redis = null,
+      redisUrl = process.env.REDIS_URL,
+      limit = parseInt(process.env.RPC_GLOBAL_RATE_LIMIT || '100', 10),
+      windowMs = 1000,
+      keyPrefix = 'keeper:rpc:rate',
+      logger = null,
+    } = options;
+
+    this.logger = logger;
+    this.limit = limit;
+    this.windowMs = windowMs;
+    this.keyPrefix = keyPrefix;
+    this.ownsClient = false;
+
+    if (redis) {
+      // Caller supplied a client (real ioredis or ioredis-mock in tests).
+      this.redis = redis;
+      this.enabled = true;
+    } else if (redisUrl) {
+      // Lazily construct a real ioredis client from the URL.
+      const Redis = require('ioredis');
+      this.redis = new Redis(redisUrl, {
+        maxRetriesPerRequest: 2,
+        enableOfflineQueue: true,
+        lazyConnect: false,
+      });
+      this.ownsClient = true;
+      this.enabled = true;
+      this.redis.on('error', (err) => {
+        if (this.logger) {
+          this.logger.warn('Distributed rate limiter Redis error (failing open)', {
+            error: err.message,
+          });
+        }
+      });
+    } else {
+      // No Redis configured → no-op passthrough. Per-process limiter still applies.
+      this.redis = null;
+      this.enabled = false;
+      if (this.logger) {
+        this.logger.info(
+          'REDIS_URL not set — distributed RPC rate limiter disabled (no-op passthrough). '
+          + 'Cluster-wide RPC limiting is inactive; per-process limiting still applies.',
+        );
+      }
+    }
+
+    if (this.enabled && typeof this.redis.consumeRateToken !== 'function') {
+      // Register the atomic Lua command on the client.
+      this.redis.defineCommand('consumeRateToken', {
+        numberOfKeys: 1,
+        lua: CONSUME_SCRIPT,
+      });
+    }
+  }
+
+  /**
+   * Whether this limiter is actually enforcing a global limit (false = no-op).
+   */
+  isEnabled() {
+    return this.enabled;
+  }
+
+  _currentKey(now = Date.now()) {
+    const windowId = Math.floor(now / this.windowMs);
+    return `${this.keyPrefix}:${windowId}`;
+  }
+
+  /**
+   * Attempt to consume one token from the cluster-wide budget for the current
+   * window. Returns true if allowed, false if the global budget is exhausted.
+   *
+   * On any Redis error this "fails open" (returns true) so a Redis outage
+   * degrades to per-process limiting rather than halting all RPC reads.
+   *
+   * @returns {Promise<boolean>}
+   */
+  async tryAcquire() {
+    if (!this.enabled) {
+      return true; // no-op passthrough
+    }
+    try {
+      const key = this._currentKey();
+      const ttl = this.windowMs + 1000; // small slack so the key outlives the window
+      const allowed = await this.redis.consumeRateToken(key, this.limit, ttl);
+      return Number(allowed) === 1;
+    } catch (err) {
+      if (this.logger) {
+        this.logger.warn('Distributed rate limiter check failed — failing open', {
+          error: err.message,
+        });
+      }
+      return true;
+    }
+  }
+
+  /**
+   * Block until a token is available (or maxWaitMs elapses), then proceed.
+   * Polls the current window; because windows are short (default 1s) the wait
+   * is bounded and cheap. Intended to gate an RPC call so the cluster never
+   * exceeds the global budget.
+   *
+   * @param {Object} [opts]
+   * @param {number} [opts.maxWaitMs=5000] - Give up waiting after this long and
+   *   proceed anyway (fail open) to avoid deadlocking the poll cycle.
+   * @param {number} [opts.pollMs=25] - Retry interval while over budget.
+   * @returns {Promise<boolean>} true if a token was acquired, false if it
+   *   proceeded via fail-open after maxWaitMs.
+   */
+  async acquire(opts = {}) {
+    if (!this.enabled) {
+      return true;
+    }
+    const { maxWaitMs = 5000, pollMs = 25 } = opts;
+    const deadline = Date.now() + maxWaitMs;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (await this.tryAcquire()) {
+        return true;
+      }
+      if (Date.now() >= deadline) {
+        if (this.logger) {
+          this.logger.warn('Distributed rate limiter wait exceeded maxWaitMs — proceeding (fail open)', {
+            maxWaitMs,
+          });
+        }
+        return false;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+  }
+
+  /**
+   * Wrap a function so it only runs after acquiring a global token. Designed to
+   * compose with the per-process `createRateLimiter` from concurrency.js:
+   *   readLimit(() => distributed.schedule(() => server.getX()))
+   *
+   * @param {Function} fn
+   * @param {Object} [opts] - forwarded to acquire()
+   * @returns {Promise<*>}
+   */
+  async schedule(fn, opts = {}) {
+    await this.acquire(opts);
+    return fn();
+  }
+
+  /**
+   * Close the Redis connection if this limiter created it.
+   */
+  async close() {
+    if (this.ownsClient && this.redis) {
+      try {
+        await this.redis.quit();
+      } catch (_e) {
+        // ignore
+      }
+    }
+  }
+}
+
+/**
+ * Convenience factory mirroring createRateLimiter's style.
+ * @param {Object} options - see DistributedRateLimiter constructor
+ * @returns {DistributedRateLimiter}
+ */
+function createDistributedRateLimiter(options = {}) {
+  return new DistributedRateLimiter(options);
+}
+
+module.exports = { DistributedRateLimiter, createDistributedRateLimiter };

--- a/keeper/src/poller.js
+++ b/keeper/src/poller.js
@@ -1,5 +1,6 @@
 const { Contract, xdr, TransactionBuilder, BASE_FEE, Networks, scValToNative } = require('@stellar/stellar-sdk');
 const { createRateLimiter } = require('./concurrency');
+const { DistributedRateLimiter } = require('./distributedRateLimiter');
 const { createLogger } = require('./logger');
 const { validateTaskPayload } = require('./taskValidator');
 const { TaskFilterChain } = require('./taskFilter');
@@ -87,6 +88,23 @@ class TaskPoller {
           this.metricsServer.increment('throttledRequestsTotal', { name: event.name });
         }
       },
+    });
+
+    // Cluster-wide (distributed) RPC rate limiter — Issue #849.
+    // This gates RPC reads across ALL keeper processes via Redis, enforcing a
+    // single global budget. It composes with (does not replace) the per-process
+    // `readLimit` above: the local limiter protects against a single process's
+    // burst, the distributed one enforces the cluster-wide global limit.
+    // If REDIS_URL is unset it is a no-op passthrough (see distributedRateLimiter.js),
+    // so single-instance/dev deployments are unaffected.
+    this.distributedReadLimit = options.distributedRateLimiter || new DistributedRateLimiter({
+      redis: options.redisClient || null,
+      redisUrl: options.redisUrl !== undefined ? options.redisUrl : process.env.REDIS_URL,
+      limit: parseInt(
+        options.rpcGlobalRateLimit || process.env.RPC_GLOBAL_RATE_LIMIT || '100',
+        10,
+      ),
+      logger: this.logger,
     });
 
     // Statistics
@@ -261,6 +279,9 @@ class TaskPoller {
         this.readLimit(async () => {
           const startedAt = Date.now();
           const correlationId = `poll-${taskId}-${crypto.randomBytes(4).toString('hex')}`;
+          // Cluster-wide gate: wait for a global RPC token before issuing the
+          // per-task read. No-op passthrough when Redis is not configured.
+          await this.distributedReadLimit.acquire();
           const preloaded = preloadedConfigs ? preloadedConfigs.get(Number(taskId)) : undefined;
           const result = await this.checkTask(
             taskId,


### PR DESCRIPTION
## Summary
The existing `createRateLimiter` in `keeper/src/concurrency.js` only enforces concurrency/RPS limits in-process — multiple keeper worker processes each running their own local limiter still collectively exceed the real Stellar RPC rate limit.

Added `keeper/src/distributedRateLimiter.js` (`DistributedRateLimiter`/`createDistributedRateLimiter`): an `ioredis`-backed limiter using a Lua script (`defineCommand`) for an atomic check-and-increment against a fixed-window counter keyed by `floor(now/windowMs)` with a TTL — no read-then-write race across concurrent processes. API: `tryAcquire()`, `acquire({maxWaitMs, pollMs})`, `schedule(fn)`, `isEnabled()`, `close()`.

Wired into `poller.js` as an additional gate inside the existing per-process `readLimit` wrapper — both the local burst limit and the new cluster-wide limit apply; nothing was ripped out.

**Env vars:** `REDIS_URL`, `RPC_GLOBAL_RATE_LIMIT` (default 100).
**Fallback behavior:** if `REDIS_URL` is unset (and no client is injected), the limiter is a no-op passthrough — single-instance/dev deployments aren't forced to run Redis. It also fails open on any Redis error (degrades to per-process-only limiting rather than halting reads on a Redis outage).

## Test plan
- [x] `npm test` (keeper, using `ioredis-mock`) — 5/5 new tests pass: two simulated processes sharing a mock Redis instance correctly share/exhaust one global budget, the limiter resets after the window expires, and the no-Redis fallback passes everything through
- [x] Existing `poller` (39/39) and related suites still pass

Closes #849