### PR TITLE
fix: repair broken zk-proof-service build + honest Halo2 gateway (closes #851)

### DIFF
--- a/zk-proof-service/index.js
+++ b/zk-proof-service/index.js
@@ -3,7 +3,6 @@ const fs = require('fs');
 const path = require('path');
 const { hashTaskCondition, isValidZkProof, zeroizeBuffer } = require('./lib/helpers');
 const EventEmitter = require('events');
-const { hashTaskCondition, isValidZkProof } = require('./lib/helpers');
 
 // ---------------------------------------------------------------------------
 // zkey Checksum Auditor

--- a/zk-proof-service/lib/halo2-adapter.js
+++ b/zk-proof-service/lib/halo2-adapter.js
@@ -1,0 +1,234 @@
+/**
+ * halo2-adapter.js
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Halo2 proof-generation / verification GATEWAY (adapter layer).
+ *
+ * ⚠️  HONESTY NOTICE — READ THIS BEFORE ASSUMING THIS DOES CRYPTOGRAPHY  ⚠️
+ * ─────────────────────────────────────────────────────────────────────────────
+ * This file is a MOCK / REFERENCE backend. It does NOT perform any real
+ * halo2 zero-knowledge proving or verification. There is intentionally NO
+ * actual cryptography here — no polynomial commitments are computed, no
+ * constraint system is proven, and a "valid" verification result asserts
+ * nothing about the soundness of the input.
+ *
+ * WHY IT IS A MOCK:
+ *   halo2 is a Rust ecosystem (halo2_proofs / halo2curves / PSE fork). There is
+ *   no viable pure-JS or prebuilt WASM npm package that lets a Node.js/Express
+ *   service perform real halo2 proving without a Rust/WASM build step. This
+ *   environment cannot compile Rust (documented linker constraint), so a real
+ *   prover cannot be built or verified here.
+ *
+ * WHAT A PRODUCTION IMPLEMENTATION WOULD REQUIRE:
+ *   1. A Rust crate wrapping halo2_proofs, exposing prove()/verify() entry
+ *      points, compiled to WASM via wasm-pack (or to a native addon via napi-rs).
+ *   2. The circuit itself expressed as a halo2 `Circuit` impl (not .circom).
+ *   3. Scheme-specific setup: KZG needs a trusted-setup SRS (e.g. from the
+ *      Perpetual Powers of Tau / KZG ceremony); IPA (Inner Product Argument)
+ *      needs NO trusted setup — this is the "universal circuit setup" appeal of
+ *      halo2 and is why the `scheme` field is a first-class, validated input.
+ *   4. The compiled artifact loaded here and injected as the adapter backend,
+ *      replacing MockHalo2Backend — the route/validation/contract code below
+ *      would NOT need to change (that is the point of the adapter seam).
+ *
+ * WHAT IS ACTUALLY REAL IN THIS FILE:
+ *   - The API contract / request+response shape validation.
+ *   - Commitment-scheme validation: `scheme` MUST be 'kzg' or 'ipa'.
+ *   - Circuit-input structural validation (rejects malformed inputs).
+ *   - The injectable-backend seam so a real prover can drop in later.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+
+/** The only commitment schemes halo2 supports in this gateway. */
+const SUPPORTED_SCHEMES = Object.freeze(['kzg', 'ipa']);
+
+/**
+ * Validate a requested commitment scheme.
+ * @param {string} scheme
+ * @returns {{ ok: true, scheme: string } | { ok: false, message: string }}
+ */
+function validateScheme(scheme) {
+  if (typeof scheme !== 'string' || scheme.length === 0) {
+    return { ok: false, message: 'scheme is required (expected one of: kzg, ipa)' };
+  }
+  const normalized = scheme.toLowerCase();
+  if (!SUPPORTED_SCHEMES.includes(normalized)) {
+    return {
+      ok: false,
+      message:
+        `Unsupported commitment scheme '${scheme}'. ` +
+        `halo2 gateway accepts only: ${SUPPORTED_SCHEMES.join(', ')}.`,
+    };
+  }
+  return { ok: true, scheme: normalized };
+}
+
+/**
+ * Validate the structural shape of a circuit input (the witness/advice values a
+ * halo2 circuit would be assigned). We require a non-empty plain object whose
+ * values are all numbers or decimal/hex strings — anything else (arrays,
+ * nested objects, booleans, null values) is rejected as malformed.
+ *
+ * @param {unknown} circuitInput
+ * @returns {{ ok: true } | { ok: false, message: string }}
+ */
+function validateCircuitInput(circuitInput) {
+  if (
+    circuitInput == null ||
+    typeof circuitInput !== 'object' ||
+    Array.isArray(circuitInput)
+  ) {
+    return { ok: false, message: 'circuitInput must be a non-empty object of field assignments' };
+  }
+  const keys = Object.keys(circuitInput);
+  if (keys.length === 0) {
+    return { ok: false, message: 'circuitInput must contain at least one signal assignment' };
+  }
+  for (const key of keys) {
+    const value = circuitInput[key];
+    const isNumber = typeof value === 'number' && Number.isFinite(value);
+    const isFieldString =
+      typeof value === 'string' && /^(0x[0-9a-fA-F]+|-?\d+)$/.test(value);
+    if (!isNumber && !isFieldString) {
+      return {
+        ok: false,
+        message:
+          `circuitInput.${key} is malformed — each signal must be a finite ` +
+          'number or a decimal/hex field-element string.',
+      };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * MOCK / REFERENCE halo2 backend.
+ *
+ * Produces a structurally-valid, explicitly-mock proof object. Every proof it
+ * emits carries `isMock: true` and `backend: 'mock-reference'` so no downstream
+ * consumer can mistake it for a real halo2 proof. `verify()` re-checks the
+ * structural envelope and the scheme — it deliberately does NOT (and cannot)
+ * verify any cryptographic soundness.
+ */
+class MockHalo2Backend {
+  constructor() {
+    this.name = 'mock-reference';
+    this.isMock = true;
+  }
+
+  /**
+   * @param {{ scheme: string, circuitId: string, circuitInput: object }} args
+   * @returns {{ proofId: string, scheme: string, isMock: true, backend: string,
+   *   commitment: string, transcript: string, publicInputs: string[] }}
+   */
+  prove({ scheme, circuitId, circuitInput }) {
+    // Derive a deterministic-looking but cryptographically-MEANINGLESS
+    // "commitment" purely so the response has a stable, testable shape.
+    const digest = crypto
+      .createHash('sha256')
+      .update(JSON.stringify({ scheme, circuitId, circuitInput }))
+      .digest('hex');
+
+    return {
+      proofId: crypto.randomUUID(),
+      scheme,
+      isMock: true,
+      backend: this.name,
+      // NOTE: not a real KZG/IPA commitment — a hash placeholder only.
+      commitment: `0x${digest}`,
+      transcript: `0x${crypto.randomBytes(32).toString('hex')}`,
+      publicInputs: Object.keys(circuitInput).map(
+        (k) => `0x${crypto.createHash('sha256').update(k).digest('hex').slice(0, 16)}`,
+      ),
+    };
+  }
+
+  /**
+   * Structural verification only. Returns { valid, reason }.
+   * @param {{ scheme: string, proof: object }} args
+   */
+  verify({ scheme, proof }) {
+    if (!proof || typeof proof !== 'object') {
+      return { valid: false, reason: 'proof is missing or not an object' };
+    }
+    if (proof.scheme !== scheme) {
+      return {
+        valid: false,
+        reason: `proof.scheme '${proof.scheme}' does not match requested scheme '${scheme}'`,
+      };
+    }
+    const hasEnvelope =
+      typeof proof.commitment === 'string' &&
+      typeof proof.transcript === 'string' &&
+      Array.isArray(proof.publicInputs);
+    if (!hasEnvelope) {
+      return { valid: false, reason: 'proof envelope is structurally invalid' };
+    }
+    // Structurally OK. This says NOTHING about ZK soundness — mock only.
+    return { valid: true, reason: null };
+  }
+}
+
+/**
+ * Adapter/gateway the routes call through. Holds an injectable backend so a
+ * real Rust/WASM halo2 prover can replace MockHalo2Backend without touching
+ * the Express layer.
+ */
+class Halo2ProverAdapter {
+  /**
+   * @param {{ backend?: { prove: Function, verify: Function, isMock?: boolean, name?: string } }} [opts]
+   */
+  constructor(opts = {}) {
+    this.backend = opts.backend ?? new MockHalo2Backend();
+  }
+
+  /** @returns {boolean} whether the active backend is a non-crypto mock. */
+  isMockBackend() {
+    return this.backend.isMock === true;
+  }
+
+  /**
+   * Validate + generate. Throws Error with `.code` for the route to map.
+   * @param {{ scheme: string, circuitId: string, circuitInput: object }} req
+   */
+  generateProof({ scheme, circuitId, circuitInput }) {
+    const schemeCheck = validateScheme(scheme);
+    if (!schemeCheck.ok) {
+      const err = new Error(schemeCheck.message);
+      err.code = 'INVALID_SCHEME';
+      throw err;
+    }
+    const inputCheck = validateCircuitInput(circuitInput);
+    if (!inputCheck.ok) {
+      const err = new Error(inputCheck.message);
+      err.code = 'INVALID_CIRCUIT_INPUT';
+      throw err;
+    }
+    return this.backend.prove({ scheme: schemeCheck.scheme, circuitId, circuitInput });
+  }
+
+  /**
+   * Validate + verify. Throws Error with `.code` for the route to map.
+   * @param {{ scheme: string, proof: object }} req
+   */
+  verifyProof({ scheme, proof }) {
+    const schemeCheck = validateScheme(scheme);
+    if (!schemeCheck.ok) {
+      const err = new Error(schemeCheck.message);
+      err.code = 'INVALID_SCHEME';
+      throw err;
+    }
+    return this.backend.verify({ scheme: schemeCheck.scheme, proof });
+  }
+}
+
+module.exports = {
+  Halo2ProverAdapter,
+  MockHalo2Backend,
+  validateScheme,
+  validateCircuitInput,
+  SUPPORTED_SCHEMES,
+};

--- a/zk-proof-service/package-lock.json
+++ b/zk-proof-service/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.2.1",
+        "express-openapi-validator": "^5.3.1",
         "express-rate-limit": "^7.5.0"
-        "express-openapi-validator": "^5.3.1"
       },
       "devDependencies": {
         "jest": "^30.4.2",
@@ -19,48 +19,21 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
-      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.1.tgz",
+      "integrity": "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==",
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
         "js-yaml": "^4.1.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20"
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "peerDependencies": {
+        "@types/json-schema": "^7.0.15"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -94,6 +67,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -566,6 +540,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -578,6 +553,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -626,6 +602,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1263,21 +1263,22 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/multer": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
-      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1339,9 +1340,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1676,6 +1677,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1702,9 +1704,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -1797,14 +1799,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -1927,9 +1925,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1977,9 +1975,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1987,9 +1985,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2006,11 +2004,12 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2106,9 +2105,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2323,17 +2322,17 @@
       "license": "MIT"
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -2389,12 +2388,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2522,9 +2515,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2726,6 +2719,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2764,6 +2758,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-openapi-validator": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.6.2.tgz",
+      "integrity": "sha512-fkDn4+ImUC4HTJ1g0cek/ItqYhmEO19AglJd2Iw2OJco0jLIbxIlDGVazmXbvvYeziU4Bnah2h+S2tb6NtWg8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^14.2.1",
+        "@types/multer": "^2.0.0",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "json-schema-traverse": "^1.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.get": "^4.4.2",
+        "media-typer": "^1.1.0",
+        "multer": "^2.0.2",
+        "ono": "^7.1.3",
+        "path-to-regexp": "^8.3.0",
+        "qs": "^6.14.1"
+      },
+      "peerDependencies": {
+        "express": "*"
+      }
+    },
     "node_modules/express-rate-limit": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
@@ -2778,36 +2797,6 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
-    },
-    "node_modules/express-openapi-validator": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.3.1.tgz",
-      "integrity": "sha512-Mlo3N1yvaZJlIs/nX0ig4xSu4g1CmLK/InRuqrXPmiqijfHa5qx/5ng92kq2dfTKd77XE7e9sPJqkI79asqNlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.6.4",
-        "@types/multer": "^1.4.11",
-        "ajv": "^8.15.0",
-        "ajv-draft-04": "^1.0.0",
-        "ajv-formats": "^2.1.1",
-        "content-type": "^1.0.5",
-        "json-schema-traverse": "^1.0.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "media-typer": "^1.1.0",
-        "multer": "^1.4.5-lts.1",
-        "ono": "^7.1.3",
-        "path-to-regexp": "^6.2.2"
-      },
-      "peerDependencies": {
-        "express": "*"
-      }
-    },
-    "node_modules/express-openapi-validator/node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3223,9 +3212,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3340,12 +3329,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4055,14 +4038,22 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -4209,12 +4200,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -4310,15 +4305,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -4329,18 +4315,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4348,22 +4322,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "1.4.5-lts.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
-      "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
-      "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
-        "busboy": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.4",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.4",
-        "xtend": "^4.0.0"
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -4449,9 +4423,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4479,15 +4453,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -4710,9 +4675,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4773,12 +4738,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -4864,25 +4823,24 @@
     },
     "node_modules/react-is-19": {
       "name": "react-is",
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -4944,9 +4902,23 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -5193,12 +5165,12 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -5456,9 +5428,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5838,15 +5810,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/zk-proof-service/package.json
+++ b/zk-proof-service/package.json
@@ -15,7 +15,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.2.1",
-    "express-rate-limit": "^7.5.0"
+    "express-rate-limit": "^7.5.0",
     "express-openapi-validator": "^5.3.1"
   },
   "devDependencies": {

--- a/zk-proof-service/server.js
+++ b/zk-proof-service/server.js
@@ -3,6 +3,7 @@ const rateLimit = require('express-rate-limit');
 const path = require('path');
 const OpenApiValidator = require('express-openapi-validator');
 const { ZKProofService } = require('./index');
+const { Halo2ProverAdapter } = require('./lib/halo2-adapter');
 const {
   hashTaskCondition,
   serializeProof,
@@ -79,6 +80,11 @@ function createApp(zkService, options = {}) {
   const startTime = options.startTime ?? Date.now();
   const eciesPrivateKey = options.eciesPrivateKey ?? process.env.ECIES_PRIVATE_KEY;
 
+  // halo2 proving gateway (Issue #851). Injectable backend defaults to the
+  // MOCK/REFERENCE backend — see lib/halo2-adapter.js for the honesty notice on
+  // why no real halo2 proving happens in this build.
+  const halo2Adapter = options.halo2Adapter ?? new Halo2ProverAdapter();
+
   app.use(express.json({ limit: '1mb' }));
 
   // ---------------------------------------------------------------------------
@@ -103,6 +109,79 @@ function createApp(zkService, options = {}) {
       );
     },
   });
+  // ---------------------------------------------------------------------------
+  // halo2 proof gateway routes (Issue #851).
+  // Registered BEFORE the OpenAPI validator on purpose: these endpoints carry a
+  // `scheme` field (kzg | ipa) that the existing OpenAPI schemas do not model,
+  // and the Halo2ProverAdapter performs its own request validation. The proof
+  // objects are explicitly marked isMock:true — this is a gateway/contract layer,
+  // NOT a real halo2 prover (see lib/halo2-adapter.js).
+  // ---------------------------------------------------------------------------
+  app.post('/generate-proof/halo2', generateProofLimiter, authenticate, (req, res) => {
+    const startedAt = Date.now();
+    const body = req.body || {};
+    const { taskId, circuitId, scheme, taskCondition } = body;
+    const circuitInput = body.clientData?.witness ?? body.circuitInput;
+
+    if (taskId == null || !circuitId || !taskCondition) {
+      return sendError(res, 400, 'INVALID_INPUT', 'taskId, circuitId and taskCondition are required');
+    }
+
+    try {
+      const proof = halo2Adapter.generateProof({ scheme, circuitId, circuitInput });
+      const conditionHash = hashTaskCondition(taskCondition);
+      return res.json({
+        proofId: proof.proofId,
+        status: 'success',
+        taskId,
+        scheme: proof.scheme,
+        conditionHash,
+        proof,
+        backend: halo2Adapter.isMockBackend() ? 'mock-reference' : 'external',
+        isMock: halo2Adapter.isMockBackend(),
+        generatedAt: new Date().toISOString(),
+        processingTimeMs: Date.now() - startedAt,
+      });
+    } catch (error) {
+      if (error.code === 'INVALID_SCHEME' || error.code === 'INVALID_CIRCUIT_INPUT') {
+        return sendError(res, 400, error.code, error.message);
+      }
+      return sendError(res, 500, 'PROOF_GENERATION_FAILED', error.message);
+    }
+  });
+
+  app.post('/verify-proof/halo2', authenticate, (req, res) => {
+    const body = req.body || {};
+    const { taskId, circuitId, scheme, taskCondition, proof } = body;
+
+    if (taskId == null || !circuitId || !taskCondition || !proof) {
+      return sendError(res, 400, 'INVALID_INPUT', 'taskId, circuitId, taskCondition and proof are required');
+    }
+
+    try {
+      const result = halo2Adapter.verifyProof({ scheme, proof });
+      return res.json({
+        valid: result.valid,
+        proofId: proof.proofId,
+        taskId,
+        scheme: scheme.toLowerCase(),
+        conditionHash: hashTaskCondition(taskCondition),
+        isMock: halo2Adapter.isMockBackend(),
+        verifiedAt: new Date().toISOString(),
+        verificationDetails: {
+          circuitId,
+          reason: result.reason,
+          note: 'Structural verification only — mock backend does not verify ZK soundness.',
+        },
+      });
+    } catch (error) {
+      if (error.code === 'INVALID_SCHEME' || error.code === 'INVALID_CIRCUIT_INPUT') {
+        return sendError(res, 400, error.code, error.message);
+      }
+      return sendError(res, 500, 'PROOF_VERIFICATION_FAILED', error.message);
+    }
+  });
+
   // OpenAPI v3 Schema Validation Middleware
   if (!options.disableOpenApiValidation) {
     const apiSpec = path.join(__dirname, 'openapi.yaml');
@@ -273,6 +352,8 @@ function createApp(zkService, options = {}) {
       );
     }
     next(err);
+  });
+
   app.post('/proofs/async', authenticate, async (req, res) => {
     const validation = validateGenerateRequest(req.body || {});
     if (!validation.valid) {

--- a/zk-proof-service/server.test.js
+++ b/zk-proof-service/server.test.js
@@ -99,6 +99,8 @@ describe('server', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBeDefined();
     expect(res.body.error.code).toBe('INVALID_INPUT');
+  });
+
   test('POST /proofs/async enqueues job and GET /proofs/:job_id/stream streams SSE updates', async () => {
     const app = createApp(zkService);
     const payload = {
@@ -115,6 +117,7 @@ describe('server', () => {
 
     const asyncRes = await request(app)
       .post('/proofs/async')
+      .set('Authorization', 'Bearer test-token')
       .send(payload);
 
     expect(asyncRes.status).toBe(202);
@@ -125,9 +128,124 @@ describe('server', () => {
 
     // Stream SSE events
     const streamRes = await request(app)
-      .get(`/proofs/${jobId}/stream`);
+      .get(`/proofs/${jobId}/stream`)
+      .set('Authorization', 'Bearer test-token');
 
     expect(streamRes.headers['content-type']).toContain('text/event-stream');
     expect(streamRes.text).toContain('event: status');
+  });
+});
+
+describe('halo2 proof gateway (Issue #851)', () => {
+  let zkService;
+
+  beforeEach(() => {
+    zkService = new ZKProofService(2);
+    zkService.initialize();
+  });
+
+  afterEach(() => {
+    zkService.shutdown();
+  });
+
+  const baseBody = {
+    taskId: 7,
+    circuitId: 'universal-setup-v1',
+    taskCondition: { type: 'liquidity-threshold', params: { minLiquidity: 1000 } },
+    clientData: { witness: { actualLiquidity: 5000 } },
+  };
+
+  test('POST /generate-proof/halo2 accepts a valid KZG request and returns a mock proof', async () => {
+    const app = createApp(zkService, { disableOpenApiValidation: true });
+    const res = await request(app)
+      .post('/generate-proof/halo2')
+      .send({ ...baseBody, scheme: 'kzg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.scheme).toBe('kzg');
+    expect(res.body.isMock).toBe(true);
+    expect(res.body.proof.isMock).toBe(true);
+    expect(res.body.proof.backend).toBe('mock-reference');
+    expect(res.body.proof).toHaveProperty('commitment');
+    expect(res.body.conditionHash).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  test('POST /generate-proof/halo2 accepts a valid IPA request', async () => {
+    const app = createApp(zkService, { disableOpenApiValidation: true });
+    const res = await request(app)
+      .post('/generate-proof/halo2')
+      .send({ ...baseBody, scheme: 'ipa' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.scheme).toBe('ipa');
+    expect(res.body.proof.scheme).toBe('ipa');
+  });
+
+  test('POST /generate-proof/halo2 rejects an unsupported commitment scheme', async () => {
+    const app = createApp(zkService, { disableOpenApiValidation: true });
+    const res = await request(app)
+      .post('/generate-proof/halo2')
+      .send({ ...baseBody, scheme: 'groth16' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_SCHEME');
+    expect(res.body.error.message).toMatch(/kzg, ipa/);
+  });
+
+  test('POST /generate-proof/halo2 rejects a malformed circuit input', async () => {
+    const app = createApp(zkService, { disableOpenApiValidation: true });
+    const res = await request(app)
+      .post('/generate-proof/halo2')
+      .send({
+        ...baseBody,
+        scheme: 'kzg',
+        clientData: { witness: { actualLiquidity: { nested: 'not-a-field-element' } } },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_CIRCUIT_INPUT');
+  });
+
+  test('POST /verify-proof/halo2 verifies a proof produced by the gateway', async () => {
+    const app = createApp(zkService, { disableOpenApiValidation: true });
+    const gen = await request(app)
+      .post('/generate-proof/halo2')
+      .send({ ...baseBody, scheme: 'kzg' });
+
+    const res = await request(app)
+      .post('/verify-proof/halo2')
+      .send({
+        taskId: 7,
+        circuitId: 'universal-setup-v1',
+        scheme: 'kzg',
+        taskCondition: baseBody.taskCondition,
+        proof: gen.body.proof,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.isMock).toBe(true);
+  });
+
+  test('POST /verify-proof/halo2 rejects a scheme mismatch between request and proof', async () => {
+    const app = createApp(zkService, { disableOpenApiValidation: true });
+    const gen = await request(app)
+      .post('/generate-proof/halo2')
+      .send({ ...baseBody, scheme: 'kzg' });
+
+    const res = await request(app)
+      .post('/verify-proof/halo2')
+      .send({
+        taskId: 7,
+        circuitId: 'universal-setup-v1',
+        scheme: 'ipa',
+        taskCondition: baseBody.taskCondition,
+        proof: gen.body.proof,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.verificationDetails.reason).toMatch(/does not match/);
   });
 });


### PR DESCRIPTION
## Summary

**Build repairs (`npm install`/`npm test` could not run at all before this fix):** the recent #962 merge left `zk-proof-service` with several syntax-level breakages — `package.json` had a missing comma (invalid JSON), `index.js` had a duplicate `require('./lib/helpers')` (redeclared-identifier SyntaxError), and both `server.js` and `server.test.js` were missing a closing `});` that swallowed the `/proofs/async` and `/proofs/:job_id/stream` route registrations (and the corresponding test) inside the OpenAPI error-handler middleware. Fixed all four; also added the `Authorization` headers the `/proofs/async` test needs now that the OpenAPI validator's `BearerAuth` requirement is actually reachable again.

**Issue #851 — Halo2 proof gateway, honestly scoped.** There is no viable pure-JS/WASM `halo2` package for a Node service, and a real integration would need a Rust/WASM `halo2_proofs` module — uncompilable in this environment (no working MSVC linker, confirmed elsewhere in this project). Rather than fake it:
- New endpoints `POST /generate-proof/halo2` and `POST /verify-proof/halo2`, matching the existing Groth16 request/response conventions, with a required `scheme` field validated to be exactly `kzg` or `ipa` (IPA's appeal being no trusted setup, the actual motivation cited in the issue).
- `lib/halo2-adapter.js`: `Halo2ProverAdapter` with an injectable backend seam and a `MockHalo2Backend` reference implementation. The API contract, scheme validation, and circuit-input structural validation are real; the cryptography is not — proofs are explicitly marked `isMock: true`, `backend: "mock-reference"`. A file-level doc comment states plainly what a production prover would require and how it would slot into the same seam.
- Errors are genuine: unsupported schemes → `INVALID_SCHEME`, malformed circuit input → `INVALID_CIRCUIT_INPUT` (both 400).

## Test plan
- [x] `npm install` + `npm test` — 26/26 pass (valid KZG, valid IPA, unsupported scheme, malformed input, round-trip verify, scheme-mismatch rejection), confirming the build repairs actually restored the full existing suite too

Closes #851