### PR TITLE
feat(zk-proof-service): client-side WASM ZK prover package with fallback

### DIFF
--- a/zk-proof-service/packages/zk-prover/README.md
+++ b/zk-proof-service/packages/zk-prover/README.md
@@ -1,0 +1,71 @@
+# @sorotask/zk-prover
+
+Client-side Zero-Knowledge proof generation for SoroTask (#852). Runs
+[snarkjs](https://github.com/iden3/snarkjs)'s Groth16 WASM prover directly
+in the browser so private witness data never has to be sent to a server —
+sending it to the `zk-proof-service` backend requires trusting that
+service's host with it.
+
+On devices that look too memory-constrained to run the WASM prover
+reliably, it automatically falls back to calling the `zk-proof-service`
+backend's `POST /generate-proof` instead.
+
+## Install
+
+```sh
+npm install @sorotask/zk-prover
+# Only needed if you want browser-side proving (the fallback path doesn't need it):
+npm install snarkjs
+```
+
+## Usage
+
+```js
+const { generateProof } = require('@sorotask/zk-prover');
+
+const result = await generateProof({
+  // Browser-proving path:
+  input: { a: 3, b: 5 },
+  wasmUrl: '/circuits/liquidity_threshold.wasm',
+  zkeyUrl: '/circuits/liquidity_threshold_final.zkey',
+
+  // Backend-fallback path (used automatically on constrained devices):
+  backendBaseUrl: 'https://zk.sorotask.example.com',
+  backendPayload: {
+    taskCondition: { type: 'liquidity-threshold', params: { minLiquidity: 100 } },
+    clientData: { witness: { actualLiquidity: 150 } },
+  },
+});
+
+console.log(result.source); // 'browser' or 'backend'
+console.log(result.proof, result.publicSignals);
+```
+
+## How the fallback decision is made
+
+`shouldUseFallback()` checks, in order:
+1. Is `WebAssembly` unavailable at all? → fall back.
+2. Does the browser report (via the non-standard `navigator.deviceMemory`,
+   Chromium-only) less than `minDeviceMemoryGb` (default `4`)? → fall back.
+3. Otherwise, prove locally.
+
+`navigator.deviceMemory` isn't implemented in every browser (notably
+Safari/Firefox). When it's unreported, this assumes the device **can**
+run the prover rather than silently routing everyone through the backend
+on browsers that just don't expose the API — that would defeat this
+package's privacy goal for most users.
+
+You can override the memory threshold or inject a mock `navigator` (useful
+for testing or non-browser environments):
+
+```js
+const { shouldUseFallback } = require('@sorotask/zk-prover');
+shouldUseFallback({ minDeviceMemoryGb: 2, nav: { deviceMemory: 3 } }); // false
+```
+
+## API
+
+- `generateProof(params, options)` — the main entry point described above.
+- `generateProofInBrowser(input, wasmUrl, zkeyUrl)` — always proves locally via snarkjs; throws if `snarkjs` isn't installed.
+- `generateProofViaBackend(baseUrl, payload, options)` — always calls the backend; `options.fetch` and `options.authToken` are supported for non-browser use and auth.
+- `shouldUseFallback(options)` — the fallback heuristic on its own.

--- a/zk-proof-service/packages/zk-prover/package.json
+++ b/zk-proof-service/packages/zk-prover/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sorotask/zk-prover",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Client-side WASM Zero-Knowledge proof generation for SoroTask, with automatic fallback to the zk-proof-service backend on memory-constrained devices.",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": ["zk", "zero-knowledge", "snarkjs", "wasm", "soroban"],
+  "author": "",
+  "license": "ISC",
+  "peerDependencies": {
+    "snarkjs": "^0.7.0"
+  },
+  "peerDependenciesMeta": {
+    "snarkjs": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "jest": "^30.4.2"
+  },
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/zk-proof-service/packages/zk-prover/src/index.js
+++ b/zk-proof-service/packages/zk-prover/src/index.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/**
+ * @sorotask/zk-prover — client-side WASM ZK proof generation (#852).
+ *
+ * Wraps snarkjs's groth16 prover (already WASM-based and browser-compatible)
+ * so witness data never leaves the browser for devices that can handle the
+ * computation locally — sending private witness data to the backend
+ * zk-proof-service requires trusting that service's host with it.
+ *
+ * Falls back to the backend only when the device looks too constrained to
+ * run the WASM prover reliably (e.g. low-memory mobile devices), per the
+ * issue's proposed solution. snarkjs is an optional peer dependency: it's
+ * only actually imported on the browser-proving path, so consumers who
+ * always take the backend fallback don't need it bundled.
+ */
+
+const DEFAULT_FALLBACK_DEVICE_MEMORY_GB = 4;
+
+/**
+ * Heuristic: should this device use the backend fallback instead of proving
+ * locally? True when WebAssembly is unavailable, or when the browser
+ * reports (via the non-standard but Chromium-supported
+ * `navigator.deviceMemory`) less RAM than `minDeviceMemoryGb`.
+ *
+ * `navigator.deviceMemory` isn't implemented in every browser (notably
+ * Safari/Firefox) — when it's absent, this assumes the device CAN run the
+ * prover rather than silently routing everyone through the backend, since
+ * that would defeat this package's whole privacy goal for the majority of
+ * users on browsers that just don't expose the API.
+ *
+ * @param {{ minDeviceMemoryGb?: number, nav?: { deviceMemory?: number } }} [options]
+ * @returns {boolean}
+ */
+function shouldUseFallback(options = {}) {
+  const minDeviceMemoryGb = options.minDeviceMemoryGb ?? DEFAULT_FALLBACK_DEVICE_MEMORY_GB;
+  const nav = options.nav ?? (typeof navigator !== 'undefined' ? navigator : undefined);
+
+  if (typeof WebAssembly === 'undefined') return true;
+
+  const deviceMemory = nav && typeof nav.deviceMemory === 'number' ? nav.deviceMemory : undefined;
+  if (deviceMemory !== undefined && deviceMemory < minDeviceMemoryGb) return true;
+
+  return false;
+}
+
+/**
+ * Generate a Groth16 proof entirely client-side using snarkjs's WASM
+ * prover. The witness (`input`) never leaves the browser.
+ *
+ * @param {Record<string, unknown>} input - Circuit witness input.
+ * @param {string} wasmUrl - URL to the circuit's compiled .wasm witness calculator.
+ * @param {string} zkeyUrl - URL to the circuit's proving key (.zkey).
+ * @returns {Promise<{ proof: object, publicSignals: string[] }>}
+ */
+async function generateProofInBrowser(input, wasmUrl, zkeyUrl) {
+  let snarkjs;
+  try {
+    // eslint-disable-next-line global-require
+    snarkjs = require('snarkjs');
+  } catch (err) {
+    throw new Error(
+      '[zk-prover] snarkjs is required for browser-side proving but is not installed. ' +
+      'Install it (npm install snarkjs), or always pass a backendBaseUrl to generateProof ' +
+      'so it can use the backend fallback instead.',
+    );
+  }
+  return snarkjs.groth16.fullProve(input, wasmUrl, zkeyUrl);
+}
+
+/**
+ * Request proof generation from the zk-proof-service backend's
+ * POST /generate-proof route — used when `shouldUseFallback()` is true.
+ *
+ * @param {string} baseUrl - zk-proof-service base URL.
+ * @param {{ taskId?: string, circuitId?: string, taskCondition: object, clientData: object }} payload
+ * @param {{ authToken?: string, fetch?: typeof fetch }} [options]
+ * @returns {Promise<object>}
+ */
+async function generateProofViaBackend(baseUrl, payload, options = {}) {
+  const doFetch = options.fetch ?? (typeof fetch !== 'undefined' ? fetch : undefined);
+  if (!doFetch) {
+    throw new Error(
+      '[zk-prover] No fetch implementation available for the backend fallback. ' +
+      'Pass options.fetch explicitly in non-browser environments.',
+    );
+  }
+
+  const response = await doFetch(`${baseUrl.replace(/\/$/, '')}/generate-proof`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.authToken ? { Authorization: `Bearer ${options.authToken}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`[zk-prover] Backend proof generation failed (${response.status}): ${body}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Generate a ZK proof, proving locally in the browser when the device looks
+ * capable, and falling back to the backend zk-proof-service otherwise.
+ *
+ * @param {object} params
+ * @param {Record<string, unknown>} [params.input] - Circuit witness input (browser path only).
+ * @param {string} [params.wasmUrl] - Required for the browser path.
+ * @param {string} [params.zkeyUrl] - Required for the browser path.
+ * @param {string} [params.backendBaseUrl] - zk-proof-service base URL, required for the fallback path.
+ * @param {object} [params.backendPayload] - Request body for the fallback path (see generateProofViaBackend).
+ * @param {{ minDeviceMemoryGb?: number, nav?: object, authToken?: string, fetch?: typeof fetch }} [options]
+ * @returns {Promise<{ proof: object, publicSignals: string[], source: 'browser' | 'backend' }>}
+ */
+async function generateProof(params, options = {}) {
+  const useFallback = shouldUseFallback(options);
+
+  if (useFallback) {
+    if (!params.backendBaseUrl || !params.backendPayload) {
+      throw new Error(
+        '[zk-prover] This device requires the backend fallback but backendBaseUrl/' +
+        'backendPayload were not provided.',
+      );
+    }
+    const result = await generateProofViaBackend(params.backendBaseUrl, params.backendPayload, options);
+    return { ...result, source: 'backend' };
+  }
+
+  if (!params.wasmUrl || !params.zkeyUrl) {
+    throw new Error('[zk-prover] wasmUrl/zkeyUrl are required to prove in the browser.');
+  }
+  const result = await generateProofInBrowser(params.input, params.wasmUrl, params.zkeyUrl);
+  return { ...result, source: 'browser' };
+}
+
+module.exports = {
+  shouldUseFallback,
+  generateProofInBrowser,
+  generateProofViaBackend,
+  generateProof,
+};

--- a/zk-proof-service/packages/zk-prover/src/index.test.js
+++ b/zk-proof-service/packages/zk-prover/src/index.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { shouldUseFallback, generateProofViaBackend, generateProof } = require('./index');
+
+describe('shouldUseFallback', () => {
+  it('falls back when WebAssembly is unavailable', () => {
+    const realWebAssembly = global.WebAssembly;
+    delete global.WebAssembly;
+    try {
+      expect(shouldUseFallback({ nav: {} })).toBe(true);
+    } finally {
+      global.WebAssembly = realWebAssembly;
+    }
+  });
+
+  it('falls back when reported device memory is below the threshold', () => {
+    expect(shouldUseFallback({ nav: { deviceMemory: 2 }, minDeviceMemoryGb: 4 })).toBe(true);
+  });
+
+  it('does not fall back when device memory meets the threshold', () => {
+    expect(shouldUseFallback({ nav: { deviceMemory: 8 }, minDeviceMemoryGb: 4 })).toBe(false);
+  });
+
+  it('does not fall back when deviceMemory is unreported (assume capable)', () => {
+    expect(shouldUseFallback({ nav: {} })).toBe(false);
+  });
+});
+
+describe('generateProofViaBackend', () => {
+  it('posts to /generate-proof with the expected shape and returns the parsed body', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ proof: { pi_a: [] }, publicSignals: [] }),
+    });
+
+    const payload = { taskCondition: { type: 'liquidity-threshold' }, clientData: { witness: {} } };
+    const result = await generateProofViaBackend('https://zk.example.com/', payload, {
+      fetch: fetchMock,
+      authToken: 'token123',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://zk.example.com/generate-proof',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token123',
+        }),
+        body: JSON.stringify(payload),
+      }),
+    );
+    expect(result).toEqual({ proof: { pi_a: [] }, publicSignals: [] });
+  });
+
+  it('throws with the response body on a non-ok response', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => '{"error":"INVALID_INPUT"}',
+    });
+
+    await expect(
+      generateProofViaBackend('https://zk.example.com', {}, { fetch: fetchMock }),
+    ).rejects.toThrow(/400/);
+  });
+});
+
+describe('generateProof', () => {
+  it('routes to the backend when the device requires the fallback', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ proof: {}, publicSignals: [] }),
+    });
+
+    const result = await generateProof(
+      {
+        backendBaseUrl: 'https://zk.example.com',
+        backendPayload: { taskCondition: {}, clientData: {} },
+      },
+      { nav: { deviceMemory: 1 }, fetch: fetchMock },
+    );
+
+    expect(result.source).toBe('backend');
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('throws a clear error when the fallback is required but not configured', async () => {
+    await expect(
+      generateProof({}, { nav: { deviceMemory: 1 } }),
+    ).rejects.toThrow(/requires the backend fallback/);
+  });
+
+  it('throws a clear error when browser proving is selected but wasmUrl/zkeyUrl are missing', async () => {
+    await expect(
+      generateProof({ input: {} }, { nav: { deviceMemory: 8 } }),
+    ).rejects.toThrow(/wasmUrl\/zkeyUrl are required/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `@sorotask/zk-prover` (`zk-proof-service/packages/zk-prover`): wraps snarkjs's Groth16 prover — already WASM-based and browser-compatible — so private witness data never has to leave the browser. Sending it to the `zk-proof-service` backend instead requires trusting that service's host with it, which is exactly the problem this issue describes.

- **`generateProofInBrowser(input, wasmUrl, zkeyUrl)`** — calls `snarkjs.groth16.fullProve` directly. `snarkjs` is an optional peer dependency, only actually required on this path, so backend-only consumers don't need it bundled.
- **`generateProofViaBackend(baseUrl, payload, options)`** — POSTs to the existing `zk-proof-service` `POST /generate-proof` route. Injectable `fetch`/`authToken` for non-browser use and auth.
- **`shouldUseFallback(options)`** — the mobile/low-RAM fallback heuristic: no `WebAssembly`, or `navigator.deviceMemory` (Chromium-only) below a configurable threshold (default 4GB), triggers the backend path. Deliberately does **not** fall back when `deviceMemory` is unreported (Safari/Firefox don't implement it) — defaulting unreported devices to the backend would defeat this package's whole privacy goal for most users.
- **`generateProof(params, options)`** — picks a path via `shouldUseFallback` and runs it, tagging the result with `source: 'browser' | 'backend'`.

I checked the existing `frontend/src/lib/zk-proof/*` prover engine first — it's a well-built UI/UX simulation of the proving pipeline (fake timers, `simulateFailure`/`simulateCongestion` flags), not real cryptography, so this package is genuinely new capability rather than a duplicate.

## Test plan
jest isn't installed in this environment (out of scope per task instructions), so I verified the core logic manually with plain `node -e` scripts: device-memory thresholds in both directions, the no-`WebAssembly` branch, the backend request shape/auth header, and both configuration-error paths — all passed. `src/index.test.js` encodes the same cases, ready for CI once dependencies are installed.

Closes #852