### PR TITLE
feat(zk-proof-service): proof verification benchmarking engine

### DIFF
--- a/zk-proof-service/benchmarks/README.md
+++ b/zk-proof-service/benchmarks/README.md
@@ -1,0 +1,56 @@
+# zk-proof-service benchmarks (#856)
+
+Two benchmarks, both writing JSON reports to `results/` (same convention as
+`keeper/benchmarks`: `{ name, date, results: [...] }`), comparable with
+`compare.js`.
+
+## `proof-service.bench.js` — real numbers, today
+
+Benchmarks the `ZKProofService` that actually exists in this repo:
+`generateProof`/`verifyProof` latency at increasing concurrent load (1, 10,
+50). This is a load proxy for the "constraint size" axis the issue asks
+for, since `ZKProofService`'s (currently mocked) proof generation isn't
+parameterized by a real circuit.
+
+```sh
+node proof-service.bench.js
+node compare.js results/proof-service-<old>.json results/proof-service-<new>.json
+```
+
+## `scheme-matrix.bench.js` — the Groth16/Plonk/Halo2 × constraint-size matrix
+
+This is the actual comparison the issue describes: every combination of
+`{groth16, plonk, halo2} × {1K, 10K, 100K, 1M}` constraints, reporting
+proof size, generation time, verification time, and a gas estimate.
+
+**Every cell is currently reported as `skipped`, honestly**, because none
+of the infrastructure to produce real numbers exists in this repo yet:
+
+- Groth16/Plonk need a circuit compiled at each constraint size (a
+  `.circom` file plus a trusted-setup `.zkey`) and `snarkjs` installed —
+  neither exists here.
+- Halo2 needs an entire separate Rust crate — there's no `circom`
+  equivalent for it, and this repo has no Halo2 circuit code at all.
+- Gas-cost comparison needs an on-chain verifier contract per scheme
+  deployed in `contract/`, so a real resource-fee simulation can run
+  against it — none exists.
+
+Fabricating plausible-looking numbers for any of this would actively
+mislead the developers this tool is meant to help pick a scheme correctly.
+`schemes/index.js` documents exactly what each adapter needs; once real
+artifacts exist for a scheme, fill in its `generateProof`/`verifyProof` and
+`scheme-matrix.bench.js` picks it up automatically — no changes needed to
+the runner itself.
+
+```sh
+node scheme-matrix.bench.js
+```
+
+## Not done here (out of scope for `zk-proof-service/`)
+
+The issue's proposed solution also asks for a frontend docs page
+publishing these reports and a "recommended scheme selector" tool for
+developers. Both are frontend features (this issue's affected area is
+`zk-proof-service/index.test.js`) — once `scheme-matrix.bench.js` has real
+data to report, a `frontend/app/.../benchmarks` page reading its JSON
+output would be the natural next step.

--- a/zk-proof-service/benchmarks/compare.js
+++ b/zk-proof-service/benchmarks/compare.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Compare two benchmark report JSON files (from proof-service.bench.js or
+ * scheme-matrix.bench.js), same convention as keeper/benchmarks/compare.js.
+ *
+ * Usage: node compare.js <old-results.json> <new-results.json>
+ */
+
+const fs = require('fs');
+
+function parseResult(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw);
+    const map = new Map();
+    (data.results || []).forEach((r) => {
+      const key = r.name || `${r.scheme}@${r.constraintCount}`;
+      map.set(key, r);
+    });
+    return { name: data.name, date: data.date, map };
+  } catch (err) {
+    console.error(`Error reading or parsing ${filePath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function metricFor(result) {
+  if (typeof result.ops === 'number') return { label: 'ops/sec', value: result.ops };
+  if (typeof result.generationMs === 'number') return { label: 'gen ms', value: result.generationMs };
+  return { label: 'n/a', value: null };
+}
+
+function compare(oldFile, newFile) {
+  const oldData = parseResult(oldFile);
+  const newData = parseResult(newFile);
+
+  console.log(`\nComparing Benchmarks for: ${newData.name}`);
+  console.log(`Old Run: ${oldData.date}`);
+  console.log(`New Run: ${newData.date}`);
+  console.log('----------------------------------------------------------------------------------');
+  console.log(`| ${'Test Name'.padEnd(35)} | ${'Old'.padEnd(15)} | ${'New'.padEnd(15)} | ${'Diff %'.padEnd(8)} |`);
+  console.log('----------------------------------------------------------------------------------');
+
+  for (const [name, newResult] of newData.map.entries()) {
+    const oldResult = oldData.map.get(name);
+    const { value: newVal } = metricFor(newResult);
+
+    if (!oldResult || newVal === null) {
+      console.log(`| ${name.padEnd(35)} | ${'N/A'.padEnd(15)} | ${String(newVal ?? 'N/A').padEnd(15)} | ${'N/A'.padEnd(8)} |`);
+      continue;
+    }
+
+    const { value: oldVal } = metricFor(oldResult);
+    if (oldVal === null || oldVal === 0) {
+      console.log(`| ${name.padEnd(35)} | ${String(oldVal).padEnd(15)} | ${String(newVal).padEnd(15)} | ${'N/A'.padEnd(8)} |`);
+      continue;
+    }
+
+    const diff = ((newVal - oldVal) / oldVal) * 100;
+    const diffStr = diff > 0 ? `+${diff.toFixed(2)}%` : `${diff.toFixed(2)}%`;
+
+    console.log(`| ${name.padEnd(35)} | ${String(oldVal).padEnd(15)} | ${String(newVal).padEnd(15)} | ${diffStr.padEnd(8)} |`);
+  }
+  console.log('----------------------------------------------------------------------------------\n');
+}
+
+const args = process.argv.slice(2);
+if (args.length !== 2) {
+  console.error('Usage: node compare.js <old-results.json> <new-results.json>');
+  process.exit(1);
+}
+
+compare(args[0], args[1]);

--- a/zk-proof-service/benchmarks/lib/stats.js
+++ b/zk-proof-service/benchmarks/lib/stats.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Small, dependency-free timing/statistics helper for the benchmarking
+ * engine (#856). No external benchmark library dependency (keeper's
+ * benchmarks use `benny`, which isn't a zk-proof-service dependency) —
+ * this is deliberately minimal: run a function N times, record wall-clock
+ * duration per run, report mean/median/p95/ops-per-second.
+ */
+
+/**
+ * Run `fn` `iterations` times sequentially, timing each call.
+ *
+ * @param {() => Promise<unknown>} fn
+ * @param {number} iterations
+ * @returns {Promise<number[]>} Duration of each run, in milliseconds.
+ */
+async function timeIterations(fn, iterations) {
+  const durationsMs = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = process.hrtime.bigint();
+    await fn();
+    const end = process.hrtime.bigint();
+    durationsMs.push(Number(end - start) / 1e6);
+  }
+  return durationsMs;
+}
+
+/**
+ * Summarize an array of millisecond durations.
+ *
+ * @param {number[]} durationsMs
+ * @returns {{ count: number, meanMs: number, p50Ms: number, p95Ms: number, minMs: number, maxMs: number, opsPerSec: number }}
+ */
+function summarize(durationsMs) {
+  if (durationsMs.length === 0) {
+    return { count: 0, meanMs: 0, p50Ms: 0, p95Ms: 0, minMs: 0, maxMs: 0, opsPerSec: 0 };
+  }
+
+  const sorted = [...durationsMs].sort((a, b) => a - b);
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  const mean = sum / sorted.length;
+  const percentile = (p) => {
+    const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+    return sorted[idx];
+  };
+
+  return {
+    count: sorted.length,
+    meanMs: Number(mean.toFixed(3)),
+    p50Ms: Number(percentile(50).toFixed(3)),
+    p95Ms: Number(percentile(95).toFixed(3)),
+    minMs: Number(sorted[0].toFixed(3)),
+    maxMs: Number(sorted[sorted.length - 1].toFixed(3)),
+    opsPerSec: mean > 0 ? Number((1000 / mean).toFixed(2)) : 0,
+  };
+}
+
+module.exports = { timeIterations, summarize };

--- a/zk-proof-service/benchmarks/proof-service.bench.js
+++ b/zk-proof-service/benchmarks/proof-service.bench.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Real (not skipped) benchmark for #856: exercises the ZKProofService that
+ * actually exists in this repo today — proof generation and verification
+ * latency, at increasing concurrent load. This is a proxy for the
+ * "constraint size" axis the issue asks for, using load instead, since
+ * ZKProofService's proof generation isn't parameterized by a real circuit
+ * (see scheme-matrix.bench.js for the actual per-scheme/per-constraint-size
+ * matrix, which is honestly "skipped" everywhere pending real circuit
+ * artifacts). Mirrors keeper/benchmarks' JSON report convention so
+ * compare.js works the same way across both.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { ZKProofService } = require('../index');
+const { timeIterations, summarize } = require('./lib/stats');
+
+const LOAD_LEVELS = [1, 10, 50];
+const ITERATIONS_PER_LEVEL = 20;
+
+async function benchmarkGenerateProof(service, concurrency) {
+  const taskCondition = { type: 'privacy-preserving', params: {} };
+  const clientData = { witness: { clientId: 'bench-client' } };
+
+  const durations = await timeIterations(async () => {
+    await Promise.all(
+      Array.from({ length: concurrency }, () => service.generateProof(taskCondition, clientData)),
+    );
+  }, ITERATIONS_PER_LEVEL);
+
+  return summarize(durations);
+}
+
+async function benchmarkVerifyProof(service, concurrency) {
+  const taskCondition = { type: 'privacy-preserving', params: {} };
+  const clientData = { witness: { clientId: 'bench-client' } };
+  const proof = await service.generateProof(taskCondition, clientData);
+
+  const durations = await timeIterations(async () => {
+    await Promise.all(
+      Array.from({ length: concurrency }, () =>
+        service.verifyProof({ taskCondition, proof, circuitId: 'bench' }),
+      ),
+    );
+  }, ITERATIONS_PER_LEVEL);
+
+  return summarize(durations);
+}
+
+async function main() {
+  // Worker pool must be at least as large as the highest concurrency level
+  // tested, or ZKProofService.generateProof throws "Worker pool at
+  // capacity" for the overflow instead of measuring real load.
+  const service = new ZKProofService(Math.max(...LOAD_LEVELS));
+  service.initialize();
+
+  console.log('[proof-service-bench] Benchmarking ZKProofService.generateProof / verifyProof...\n');
+
+  const results = [];
+  for (const concurrency of LOAD_LEVELS) {
+    const generation = await benchmarkGenerateProof(service, concurrency);
+    console.log(`  generateProof x${concurrency} concurrent — mean ${generation.meanMs}ms, p95 ${generation.p95Ms}ms, ${generation.opsPerSec} batches/sec`);
+    results.push({ name: `generateProof-concurrency-${concurrency}`, ops: generation.opsPerSec, ...generation });
+
+    const verification = await benchmarkVerifyProof(service, concurrency);
+    console.log(`  verifyProof   x${concurrency} concurrent — mean ${verification.meanMs}ms, p95 ${verification.p95Ms}ms, ${verification.opsPerSec} batches/sec`);
+    results.push({ name: `verifyProof-concurrency-${concurrency}`, ops: verification.opsPerSec, ...verification });
+  }
+
+  service.shutdown();
+
+  const report = {
+    name: 'zk-proof-service ZKProofService benchmark',
+    date: new Date().toISOString(),
+    results,
+  };
+
+  const outDir = path.join(__dirname, 'results');
+  fs.mkdirSync(outDir, { recursive: true });
+  const outFile = path.join(outDir, `proof-service-${Date.now()}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(report, null, 2));
+  console.log(`\n[proof-service-bench] Report written to ${outFile}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { benchmarkGenerateProof, benchmarkVerifyProof };

--- a/zk-proof-service/benchmarks/scheme-matrix.bench.js
+++ b/zk-proof-service/benchmarks/scheme-matrix.bench.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Proof-scheme comparison matrix (#856): Groth16 / Plonk / Halo2 across
+ * 1K / 10K / 100K / 1M constraints, as the issue's proposed solution
+ * describes. See schemes/index.js for why every cell is currently
+ * "skipped" rather than a fabricated number, and what's needed to make a
+ * cell real.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { SCHEMES } = require('./schemes');
+
+const CONSTRAINT_SIZES = [1_000, 10_000, 100_000, 1_000_000];
+
+async function runMatrix() {
+  const results = [];
+
+  for (const scheme of SCHEMES) {
+    for (const constraintCount of CONSTRAINT_SIZES) {
+      const cell = { scheme: scheme.name, constraintCount };
+
+      if (!scheme.isAvailable()) {
+        results.push({ ...cell, skipped: true, reason: scheme.unavailableReason });
+        continue;
+      }
+
+      try {
+        const genStart = process.hrtime.bigint();
+        const { proof, sizeBytes } = await scheme.generateProof(constraintCount);
+        const genMs = Number(process.hrtime.bigint() - genStart) / 1e6;
+
+        const verifyStart = process.hrtime.bigint();
+        const valid = await scheme.verifyProof(proof);
+        const verifyMs = Number(process.hrtime.bigint() - verifyStart) / 1e6;
+
+        results.push({
+          ...cell,
+          skipped: false,
+          proofSizeBytes: sizeBytes,
+          generationMs: Number(genMs.toFixed(3)),
+          verificationMs: Number(verifyMs.toFixed(3)),
+          valid,
+          // Gas/resource-cost comparison requires an on-chain verifier
+          // contract per scheme; none is deployed in this repo yet.
+          gasEstimate: null,
+        });
+      } catch (err) {
+        results.push({ ...cell, skipped: true, reason: err.message });
+      }
+    }
+  }
+
+  return results;
+}
+
+async function main() {
+  console.log('[scheme-matrix] Running proof-scheme comparison matrix...\n');
+  const results = await runMatrix();
+
+  for (const row of results) {
+    if (row.skipped) {
+      console.log(`  ${row.scheme.padEnd(8)} @ ${String(row.constraintCount).padStart(9)} constraints — SKIPPED (${row.reason})`);
+    } else {
+      console.log(
+        `  ${row.scheme.padEnd(8)} @ ${String(row.constraintCount).padStart(9)} constraints — ` +
+        `gen ${row.generationMs}ms, verify ${row.verificationMs}ms, ${row.proofSizeBytes}B, valid=${row.valid}`,
+      );
+    }
+  }
+
+  const report = {
+    name: 'zk-proof-service scheme comparison matrix',
+    date: new Date().toISOString(),
+    results,
+  };
+
+  const outDir = path.join(__dirname, 'results');
+  fs.mkdirSync(outDir, { recursive: true });
+  const outFile = path.join(outDir, `scheme-matrix-${Date.now()}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(report, null, 2));
+  console.log(`\n[scheme-matrix] Report written to ${outFile}`);
+
+  const availableCount = results.filter((r) => !r.skipped).length;
+  if (availableCount === 0) {
+    console.log(
+      '\n[scheme-matrix] No scheme produced real numbers this run — see schemes/index.js for what ' +
+      'each one needs (compiled circuit artifacts for Groth16/Plonk, a Halo2 crate for Halo2).',
+    );
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { runMatrix, CONSTRAINT_SIZES };

--- a/zk-proof-service/benchmarks/schemes/index.js
+++ b/zk-proof-service/benchmarks/schemes/index.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * Pluggable proof-scheme registry for the benchmarking matrix (#856).
+ *
+ * The issue asks for a comparison across Groth16, Plonk, and Halo2 at
+ * 1K/10K/100K/1M constraints. Producing *real* numbers for that requires,
+ * per scheme: a circuit compiler, compiled artifacts (wasm witness
+ * calculator + proving key) at each constraint size, and — for Halo2 — a
+ * separate Rust toolchain entirely. None of those exist in this repo
+ * (there isn't a single .circom file with real constraint counts, no
+ * compiled .zkey/.wasm artifacts, no Halo2 crate). Fabricating benchmark
+ * numbers without them would be actively misleading for a tool whose
+ * whole purpose is helping developers pick a scheme based on real data.
+ *
+ * So each adapter here declares `isAvailable()`, and the matrix runner
+ * (scheme-matrix.bench.js) honestly records "skipped, unavailable" rather
+ * than inventing numbers. Once real circuits/artifacts exist for a scheme,
+ * fill in its `generateProof`/`verifyProof` and the matrix runner picks it
+ * up automatically — no changes needed there.
+ */
+
+/**
+ * @typedef {Object} ProofSchemeAdapter
+ * @property {string} name
+ * @property {() => boolean} isAvailable - Whether this scheme can actually run in the current environment.
+ * @property {string} unavailableReason - Shown when isAvailable() is false.
+ * @property {(constraintCount: number) => Promise<{ proof: unknown, sizeBytes: number }>} generateProof
+ * @property {(proof: unknown) => Promise<boolean>} verifyProof
+ */
+
+function hasModule(name) {
+  try {
+    require.resolve(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** @type {ProofSchemeAdapter} */
+const groth16 = {
+  name: 'groth16',
+  isAvailable: () => false,
+  unavailableReason:
+    hasModule('snarkjs')
+      ? 'snarkjs is installed, but no compiled circuit artifacts (.wasm/.zkey) exist at any of the ' +
+        'benchmark constraint sizes. Compile circuits per size and point generateProof at them.'
+      : 'snarkjs is not installed (npm install snarkjs) and no compiled circuit artifacts exist.',
+  async generateProof() {
+    throw new Error('[benchmarks] groth16 adapter is not wired to real circuit artifacts yet.');
+  },
+  async verifyProof() {
+    throw new Error('[benchmarks] groth16 adapter is not wired to real circuit artifacts yet.');
+  },
+};
+
+/** @type {ProofSchemeAdapter} */
+const plonk = {
+  name: 'plonk',
+  isAvailable: () => false,
+  unavailableReason:
+    hasModule('snarkjs')
+      ? 'snarkjs is installed, but no compiled PLONK circuit artifacts exist at any of the ' +
+        'benchmark constraint sizes.'
+      : 'snarkjs is not installed (npm install snarkjs) and no compiled circuit artifacts exist.',
+  async generateProof() {
+    throw new Error('[benchmarks] plonk adapter is not wired to real circuit artifacts yet.');
+  },
+  async verifyProof() {
+    throw new Error('[benchmarks] plonk adapter is not wired to real circuit artifacts yet.');
+  },
+};
+
+/** @type {ProofSchemeAdapter} */
+const halo2 = {
+  name: 'halo2',
+  isAvailable: () => false,
+  unavailableReason:
+    'Halo2 needs a separate Rust crate (no circom/snarkjs equivalent — this repo has no Halo2 ' +
+    'circuit crate at all). Add one under contract/ or a new halo2-circuits/ workspace member, ' +
+    'built as a CLI or native addon this adapter can shell out to / require.',
+  async generateProof() {
+    throw new Error('[benchmarks] halo2 adapter has no backing Rust crate yet.');
+  },
+  async verifyProof() {
+    throw new Error('[benchmarks] halo2 adapter has no backing Rust crate yet.');
+  },
+};
+
+const SCHEMES = [groth16, plonk, halo2];
+
+module.exports = { SCHEMES, groth16, plonk, halo2 };


### PR DESCRIPTION
## Summary

Two benchmarks under `zk-proof-service/benchmarks/`, writing JSON reports (same `{name, date, results}` convention as `keeper/benchmarks`) and sharing keeper's `compare.js` pattern for diffing two runs.

### `proof-service.bench.js` — real, runnable numbers today
Benchmarks the `ZKProofService` that actually exists in this repo: `generateProof`/`verifyProof` latency at 1/10/50 concurrent, as a load proxy for the "constraint size" axis (since `ZKProofService`'s proof generation isn't parameterized by a real circuit). Verified locally: concurrency=1 gives ~101ms mean `generateProof` latency matching the service's simulated delay, results are stable across repeated runs, and I caught a real bug in my own first draft — the worker pool needs to be at least as large as the highest concurrency level tested, or `generateProof` throws `Worker pool at capacity` for the overflow instead of measuring real load. Fixed before committing.

### `scheme-matrix.bench.js` + `schemes/index.js` — the actual Groth16/Plonk/Halo2 matrix
This is what the issue describes: every combination of `{groth16, plonk, halo2} × {1K, 10K, 100K, 1M constraints}`, via a pluggable per-scheme adapter interface. **Every cell currently reports `skipped: true` with an honest reason** — I checked, and there are no compiled circuit artifacts (`.wasm`/`.zkey`) at any constraint size for Groth16/Plonk, no Halo2 crate at all (it has no `circom` equivalent), and no on-chain verifier contract deployed for gas-cost comparison. Fabricating plausible-looking numbers for any of this would actively mislead the developers this tool exists to help pick a scheme correctly. Once real artifacts exist for a scheme, fill in that adapter's `generateProof`/`verifyProof` in `schemes/index.js` and the matrix runner picks it up automatically — no changes needed to the runner itself.

## Not done here (frontend, not `zk-proof-service`)
The issue's proposed solution also asks for a frontend docs page publishing these reports and a "recommended scheme selector" tool for developers. Both need real matrix data to be useful, which needs the artifacts described above first. Noted in `benchmarks/README.md`.

## Test plan
jest isn't installed in this environment (out of scope per task instructions). I ran both benchmark scripts directly with `node` against a temporarily-patched copy of `index.js` (to work around the pre-existing duplicate-`require` syntax error also fixed in #854, not yet merged) to confirm they produce sensible, real numbers, then reverted the temporary patch — `index.js` in this PR is untouched. Also verified `compare.js` against two real generated reports.

Closes #856