### PR TITLE
feat(frontend): add global keyboard shortcut system with help modal

### DIFF
--- a/frontend/components/AppProviders.tsx
+++ b/frontend/components/AppProviders.tsx
@@ -2,11 +2,14 @@
 
 import React from 'react';
 import { Toaster } from 'sonner';
+import { KeyboardShortcutsProvider } from './KeyboardShortcutsProvider';
 
 export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <>
-      {children}
+      {/* Mounted once here so every page inherits the same bindings, rather
+          than each registering its own set and drifting apart (#875). */}
+      <KeyboardShortcutsProvider>{children}</KeyboardShortcutsProvider>
       <Toaster
         position="bottom-right"
         theme="dark"

--- a/frontend/components/KeyboardShortcutsProvider.tsx
+++ b/frontend/components/KeyboardShortcutsProvider.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+/**
+ * KeyboardShortcutsProvider — app-wide hotkeys and the `?` help modal (#875).
+ *
+ * Mounted once from AppProviders so every dashboard page inherits the same
+ * bindings, rather than each page registering its own and drifting.
+ */
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  useKeyboardShortcuts,
+  formatShortcutKeys,
+  type Shortcut,
+} from '../hooks/useKeyboardShortcuts';
+
+interface KeyboardShortcutsContextValue {
+  /** Shortcuts currently registered, for the help modal. */
+  shortcuts: Shortcut[];
+  openHelp: () => void;
+  closeHelp: () => void;
+  isHelpOpen: boolean;
+}
+
+const KeyboardShortcutsContext = createContext<KeyboardShortcutsContextValue | null>(null);
+
+export function useKeyboardShortcutsContext(): KeyboardShortcutsContextValue {
+  const ctx = useContext(KeyboardShortcutsContext);
+  if (!ctx) {
+    throw new Error('useKeyboardShortcutsContext must be used inside <KeyboardShortcutsProvider>');
+  }
+  return ctx;
+}
+
+export function KeyboardShortcutsProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [isHelpOpen, setHelpOpen] = useState(false);
+
+  const openHelp = useCallback(() => setHelpOpen(true), []);
+  const closeHelp = useCallback(() => setHelpOpen(false), []);
+
+  /**
+   * Focus the page's search input, falling back to dispatching the event the
+   * command palette listens for. `/` should reach whichever search surface the
+   * current page actually has rather than assuming one exists.
+   */
+  const focusSearch = useCallback(() => {
+    const input = document.querySelector<HTMLInputElement>(
+      'input[type="search"], input[data-search-input]',
+    );
+    if (input) {
+      input.focus();
+      input.select();
+      return;
+    }
+    document.dispatchEvent(new CustomEvent('sorotask:open-command-palette'));
+  }, []);
+
+  const shortcuts = useMemo<Shortcut[]>(
+    () => [
+      {
+        keys: 'n',
+        description: 'Create a new task',
+        group: 'Actions',
+        handler: () => router.push('/tasks/new'),
+      },
+      {
+        keys: '/',
+        description: 'Focus search',
+        group: 'Actions',
+        handler: focusSearch,
+      },
+      {
+        keys: '?',
+        description: 'Show this help',
+        group: 'Actions',
+        // Declared so it appears in its own list — a help modal that does not
+        // document how it was opened is a small but real gap.
+        handler: openHelp,
+      },
+      {
+        keys: 'g k',
+        description: 'Go to Keepers',
+        group: 'Navigation',
+        handler: () => router.push('/keepers'),
+      },
+      {
+        keys: 'g d',
+        description: 'Go to Dashboard',
+        group: 'Navigation',
+        handler: () => router.push('/dashboard'),
+      },
+      {
+        keys: 'g t',
+        description: 'Go to Tasks',
+        group: 'Navigation',
+        handler: () => router.push('/tasks'),
+      },
+      {
+        keys: 'Escape',
+        description: 'Close modals and overlays',
+        group: 'General',
+        // Allowed while typing: closing a dialog from inside its own field is
+        // exactly when Escape is most needed.
+        allowInEditable: true,
+        handler: () => {
+          if (isHelpOpen) {
+            closeHelp();
+            return;
+          }
+          document.dispatchEvent(new CustomEvent('sorotask:close-overlays'));
+        },
+      },
+    ],
+    [router, focusSearch, openHelp, closeHelp, isHelpOpen],
+  );
+
+  useKeyboardShortcuts(shortcuts);
+
+  const value = useMemo(
+    () => ({ shortcuts, openHelp, closeHelp, isHelpOpen }),
+    [shortcuts, openHelp, closeHelp, isHelpOpen],
+  );
+
+  return (
+    <KeyboardShortcutsContext.Provider value={value}>
+      {children}
+      {isHelpOpen && <KeyboardShortcutsHelp shortcuts={shortcuts} onClose={closeHelp} />}
+    </KeyboardShortcutsContext.Provider>
+  );
+}
+
+/** The `?` overlay listing every registered shortcut, grouped. */
+function KeyboardShortcutsHelp({
+  shortcuts,
+  onClose,
+}: {
+  shortcuts: Shortcut[];
+  onClose: () => void;
+}) {
+  const groups = useMemo(() => {
+    const byGroup = new Map<string, Shortcut[]>();
+    for (const s of shortcuts) {
+      const key = s.group ?? 'General';
+      byGroup.set(key, [...(byGroup.get(key) ?? []), s]);
+    }
+    return Array.from(byGroup.entries());
+  }, [shortcuts]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shortcuts-help-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[80vh] w-full max-w-lg overflow-y-auto rounded-xl border border-slate-700 bg-slate-900 p-6 shadow-2xl"
+        // The backdrop closes on click, so clicks inside the panel must not
+        // bubble up to it.
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 id="shortcuts-help-title" className="text-lg font-semibold text-slate-50">
+            Keyboard shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close keyboard shortcuts"
+            className="rounded-md px-2 py-1 text-slate-400 transition-colors hover:bg-slate-800 hover:text-slate-100"
+          >
+            ✕
+          </button>
+        </div>
+
+        {groups.map(([group, items]) => (
+          <section key={group} className="mb-5 last:mb-0">
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+              {group}
+            </h3>
+            <ul className="space-y-1.5">
+              {items.map((s) => (
+                <li key={s.keys} className="flex items-center justify-between gap-4">
+                  <span className="text-sm text-slate-300">{s.description}</span>
+                  <span className="flex shrink-0 gap-1">
+                    {formatShortcutKeys(s.keys).map((k, i) => (
+                      <kbd
+                        key={`${s.keys}-${i}`}
+                        className="rounded border border-slate-600 bg-slate-800 px-2 py-0.5 font-mono text-xs text-slate-200"
+                      >
+                        {k}
+                      </kbd>
+                    ))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+
+        <p className="mt-4 border-t border-slate-800 pt-3 text-xs text-slate-500">
+          Shortcuts are ignored while typing in a field, except Escape. Two-key
+          sequences such as <kbd className="font-mono">G</kbd>{' '}
+          <kbd className="font-mono">K</kbd> are pressed one after the other.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useKeyboardShortcuts.ts
+++ b/frontend/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,149 @@
+'use client';
+
+/**
+ * useKeyboardShortcuts — global hotkey registration (issue #875).
+ *
+ * Implemented directly on `keydown` rather than pulling in
+ * `react-hotkeys-hook`. The issue suggests that library, but the behaviour
+ * needed here is a single document-level listener plus sequence support, and
+ * the two rules that actually matter — never firing while the user is typing,
+ * and never shadowing a browser shortcut — have to be written by hand either
+ * way. Adding a dependency to wrap `addEventListener` would not have removed
+ * any of that.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+
+/** Elements that own the keystroke while focused. */
+const EDITABLE = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+/** How long a pending sequence prefix (e.g. `g`) stays armed. */
+export const SEQUENCE_TIMEOUT_MS = 1200;
+
+export interface Shortcut {
+  /**
+   * Either a single key (`'n'`, `'?'`, `'Escape'`) or a two-key sequence
+   * written space-separated (`'g k'`), matching the `G K` style in the issue.
+   */
+  keys: string;
+  /** Shown in the help modal. */
+  description: string;
+  /** Grouping label in the help modal. */
+  group?: string;
+  handler: (event: KeyboardEvent) => void;
+  /**
+   * Run even while a text field has focus. Off by default — a shortcut that
+   * fires mid-sentence is worse than no shortcut at all.
+   */
+  allowInEditable?: boolean;
+  /** Temporarily disable without unregistering. */
+  enabled?: boolean;
+}
+
+/** True when the keystroke belongs to whatever the user is typing into. */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return EDITABLE.has(target.tagName);
+}
+
+/**
+ * True when the browser or OS owns this combination.
+ *
+ * Cmd/Ctrl and Alt combinations are left alone: rebinding Ctrl+T or Cmd+W is
+ * hostile, and the browser wins on most of them regardless. `CommandPalette`
+ * handles Cmd+K separately because that one is an application convention.
+ */
+function isReservedCombination(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey || event.altKey;
+}
+
+function normalise(key: string): string {
+  // Single characters compare case-insensitively so Shift+/ ("?") and a plain
+  // "n" both match their declarations; named keys keep their casing.
+  return key.length === 1 ? key.toLowerCase() : key;
+}
+
+/**
+ * Registers `shortcuts` on the document for the lifetime of the component.
+ *
+ * Handlers are held in a ref so re-renders don't tear down and re-attach the
+ * listener — otherwise a shortcut fired mid-render could be missed, and a
+ * pending sequence prefix would be silently dropped.
+ */
+export function useKeyboardShortcuts(shortcuts: Shortcut[], enabled = true) {
+  const shortcutsRef = useRef(shortcuts);
+  const pendingPrefix = useRef<string | null>(null);
+  const prefixTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    shortcutsRef.current = shortcuts;
+  }, [shortcuts]);
+
+  const clearPrefix = useCallback(() => {
+    pendingPrefix.current = null;
+    if (prefixTimer.current) {
+      clearTimeout(prefixTimer.current);
+      prefixTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isReservedCombination(event)) return;
+
+      const key = normalise(event.key);
+      const editable = isEditableTarget(event.target);
+
+      // Escape is the exception to the editable rule: closing a dialog from
+      // inside its own text field is the whole point of Escape.
+      const active = shortcutsRef.current.filter(
+        (s) => s.enabled !== false && (!editable || s.allowInEditable || s.keys === 'Escape'),
+      );
+      if (active.length === 0) return;
+
+      // Continue a sequence already in progress.
+      if (pendingPrefix.current) {
+        const combo = `${pendingPrefix.current} ${key}`;
+        const match = active.find((s) => s.keys === combo);
+        clearPrefix();
+        if (match) {
+          event.preventDefault();
+          match.handler(event);
+        }
+        // Swallow the second keystroke either way: the user was mid-sequence,
+        // so treating an unmatched follow-up as a fresh single-key shortcut
+        // would fire something they did not ask for.
+        return;
+      }
+
+      // Exact single-key match.
+      const match = active.find((s) => s.keys === key);
+      if (match) {
+        event.preventDefault();
+        match.handler(event);
+        return;
+      }
+
+      // Arm a prefix if any registered sequence starts with this key.
+      const startsSequence = active.some((s) => s.keys.startsWith(`${key} `));
+      if (startsSequence) {
+        pendingPrefix.current = key;
+        prefixTimer.current = setTimeout(clearPrefix, SEQUENCE_TIMEOUT_MS);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      clearPrefix();
+    };
+  }, [enabled, clearPrefix]);
+}
+
+/** Render a shortcut declaration for display, e.g. `'g k'` → `['G', 'K']`. */
+export function formatShortcutKeys(keys: string): string[] {
+  return keys.split(' ').map((k) => (k.length === 1 ? k.toUpperCase() : k));
+}


### PR DESCRIPTION
Closes #875

## Problem

No shortcut infrastructure existed. `CommandPalette` bound Cmd+K on its own, `useEscapeKey` was per-component — there was no global binding surface and **no way to discover what was available**.

## What's added

`hooks/useKeyboardShortcuts.ts` plus a `KeyboardShortcutsProvider` mounted once from `AppProviders`, so every page inherits the same bindings instead of each registering its own set and drifting.

| Key | Action |
|---|---|
| `N` | Create a new task |
| `/` | Focus search |
| `?` | Show help |
| `G` `D` / `G` `T` / `G` `K` | Dashboard / Tasks / Keepers |
| `Esc` | Close modals and overlays |

## Two rules the implementation is built around

**1. Shortcuts never fire while the user is typing.** A hotkey that triggers mid-sentence is worse than no hotkey — pressing `n` in a description field must type an `n`. `INPUT`, `TEXTAREA`, `SELECT` and `contenteditable` all own the keystroke.

`Escape` is the deliberate exception: closing a dialog from inside its own text field is exactly when Escape is most needed.

**2. Shortcuts never shadow the browser.** Any combination with Cmd, Ctrl or Alt is ignored outright — rebinding Ctrl+T or Cmd+W is hostile, and the browser wins on most of them anyway. Cmd+K stays with `CommandPalette`, which is an application convention rather than a browser one.

## Sequence handling

`G K` style sequences arm a prefix for 1.2s. An unmatched follow-up keystroke is **swallowed** rather than re-tested as a single-key shortcut — the user was mid-sequence, so firing something else would be acting on input they didn't give.

Handlers live in a ref so re-renders don't tear down the listener and drop a pending prefix.

## On not adding `react-hotkeys-hook`

The issue suggests it, and I didn't — worth flagging explicitly rather than quietly diverging.

What's needed here is one document-level listener plus sequence support, and both rules above have to be written by hand either way. The library would have wrapped `addEventListener` and removed none of the actual work, while adding a dependency to the bundle. **Happy to switch if you'd rather standardise on it** — the hook's surface would stay the same.

## The `?` modal

Groups shortcuts by Actions / Navigation / General, renders each binding as `<kbd>` elements, and documents both the typing exclusion and how sequences are entered. Carries `role="dialog"` + `aria-modal`, and lists `?` itself — a help modal that doesn't document how it was opened is a small but real gap.

`/` focuses the page's own search input when there is one and falls back to opening the command palette, so it reaches whichever search surface the current page actually has rather than assuming one exists.

## Verification

I have not run the dev server or the test suite. Two things worth checking on review: that `AppProviders` is mounted above every route that should get shortcuts, and that the `sorotask:close-overlays` event I dispatch on Escape is the right integration point — if existing modals listen for something else, that's the line to change.