### PR TITLE
feat(frontend): add zoomable Gantt timeline for task execution schedules

### DIFF
--- a/frontend/components/GanttTimeline.tsx
+++ b/frontend/components/GanttTimeline.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+/**
+ * GanttTimeline — task execution schedule as a zoomable timeline (issue #873).
+ *
+ * Grid and list views cannot show overlap or schedule density; this lays every
+ * task's executions on a shared time axis so both are visible at a glance.
+ *
+ * Schedule arithmetic lives in lib/ganttSchedule.ts so it can be tested
+ * without rendering.
+ */
+
+import React, { useMemo, useState } from 'react';
+import type { Task, TaskExecution } from '@/types/task';
+import {
+  ZOOM_LEVELS,
+  STATUS_COLORS,
+  buildTimelineRows,
+  buildTicks,
+  positionPercent,
+  type ZoomLevel,
+} from '@/lib/ganttSchedule';
+
+interface GanttTimelineProps {
+  tasks: Task[];
+  /** Historical runs. Anything after `now` is projected from each interval. */
+  executions?: TaskExecution[];
+  initialZoom?: ZoomLevel;
+  onTaskSelect?: (task: Task) => void;
+}
+
+/** Axis label formatting, tightened as the window narrows. */
+function formatTick(at: number, zoom: ZoomLevel): string {
+  const d = new Date(at);
+  if (zoom === '1h' || zoom === '6h') {
+    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  }
+  if (zoom === '24h') {
+    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  }
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function GanttTimeline({
+  tasks,
+  executions = [],
+  initialZoom = '24h',
+  onTaskSelect,
+}: GanttTimelineProps) {
+  const [zoom, setZoom] = useState<ZoomLevel>(initialZoom);
+
+  // Pinned per render pass rather than read inside the loop, so every row is
+  // positioned against the same instant — otherwise blocks drift relative to
+  // each other and to the "now" marker.
+  const now = useMemo(() => Date.now(), [zoom, tasks, executions]);
+
+  const windowMs = ZOOM_LEVELS.find((z) => z.value === zoom)?.windowMs ?? 86_400_000;
+
+  // A quarter of the window behind now, so recent history is visible without
+  // the upcoming schedule — the reason to open this view — being squeezed.
+  const windowStart = now - windowMs * 0.25;
+  const windowEnd = windowStart + windowMs;
+
+  const rows = useMemo(
+    () => buildTimelineRows(tasks, executions, windowStart, windowEnd, now),
+    [tasks, executions, windowStart, windowEnd, now],
+  );
+
+  const ticks = useMemo(() => buildTicks(windowStart, windowEnd), [windowStart, windowEnd]);
+  const nowPercent = positionPercent(now, windowStart, windowEnd);
+
+  return (
+    <section
+      className="rounded-xl border border-slate-700 bg-slate-900 p-4"
+      aria-label="Task execution timeline"
+    >
+      {/* Controls */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold text-slate-100">Execution timeline</h2>
+
+        <div className="flex items-center gap-1" role="group" aria-label="Timeline zoom level">
+          {ZOOM_LEVELS.map((level) => (
+            <button
+              key={level.value}
+              type="button"
+              onClick={() => setZoom(level.value)}
+              aria-pressed={zoom === level.value}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                zoom === level.value
+                  ? 'bg-slate-700 text-slate-50'
+                  : 'text-slate-400 hover:bg-slate-800 hover:text-slate-200'
+              }`}
+            >
+              {level.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="mb-4 flex flex-wrap gap-3">
+        {(['active', 'pending', 'failed', 'paused'] as const).map((status) => (
+          <span key={status} className="flex items-center gap-1.5 text-xs text-slate-400">
+            <span className={`h-2.5 w-2.5 rounded-sm ${STATUS_COLORS[status].block}`} />
+            {STATUS_COLORS[status].label}
+          </span>
+        ))}
+        <span className="flex items-center gap-1.5 text-xs text-slate-400">
+          <span className="h-2.5 w-2.5 rounded-sm border border-dashed border-slate-400" />
+          Projected
+        </span>
+      </div>
+
+      {/* Axis */}
+      <div className="relative mb-1 ml-44 h-5 border-b border-slate-700">
+        {ticks.map((t) => (
+          <span
+            key={t}
+            className="absolute -translate-x-1/2 text-[10px] text-slate-500"
+            style={{ left: `${positionPercent(t, windowStart, windowEnd)}%` }}
+          >
+            {formatTick(t, zoom)}
+          </span>
+        ))}
+      </div>
+
+      {rows.length === 0 ? (
+        <p className="py-8 text-center text-sm text-slate-500">No tasks to display.</p>
+      ) : (
+        <div className="relative">
+          {/* "Now" marker, drawn across all rows so overlap is readable
+              against the present rather than against each row's own history. */}
+          <div
+            className="pointer-events-none absolute bottom-0 top-0 z-10 ml-44 w-px bg-amber-400/70"
+            style={{ left: `calc(${nowPercent}% )` }}
+            aria-hidden="true"
+          />
+
+          <ul className="space-y-1">
+            {rows.map(({ task, blocks, truncated }) => {
+              const colors = STATUS_COLORS[task.status];
+              return (
+                <li key={task.id} className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onTaskSelect?.(task)}
+                    disabled={!onTaskSelect}
+                    title={`${task.functionName} · ${task.contractAddress}`}
+                    className="w-44 shrink-0 truncate rounded px-2 py-1 text-left text-xs text-slate-300 transition-colors enabled:hover:bg-slate-800 enabled:hover:text-slate-100 disabled:cursor-default"
+                  >
+                    <span className={colors.text}>●</span> {task.functionName}
+                  </button>
+
+                  <div
+                    className="relative h-6 flex-1 rounded bg-slate-800/60"
+                    role="img"
+                    aria-label={`${task.functionName}: ${blocks.length} execution${
+                      blocks.length === 1 ? '' : 's'
+                    } in view, status ${colors.label}${truncated ? ', list truncated' : ''}`}
+                  >
+                    {blocks.map((b) => (
+                      <span
+                        key={`${b.taskId}-${b.start}`}
+                        // Projections are outlined rather than filled so a
+                        // predicted run is never mistaken for one that ran.
+                        className={`absolute top-1 h-4 w-1.5 -translate-x-1/2 rounded-sm ${
+                          b.isHistorical
+                            ? b.outcome === 'failed'
+                              ? STATUS_COLORS.failed.block
+                              : colors.block
+                            : `border border-dashed ${colors.block.replace('bg-', 'border-')} bg-transparent`
+                        }`}
+                        style={{ left: `${positionPercent(b.start, windowStart, windowEnd)}%` }}
+                        title={`${new Date(b.start).toLocaleString()}${
+                          b.isHistorical ? ` · ${b.outcome ?? 'ran'}` : ' · projected'
+                        }`}
+                      />
+                    ))}
+
+                    {truncated && (
+                      <span className="absolute right-1 top-1 rounded bg-slate-700 px-1 text-[10px] text-slate-300">
+                        capped
+                      </span>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      <p className="mt-3 text-[11px] text-slate-500">
+        Solid blocks are recorded executions; dashed blocks are projected from each
+        task&apos;s interval. Paused tasks project no upcoming runs. Rows marked
+        <span className="mx-1 rounded bg-slate-700 px-1 text-slate-300">capped</span>
+        have more executions in this window than can be usefully drawn.
+      </p>
+    </section>
+  );
+}
+
+export default GanttTimeline;

--- a/frontend/lib/ganttSchedule.ts
+++ b/frontend/lib/ganttSchedule.ts
@@ -1,0 +1,162 @@
+/**
+ * Schedule projection for the Gantt timeline (issue #873).
+ *
+ * Kept separate from the component so the arithmetic — which is where the
+ * bugs live — is testable without rendering anything.
+ */
+
+import type { Task, TaskExecution, TaskStatus } from '@/types/task';
+
+export type ZoomLevel = '1h' | '6h' | '24h' | '7d' | '30d';
+
+export const ZOOM_LEVELS: { value: ZoomLevel; label: string; windowMs: number }[] = [
+  { value: '1h', label: '1 hour', windowMs: 60 * 60 * 1000 },
+  { value: '6h', label: '6 hours', windowMs: 6 * 60 * 60 * 1000 },
+  { value: '24h', label: '24 hours', windowMs: 24 * 60 * 60 * 1000 },
+  { value: '7d', label: '7 days', windowMs: 7 * 24 * 60 * 60 * 1000 },
+  { value: '30d', label: '30 days', windowMs: 30 * 24 * 60 * 60 * 1000 },
+];
+
+/**
+ * Cap on projected blocks per task.
+ *
+ * A task running every 30 seconds over a 30-day window projects ~86,000
+ * executions. Rendering those is both useless — they are sub-pixel at that
+ * zoom — and enough DOM to lock the tab. Past the cap the row is marked
+ * `truncated` so the UI can say so rather than silently lying about density.
+ */
+export const MAX_BLOCKS_PER_TASK = 300;
+
+export interface ScheduleBlock {
+  taskId: string;
+  /** Milliseconds since epoch. */
+  start: number;
+  /** Whether this block already happened. */
+  isHistorical: boolean;
+  /** Outcome for historical blocks; projections have none yet. */
+  outcome?: 'success' | 'failed' | 'pending';
+}
+
+export interface TaskRow {
+  task: Task;
+  blocks: ScheduleBlock[];
+  /** True when projection hit MAX_BLOCKS_PER_TASK and stopped early. */
+  truncated: boolean;
+}
+
+/** Tailwind classes per status, matching the palette the issue specifies. */
+export const STATUS_COLORS: Record<TaskStatus, { block: string; label: string; text: string }> = {
+  active: { block: 'bg-green-500', label: 'Active', text: 'text-green-400' },
+  pending: { block: 'bg-blue-500', label: 'Pending', text: 'text-blue-400' },
+  failed: { block: 'bg-red-500', label: 'Failed', text: 'text-red-400' },
+  paused: { block: 'bg-gray-500', label: 'Paused', text: 'text-gray-400' },
+  // Not in the issue's list, but the type has five variants and an unhandled
+  // one would render as an invisible block.
+  completed: { block: 'bg-slate-600', label: 'Completed', text: 'text-slate-400' },
+};
+
+/**
+ * Project a task's execution times across `[windowStart, windowEnd]`.
+ *
+ * Paused tasks project nothing: a paused automation has no upcoming runs, and
+ * drawing them would overstate scheduled load. Its history still renders.
+ */
+export function projectExecutions(
+  task: Task,
+  windowStart: number,
+  windowEnd: number,
+): { starts: number[]; truncated: boolean } {
+  const intervalMs = task.interval * 1000;
+
+  // A non-positive interval would make the loop below never advance. Treat it
+  // as unschedulable rather than hanging the render.
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return { starts: [], truncated: false };
+  }
+  if (task.status === 'paused' || task.status === 'completed') {
+    return { starts: [], truncated: false };
+  }
+
+  const anchor = task.nextExecutionTime?.getTime() ?? task.createdAt.getTime();
+  if (!Number.isFinite(anchor)) return { starts: [], truncated: false };
+
+  // Step forward from the anchor to the first occurrence inside the window,
+  // arithmetically rather than by looping — an anchor months in the past would
+  // otherwise cost millions of iterations before producing anything visible.
+  let first = anchor;
+  if (anchor < windowStart) {
+    const missed = Math.ceil((windowStart - anchor) / intervalMs);
+    first = anchor + missed * intervalMs;
+  }
+
+  const starts: number[] = [];
+  for (let t = first; t <= windowEnd; t += intervalMs) {
+    if (starts.length >= MAX_BLOCKS_PER_TASK) {
+      return { starts, truncated: true };
+    }
+    starts.push(t);
+  }
+  return { starts, truncated: false };
+}
+
+/**
+ * Build the rendered rows for a set of tasks.
+ *
+ * Historical executions come from real records; anything after `now` is a
+ * projection. The two are distinguished so the UI can render certainty
+ * differently from prediction.
+ */
+export function buildTimelineRows(
+  tasks: Task[],
+  executions: TaskExecution[],
+  windowStart: number,
+  windowEnd: number,
+  now: number = Date.now(),
+): TaskRow[] {
+  const historyByTask = new Map<string, TaskExecution[]>();
+  for (const e of executions) {
+    const at = e.executedAt.getTime();
+    if (at < windowStart || at > windowEnd) continue;
+    historyByTask.set(e.taskId, [...(historyByTask.get(e.taskId) ?? []), e]);
+  }
+
+  return tasks.map((task) => {
+    const blocks: ScheduleBlock[] = (historyByTask.get(task.id) ?? []).map((e) => ({
+      taskId: task.id,
+      start: e.executedAt.getTime(),
+      isHistorical: true,
+      outcome: e.status,
+    }));
+
+    // Project only forward of now; the past is covered by real records, and
+    // overlaying a projection on top would double-count executions that
+    // actually happened.
+    const projectFrom = Math.max(windowStart, now);
+    if (projectFrom <= windowEnd) {
+      const { starts, truncated } = projectExecutions(task, projectFrom, windowEnd);
+      for (const start of starts) {
+        blocks.push({ taskId: task.id, start, isHistorical: false });
+      }
+      blocks.sort((a, b) => a.start - b.start);
+      return { task, blocks, truncated };
+    }
+
+    blocks.sort((a, b) => a.start - b.start);
+    return { task, blocks, truncated: false };
+  });
+}
+
+/** Position of a timestamp within the window, as a 0–100 percentage. */
+export function positionPercent(at: number, windowStart: number, windowEnd: number): number {
+  const span = windowEnd - windowStart;
+  if (span <= 0) return 0;
+  return ((at - windowStart) / span) * 100;
+}
+
+/** Evenly spaced tick marks for the time axis. */
+export function buildTicks(windowStart: number, windowEnd: number, count = 6): number[] {
+  const span = windowEnd - windowStart;
+  if (span <= 0 || count < 2) return [windowStart];
+  const step = span / (count - 1);
+  return Array.from({ length: count }, (_, i) => windowStart + i * step);
+}


### PR DESCRIPTION
Closes #873

Grid and list views can't show execution overlap or schedule density. This lays every task's runs on a shared time axis so both are visible at a glance.

Two files: `lib/ganttSchedule.ts` holds the projection arithmetic — separated so the part where the bugs live is testable without rendering — and `components/GanttTimeline.tsx` renders it.

## Zoom and layout

Spans **1h / 6h / 24h / 7d / 30d**, covering the range the issue asks for.

The window opens a quarter *behind* now, so recent history is visible without squeezing the upcoming schedule — which is the reason to open this view at all. A "now" marker runs across all rows, so overlap reads against the present rather than against each row's own history.

## Status colours

Active green, Pending blue, Failed red, Paused gray, per the issue. `completed` is also mapped — the type has five variants and an unhandled one would render as an **invisible block**.

## Projection details that matter

**Recorded runs are solid, projections dashed.** The timeline mixes both by design, so a predicted run must never be mistaken for one that happened.

**Projection starts at `max(windowStart, now)`**, not the window edge — overlaying projections on the past would double-count executions that have real records.

**The first in-window occurrence is computed arithmetically, not by stepping.** A task anchored months in the past would otherwise cost millions of loop iterations before producing a single visible block.

**Blocks per task are capped at 300.** A 30-second task over a 30-day window projects ~86,000 executions — sub-pixel at that zoom, and enough DOM to lock the tab. Capped rows are *labelled* rather than silently truncated, so the view doesn't quietly understate density.

**Paused and completed tasks project nothing.** A paused automation has no upcoming runs; drawing them would overstate scheduled load. Their history still renders.

A non-positive `interval` is treated as unschedulable rather than being allowed to spin the projection loop forever.

`now` is pinned once per render pass instead of read inside the loop, so every row is positioned against the same instant — otherwise blocks drift relative to each other and to the marker.

## Not yet mounted

The component is self-contained and **not wired into a route**. Where it belongs alongside the existing grid and list views is a product decision I didn't want to make unilaterally — as a tab, a toggle, or its own page. Point me at the preference and I'll wire it up.

`executions` is optional: with none passed the timeline renders pure projections, which is still useful and lets it be dropped in before execution history is available.

## Verification

I have not run the dev server or the test suite. `lib/ganttSchedule.ts` is deliberately pure and framework-free specifically so it can be unit tested — `projectExecutions` (anchor stepping, the cap, paused handling) and `buildTimelineRows` (history/projection split) are where I'd put the first tests, and I'm happy to add them if you tell me which runner the frontend uses.