### PR TITLE
feat(indexer): add migration runner with automatic rollback on failed validation

### DIFF
--- a/indexer/migrations/001_initial_schema.down.sql
+++ b/indexer/migrations/001_initial_schema.down.sql
@@ -1,0 +1,15 @@
+-- Down migration: 001_initial_schema
+--
+-- Reverses 001_initial_schema.sql. Tables are dropped in reverse dependency
+-- order so foreign keys never block a drop; CASCADE is deliberately avoided,
+-- because a DROP that only succeeds by silently destroying something the
+-- migration did not create is exactly the failure this rollback system exists
+-- to prevent.
+--
+-- IF EXISTS throughout: a rollback may run after a partially-applied up
+-- migration, where only some objects were created.
+
+DROP INDEX IF EXISTS idx_users_address;
+
+DROP TABLE IF EXISTS tasks;
+DROP TABLE IF EXISTS users;

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "jest test/api.test.js src/graphql/__tests__/api.test.js && node --test test/reconciliation.test.js test/staleTasks.test.js"
+    "test": "jest test/api.test.js src/graphql/__tests__/api.test.js && node --test test/migrationRunner.test.js test/reconciliation.test.js test/staleTasks.test.js"
   },
   "keywords": [],
   "author": "",

--- a/indexer/src/migrations/runner.js
+++ b/indexer/src/migrations/runner.js
@@ -1,0 +1,275 @@
+'use strict';
+
+/**
+ * Migration runner with automatic rollback (issue #868).
+ *
+ * A failed schema migration previously left the indexer's tables in whatever
+ * half-applied state the error interrupted, and recovery meant a manual restore
+ * from backup. This applies migrations inside a transaction, validates the
+ * result, and reverses the change automatically when validation fails.
+ *
+ * ## Why validation exists at all
+ *
+ * A transaction only protects against SQL that *errors*. It does nothing about
+ * a migration that succeeds and is wrong — a column added with the wrong type,
+ * an index that silently did not get created, a table left empty by a botched
+ * backfill. Those commit cleanly and corrupt the indexer downstream. The
+ * post-migration validation step is what catches that class, and it is the
+ * reason a `down` script is required rather than optional.
+ *
+ * ## Ordering guarantee
+ *
+ * Ingestion must not resume until integrity is verified. `runMigrations`
+ * returns only after the check passes, so the caller has a single place to
+ * gate on.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', 'migrations');
+
+/** Filenames ending in this are down migrations, not standalone ones. */
+const DOWN_SUFFIX = '.down.sql';
+
+/**
+ * Discover migrations on disk, newest last.
+ *
+ * A migration without a matching `.down.sql` is rejected rather than run.
+ * Applying something irreversible is precisely how the manual-restore
+ * situation in #868 arises, so the runner refuses to create it.
+ */
+function discoverMigrations(dir = MIGRATIONS_DIR) {
+  const entries = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.sql') && !f.endsWith(DOWN_SUFFIX))
+    .sort();
+
+  return entries.map((file) => {
+    const id = file.replace(/\.sql$/, '');
+    const downFile = `${id}${DOWN_SUFFIX}`;
+    const downPath = path.join(dir, downFile);
+
+    if (!fs.existsSync(downPath)) {
+      throw new Error(
+        `Migration "${file}" has no matching "${downFile}". Every migration must be ` +
+          `reversible — refusing to apply one that cannot be rolled back.`,
+      );
+    }
+
+    return {
+      id,
+      upPath: path.join(dir, file),
+      downPath,
+      up: fs.readFileSync(path.join(dir, file), 'utf8'),
+      down: fs.readFileSync(downPath, 'utf8'),
+    };
+  });
+}
+
+/** Ledger of applied migrations. Created before anything else runs. */
+async function ensureMigrationTable(db) {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id           TEXT        PRIMARY KEY,
+      applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      checksum     TEXT
+    )
+  `);
+}
+
+async function getAppliedIds(db) {
+  const result = await db.query('SELECT id FROM schema_migrations');
+  return new Set((result.rows ?? []).map((r) => r.id));
+}
+
+/**
+ * Post-migration validation.
+ *
+ * Checks are supplied per migration by the caller. Each is
+ * `{ name, run(db) -> boolean }`; any returning false triggers rollback.
+ *
+ * Deliberately not inferred from the SQL: guessing what a migration *meant* is
+ * how a validator ends up asserting the same mistake the migration made.
+ */
+async function runValidations(db, checks, logger) {
+  const failures = [];
+
+  for (const check of checks) {
+    try {
+      const ok = await check.run(db);
+      if (!ok) failures.push(check.name);
+    } catch (err) {
+      // A check that throws is a failed check. Treating an error as "unknown,
+      // proceed" would let the corruption through, which is the outcome this
+      // whole mechanism exists to prevent.
+      failures.push(`${check.name} (threw: ${err.message})`);
+    }
+  }
+
+  if (failures.length > 0) {
+    logger.error(`Validation failed: ${failures.join('; ')}`);
+  }
+  return failures;
+}
+
+/**
+ * Apply one migration, validating and rolling back on failure.
+ *
+ * The up migration and its ledger row commit together, so the ledger can never
+ * claim a migration was applied when it was not.
+ */
+async function applyMigration(db, migration, checks, logger) {
+  logger.info(`Applying migration ${migration.id}`);
+
+  await db.query('BEGIN');
+  try {
+    await db.query(migration.up);
+    await db.query('INSERT INTO schema_migrations (id) VALUES ($1)', [migration.id]);
+    await db.query('COMMIT');
+  } catch (err) {
+    await db.query('ROLLBACK').catch(() => {});
+    // The transaction already undid everything, so the down script is not run
+    // here — running it against a schema that was never changed could drop
+    // objects an earlier migration legitimately created.
+    throw new Error(`Migration ${migration.id} failed and was rolled back: ${err.message}`);
+  }
+
+  const failures = await runValidations(db, checks, logger);
+  if (failures.length === 0) {
+    logger.info(`Migration ${migration.id} applied and validated`);
+    return { id: migration.id, status: 'applied' };
+  }
+
+  // Committed but wrong — this is the case a transaction cannot catch, and the
+  // reason the down script exists.
+  logger.error(`Rolling back ${migration.id} after failed validation`);
+  await db.query('BEGIN');
+  try {
+    await db.query(migration.down);
+    await db.query('DELETE FROM schema_migrations WHERE id = $1', [migration.id]);
+    await db.query('COMMIT');
+  } catch (err) {
+    await db.query('ROLLBACK').catch(() => {});
+    // Rollback itself failing is the genuinely dangerous state: the schema is
+    // wrong and could not be reversed. Surface it loudly and stop — continuing
+    // would ingest into a schema known to be broken.
+    throw new Error(
+      `CRITICAL: rollback of ${migration.id} failed — schema is in an unknown state ` +
+        `and requires manual intervention. Validation failures: ${failures.join('; ')}. ` +
+        `Rollback error: ${err.message}`,
+    );
+  }
+
+  throw new Error(
+    `Migration ${migration.id} rolled back after validation failure: ${failures.join('; ')}`,
+  );
+}
+
+/**
+ * Integrity check run before ingestion resumes.
+ *
+ * Confirms the ledger and the schema agree. Cheap, and it catches the case
+ * where a migration was reversed manually but its ledger row was left behind —
+ * which would otherwise make the runner skip re-applying it.
+ */
+async function verifyIntegrity(db, migrations, logger) {
+  const applied = await getAppliedIds(db);
+  const known = new Set(migrations.map((m) => m.id));
+
+  const unknown = [...applied].filter((id) => !known.has(id));
+  if (unknown.length > 0) {
+    // The database is ahead of this build — likely a rollback of the
+    // application without a rollback of the schema.
+    throw new Error(
+      `Integrity check failed: database reports migrations not present on disk ` +
+        `(${unknown.join(', ')}). Refusing to start ingestion against an unknown schema.`,
+    );
+  }
+
+  const pending = migrations.filter((m) => !applied.has(m.id));
+  if (pending.length > 0) {
+    throw new Error(
+      `Integrity check failed: migrations still pending (${pending.map((m) => m.id).join(', ')}).`,
+    );
+  }
+
+  logger.info(`Integrity verified: ${applied.size} migration(s) applied`);
+  return true;
+}
+
+/**
+ * Apply all pending migrations, then verify integrity.
+ *
+ * Resolves only when the schema is known-good, so callers can gate ledger
+ * ingestion on this promise directly.
+ *
+ * @param db        Client exposing `query(sql, params?)`.
+ * @param options.validations  `{ [migrationId]: Check[] }`.
+ * @param options.dir          Override the migrations directory (tests).
+ * @param options.logger       Defaults to console.
+ */
+async function runMigrations(db, options = {}) {
+  const { validations = {}, dir = MIGRATIONS_DIR, logger = console } = options;
+
+  const migrations = discoverMigrations(dir);
+  await ensureMigrationTable(db);
+
+  const applied = await getAppliedIds(db);
+  const pending = migrations.filter((m) => !applied.has(m.id));
+
+  if (pending.length === 0) {
+    logger.info('No pending migrations');
+  }
+
+  const results = [];
+  for (const migration of pending) {
+    results.push(await applyMigration(db, migration, validations[migration.id] ?? [], logger));
+  }
+
+  await verifyIntegrity(db, migrations, logger);
+  return results;
+}
+
+/** Reverse the most recently applied migration. Operator escape hatch. */
+async function rollbackLast(db, options = {}) {
+  const { dir = MIGRATIONS_DIR, logger = console } = options;
+
+  const migrations = discoverMigrations(dir);
+  const result = await db.query(
+    'SELECT id FROM schema_migrations ORDER BY applied_at DESC, id DESC LIMIT 1',
+  );
+  const last = result.rows?.[0];
+  if (!last) {
+    logger.info('Nothing to roll back');
+    return null;
+  }
+
+  const migration = migrations.find((m) => m.id === last.id);
+  if (!migration) {
+    throw new Error(
+      `Cannot roll back "${last.id}": its down migration is not present on disk.`,
+    );
+  }
+
+  await db.query('BEGIN');
+  try {
+    await db.query(migration.down);
+    await db.query('DELETE FROM schema_migrations WHERE id = $1', [migration.id]);
+    await db.query('COMMIT');
+  } catch (err) {
+    await db.query('ROLLBACK').catch(() => {});
+    throw new Error(`Rollback of ${migration.id} failed: ${err.message}`);
+  }
+
+  logger.info(`Rolled back ${migration.id}`);
+  return migration.id;
+}
+
+module.exports = {
+  runMigrations,
+  rollbackLast,
+  verifyIntegrity,
+  discoverMigrations,
+  MIGRATIONS_DIR,
+};

--- a/indexer/test/migrationRunner.test.js
+++ b/indexer/test/migrationRunner.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+/**
+ * Tests for the migration runner (issue #868).
+ *
+ * Uses an in-memory fake client rather than a live Postgres: the behaviour
+ * under test is the runner's control flow — when it commits, when it reverses,
+ * what it refuses to do — not whether Postgres executes DDL correctly.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { runMigrations, rollbackLast, discoverMigrations } = require('../src/migrations/runner');
+
+const silentLogger = { info() {}, error() {}, warn() {} };
+
+/**
+ * Minimal client recording every statement.
+ *
+ * `failOn` makes a statement matching a substring throw, so the failure paths
+ * can be driven deterministically.
+ */
+function fakeDb({ failOn = null } = {}) {
+  const applied = new Set();
+  const statements = [];
+
+  return {
+    statements,
+    applied,
+    async query(sql, params) {
+      statements.push(sql.trim().split('\n')[0]);
+
+      if (failOn && sql.includes(failOn)) {
+        throw new Error(`simulated failure executing: ${failOn}`);
+      }
+      if (sql.startsWith('INSERT INTO schema_migrations')) {
+        applied.add(params[0]);
+        return { rows: [] };
+      }
+      if (sql.startsWith('DELETE FROM schema_migrations')) {
+        applied.delete(params[0]);
+        return { rows: [] };
+      }
+      if (sql.includes('SELECT id FROM schema_migrations')) {
+        return { rows: [...applied].map((id) => ({ id })) };
+      }
+      if (sql.includes('ORDER BY applied_at DESC')) {
+        const last = [...applied].pop();
+        return { rows: last ? [{ id: last }] : [] };
+      }
+      return { rows: [] };
+    },
+  };
+}
+
+/** Temporary migrations directory. */
+function makeDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sorotask-migrations-'));
+  for (const [name, body] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), body);
+  }
+  return dir;
+}
+
+test('applies a pending migration and records it', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS a;',
+  });
+  const db = fakeDb();
+
+  const results = await runMigrations(db, { dir, logger: silentLogger });
+
+  assert.deepStrictEqual(results, [{ id: '001_a', status: 'applied' }]);
+  assert.ok(db.applied.has('001_a'));
+});
+
+test('does not re-apply an already applied migration', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS a;',
+  });
+  const db = fakeDb();
+
+  await runMigrations(db, { dir, logger: silentLogger });
+  const second = await runMigrations(db, { dir, logger: silentLogger });
+
+  assert.deepStrictEqual(second, []);
+});
+
+test('refuses a migration with no down script', async () => {
+  const dir = makeDir({ '001_a.sql': 'CREATE TABLE a (id INT);' });
+
+  // Applying something irreversible is how the manual-restore situation in
+  // #868 arises in the first place.
+  await assert.rejects(
+    () => runMigrations(fakeDb(), { dir, logger: silentLogger }),
+    /has no matching .*down\.sql/,
+  );
+});
+
+test('rolls back when post-migration validation fails', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS a;',
+  });
+  const db = fakeDb();
+
+  await assert.rejects(
+    () =>
+      runMigrations(db, {
+        dir,
+        logger: silentLogger,
+        validations: {
+          '001_a': [{ name: 'column exists', run: async () => false }],
+        },
+      }),
+    /rolled back after validation failure/,
+  );
+
+  // The critical assertion: a migration that committed but failed validation
+  // must not remain recorded as applied.
+  assert.ok(!db.applied.has('001_a'), 'ledger row must be removed on rollback');
+  assert.ok(
+    db.statements.some((s) => s.startsWith('DROP TABLE IF EXISTS a')),
+    'down migration must actually run',
+  );
+});
+
+test('a validation check that throws counts as a failure', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS a;',
+  });
+  const db = fakeDb();
+
+  // Treating an errored check as "unknown, proceed" would let corruption
+  // through, which is what this mechanism exists to prevent.
+  await assert.rejects(
+    () =>
+      runMigrations(db, {
+        dir,
+        logger: silentLogger,
+        validations: {
+          '001_a': [
+            {
+              name: 'exploding check',
+              run: async () => {
+                throw new Error('boom');
+              },
+            },
+          ],
+        },
+      }),
+    /rolled back after validation failure/,
+  );
+  assert.ok(!db.applied.has('001_a'));
+});
+
+test('surfaces a failed rollback as CRITICAL rather than swallowing it', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS broken;',
+  });
+  // The down script itself fails — schema is wrong and cannot be reversed.
+  const db = fakeDb({ failOn: 'DROP TABLE IF EXISTS broken' });
+
+  await assert.rejects(
+    () =>
+      runMigrations(db, {
+        dir,
+        logger: silentLogger,
+        validations: { '001_a': [{ name: 'check', run: async () => false }] },
+      }),
+    /CRITICAL: rollback of 001_a failed/,
+  );
+});
+
+test('integrity check rejects a database ahead of the code', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS a;',
+  });
+  const db = fakeDb();
+  // Simulates an app rollback without a schema rollback.
+  db.applied.add('002_from_the_future');
+
+  await assert.rejects(
+    () => runMigrations(db, { dir, logger: silentLogger }),
+    /migrations not present on disk/,
+  );
+});
+
+test('rollbackLast reverses the most recent migration', async () => {
+  const dir = makeDir({
+    '001_a.sql': 'CREATE TABLE a (id INT);',
+    '001_a.down.sql': 'DROP TABLE IF EXISTS a;',
+  });
+  const db = fakeDb();
+  await runMigrations(db, { dir, logger: silentLogger });
+
+  const rolled = await rollbackLast(db, { dir, logger: silentLogger });
+
+  assert.strictEqual(rolled, '001_a');
+  assert.ok(!db.applied.has('001_a'));
+});
+
+test('discoverMigrations pairs up and down scripts in order', () => {
+  const dir = makeDir({
+    '002_b.sql': 'SELECT 2;',
+    '002_b.down.sql': 'SELECT -2;',
+    '001_a.sql': 'SELECT 1;',
+    '001_a.down.sql': 'SELECT -1;',
+  });
+
+  const found = discoverMigrations(dir);
+
+  assert.deepStrictEqual(
+    found.map((m) => m.id),
+    ['001_a', '002_b'],
+    'migrations must apply in lexical order',
+  );
+  assert.strictEqual(found[0].down.trim(), 'SELECT -1;');
+});


### PR DESCRIPTION
Closes #868

## Starting point

There was **no migration runner at all**. `migrations/` held a single raw `.sql` file with nothing to apply it, track it, or reverse it. A failed schema change left the indexer's tables in whatever half-applied state the error interrupted — hence the manual restores the issue describes.

## Why validation exists, not just transactions

Wrapping DDL in a transaction only protects against SQL that **errors**. It does nothing about a migration that *succeeds and is wrong*: a column added with the wrong type, an index that silently wasn't created, a table left empty by a botched backfill. Those commit cleanly and corrupt the indexer downstream.

That's the class post-migration validation catches — and it's why a down script is **required rather than optional**.

The two failure modes are handled differently on purpose:

| Failure | Response |
|---|---|
| SQL error | Transaction already undid everything — the down script is **not** run. Running it against a schema that was never changed could drop objects an earlier migration legitimately created. |
| Committed but invalid | Down script runs, and the ledger row is deleted with it so the migration isn't recorded as applied. |

## Bidirectional by construction

`discoverMigrations` **refuses** to apply a migration with no matching `.down.sql`. Applying something irreversible is how the manual-restore situation arises in the first place, so the runner won't create it.

Adds `001_initial_schema.down.sql`, dropping in reverse dependency order and deliberately **without CASCADE** — a `DROP` that only succeeds by destroying something the migration didn't create is exactly what this system exists to prevent.

## Integrity before ingestion

`runMigrations` resolves only after `verifyIntegrity` passes, so callers have **one place** to gate ledger ingestion on.

The check also rejects a database reporting migrations absent from disk — which is what an application rollback without a schema rollback looks like, and would otherwise start ingestion against an unknown schema.

Two more deliberate choices:

- **A validation check that throws counts as a failure.** Treating an errored check as "unknown, proceed" would let corruption through.
- **A rollback that itself fails is raised as `CRITICAL` and stops.** The schema is wrong and couldn't be reversed; continuing would ingest into a schema known to be broken.

## Tests — these actually ran

9 tests via an in-memory fake client, so the control flow (when it commits, when it reverses, what it refuses) is exercised without a live Postgres:

```
✔ applies a pending migration and records it
✔ does not re-apply an already applied migration
✔ refuses a migration with no down script
✔ rolls back when post-migration validation fails
✔ a validation check that throws counts as a failure
✔ surfaces a failed rollback as CRITICAL rather than swallowing it
✔ integrity check rejects a database ahead of the code
✔ rollbackLast reverses the most recent migration
✔ discoverMigrations pairs up and down scripts in order

ℹ pass 9   ℹ fail 0
```

Wired into the existing `npm test` script.

## Not yet called from `src/index.js`

The indexer currently opens `sqlite3` directly and has no shared `pg` client to hand the runner, so choosing the call site is a wiring decision rather than part of this change — and the `migrations/` SQL is Postgres-flavoured (`BIGSERIAL`, `TIMESTAMPTZ`, `JSONB`), which doesn't match the sqlite3 dependency. Worth resolving which database the indexer actually targets before mounting this; the runner only needs a client exposing `query(sql, params)`.