### PR TITLE
feat(keeper): add P2P mesh task allocation

### DIFF
--- a/keeper/.env.example
+++ b/keeper/.env.example
@@ -75,6 +75,9 @@ P2P_HEARTBEAT_INTERVAL_MS=10000
 P2P_STALE_PEER_MS=45000
 P2P_AUTH_WINDOW_MS=30000
 P2P_CONNECT_TIMEOUT_MS=5000
+# socketio, libp2p, or hybrid. libp2p requires a runtime libp2p node/factory.
+P2P_TRANSPORT=socketio
+P2P_TASK_LOCK_TTL_MS=60000
 
 # Recurring execution drift detection thresholds (seconds)
 DRIFT_WARNING_SECONDS=60

--- a/keeper/__tests__/p2pNetwork.test.js
+++ b/keeper/__tests__/p2pNetwork.test.js
@@ -164,4 +164,114 @@ describe('KeeperP2PNetwork', () => {
     expect(network.pruneStalePeers()).toEqual(['keeper-b']);
     expect(network.getHealthyPeers()).toEqual([]);
   });
+
+  test('starts injected libp2p node and publishes discovery over gossipsub', async () => {
+    const published = [];
+    const subscribed = [];
+    const libp2pNode = {
+      start: jest.fn(),
+      stop: jest.fn(),
+      services: {
+        pubsub: {
+          subscribe: jest.fn((topic) => subscribed.push(topic)),
+          publish: jest.fn((topic, data) => published.push({ topic, data })),
+          addEventListener: jest.fn(),
+        },
+      },
+    };
+
+    const network = new KeeperP2PNetwork({
+      enabled: true,
+      nodeId: 'keeper-libp2p',
+      sharedSecret: 'shared-secret',
+      transport: 'libp2p',
+      libp2pNode,
+      logger,
+    });
+    networks.push(network);
+
+    await network.start();
+
+    expect(libp2pNode.start).toHaveBeenCalled();
+    expect(subscribed).toEqual([
+      'sorotask.keeper.discovery.v1',
+      'sorotask.keeper.task-locks.v1',
+      'sorotask.keeper.bids.v1',
+    ]);
+    expect(published[0].topic).toBe('sorotask.keeper.discovery.v1');
+    expect(network.getStateSnapshot()).toMatchObject({
+      transport: 'libp2p',
+      libp2pStarted: true,
+    });
+  });
+
+  test('records task locks, skips remotely claimed work, and reassigns on stale peer', () => {
+    const network = new KeeperP2PNetwork({
+      enabled: true,
+      nodeId: 'keeper-a',
+      sharedSecret: 'shared-secret',
+      stalePeerMs: 1000,
+      taskLockTtlMs: 1000,
+      logger,
+    });
+    const reassign = jest.fn();
+    network.on('tasks:reassign', reassign);
+
+    network.upsertPeer('keeper-b', {
+      load: { capacity: 1 },
+    });
+    const lock = createSignedEnvelope({
+      type: 'task_lock_claimed',
+      payload: {
+        taskId: 'task-1',
+        claimedAt: Date.now(),
+        expiresAt: Date.now() + 1000,
+      },
+      nodeId: 'keeper-b',
+      secret: 'shared-secret',
+    });
+
+    network.handleTaskLockEnvelope(lock);
+    const selection = network.selectOwnedTasks(['task-1', 'task-2']);
+
+    expect(selection.activeLocks['task-1'].nodeId).toBe('keeper-b');
+    expect(selection.owners['task-1']).toBe('keeper-b');
+    expect(selection.skippedTaskIds).toContain('task-1');
+
+    network.peers.get('keeper-b').lastSeenAt = Date.now() - 2000;
+    network.pruneStalePeers();
+
+    expect(reassign).toHaveBeenCalledWith({ nodeId: 'keeper-b', taskIds: ['task-1'] });
+    expect(network.getActiveTaskLocks()).toEqual({});
+  });
+
+  test('broadcasts local task locks over mesh transports', () => {
+    const published = [];
+    const network = new KeeperP2PNetwork({
+      enabled: true,
+      nodeId: 'keeper-a',
+      sharedSecret: 'shared-secret',
+      transport: 'libp2p',
+      logger,
+      libp2pNode: {
+        services: {
+          pubsub: {
+            subscribe: jest.fn(),
+            publish: jest.fn((topic, data) => published.push({ topic, data })),
+          },
+        },
+      },
+    });
+    network.started = true;
+    network.libp2pStarted = true;
+
+    const envelope = network.broadcastTaskLock('task-7', { correlationId: 'poll-1' });
+
+    expect(envelope.payload).toMatchObject({
+      taskId: 'task-7',
+      correlationId: 'poll-1',
+    });
+    expect(network.getActiveTaskLocks()['task-7'].nodeId).toBe('keeper-a');
+    expect(published[0].topic).toBe('sorotask.keeper.task-locks.v1');
+  });
 });

--- a/keeper/docs/p2p-keeper-discovery.md
+++ b/keeper/docs/p2p-keeper-discovery.md
@@ -4,12 +4,16 @@ The keeper can run an optional peer-to-peer discovery layer so keeper nodes can 
 
 ## Architecture
 
-- Each keeper starts a Socket.IO listener on `P2P_LISTEN_HOST:P2P_LISTEN_PORT`.
+- Each keeper starts a P2P transport on `P2P_LISTEN_HOST:P2P_LISTEN_PORT`.
+- The default transport is the existing signed Socket.IO mesh. `P2P_TRANSPORT=libp2p`
+  starts an injected libp2p node and subscribes to gossipsub topics; `hybrid` runs both.
 - `P2P_BOOTSTRAP_PEERS` is used only to find the first peers. Connected keepers gossip known peer URLs.
 - Every P2P message is wrapped in a signed envelope with `nodeId`, `timestamp`, `nonce`, payload, and HMAC-SHA256 signature.
 - Peers publish signed heartbeats containing current load, queue depth, in-flight work, task count, and pause status.
+- Peer discovery, bid announcements, and task lock claims use dedicated pubsub channels.
 - Task ownership uses deterministic load-aware rendezvous hashing across the local keeper and healthy peers.
-- Stale peers are pruned after `P2P_STALE_PEER_MS`, and ownership automatically falls back to the remaining healthy nodes.
+- Keepers broadcast task lock claims before enqueueing due work. Active remote locks are skipped locally.
+- Stale peers are pruned after `P2P_STALE_PEER_MS`, their task locks are released, and ownership automatically falls back to the remaining healthy nodes.
 
 ## Configuration
 
@@ -26,11 +30,16 @@ P2P_HEARTBEAT_INTERVAL_MS=10000
 P2P_STALE_PEER_MS=45000
 P2P_AUTH_WINDOW_MS=30000
 P2P_CONNECT_TIMEOUT_MS=5000
+P2P_TRANSPORT=socketio
+P2P_TASK_LOCK_TTL_MS=60000
 ```
 
 `P2P_SHARED_SECRET` is required when `P2P_ENABLED=true`. Distribute it out-of-band through the same secret-management path used for keeper credentials. Rotate it by deploying the new value to all keepers in a short window.
 
 `P2P_NODE_ID` is optional. When omitted, the keeper public key is used as the node ID.
+
+`P2P_TRANSPORT=libp2p` uses the optional libp2p runtime path. Install the libp2p
+transport/pubsub packages in deployments that enable it, or inject a prebuilt node factory.
 
 ## Health And Metrics
 
@@ -44,8 +53,21 @@ P2P_CONNECT_TIMEOUT_MS=5000
 - `peerCount`
 - `healthyPeerCount`
 - healthy peer load snapshots
+- `transport`
+- `libp2pStarted`
+- active task lock count
 
 The keeper logs P2P lifecycle events, rejected messages, stale-peer pruning, and ownership decisions with the `p2p` module label.
+
+## Pubsub Topics
+
+The P2P network publishes signed envelopes to:
+
+- `sorotask.keeper.discovery.v1`: heartbeat, load, and peer discovery.
+- `sorotask.keeper.task-locks.v1`: task lock claims before execution.
+- `sorotask.keeper.bids.v1`: keeper bid auction messages.
+
+When a peer goes offline or a task lock expires, the network emits `tasks:reassign` so the next ownership pass can include those tasks again.
 
 ## Security Review Notes
 

--- a/keeper/index.js
+++ b/keeper/index.js
@@ -591,6 +591,17 @@ async function main() {
   });
   metricsServer.setP2PStateProvider(() => p2pNetwork.getStateSnapshot());
   try {
+    await p2pNetwork.start();
+  } catch (err) {
+    logger.warn("P2P network startup failed - continuing with shard ownership", { error: err.message });
+  }
+  p2pNetwork.on("tasks:reassign", ({ nodeId, taskIds }) => {
+    logger.warn("P2P task locks released for reassignment", {
+      nodeId,
+      taskCount: taskIds.length,
+    });
+  });
+  try {
     const startupReport = await reconciler.reconcile();
     logger.info("Startup reconciliation complete", {
       checked: startupReport.checked,
@@ -807,6 +818,11 @@ async function main() {
           taskId: d.taskId,
           context: { pollCorrelationId: d.correlationId }
         }));
+        tasksToEnqueue.forEach((task) => {
+          p2pNetwork.broadcastTaskLock(task.taskId, {
+            correlationId: task.context.pollCorrelationId,
+          });
+        });
         
         await queue.enqueue(tasksToEnqueue, executeTask);
       } else {
@@ -835,8 +851,14 @@ async function main() {
           registry,
           idempotencyGuard,
           includeContext: true,
-        });
+      });
       if (dueTaskIds.length > 0) {
+        dueTaskIds.forEach((task) => {
+          const taskId = typeof task === "object" ? task.taskId : task;
+          p2pNetwork.broadcastTaskLock(taskId, {
+            correlationId: typeof task === "object" ? task.correlationId : null,
+          });
+        });
         await queue.enqueue(dueTaskIds, executeTask);
       }
     } catch (error) {

--- a/keeper/src/config.js
+++ b/keeper/src/config.js
@@ -132,6 +132,8 @@ function loadConfig() {
       stalePeerMs: parseInteger(process.env.P2P_STALE_PEER_MS, 45000),
       authWindowMs: parseInteger(process.env.P2P_AUTH_WINDOW_MS, 30000),
       connectTimeoutMs: parseInteger(process.env.P2P_CONNECT_TIMEOUT_MS, 5000),
+      transport: process.env.P2P_TRANSPORT || 'socketio',
+      taskLockTtlMs: parseInteger(process.env.P2P_TASK_LOCK_TTL_MS, 60000),
     },
     // RPC Load Balancer Configuration
     rpcEndpoints: process.env.RPC_ENDPOINTS || null,

--- a/keeper/src/p2pNetwork.js
+++ b/keeper/src/p2pNetwork.js
@@ -9,6 +9,12 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 10000;
 const DEFAULT_STALE_PEER_MS = 45000;
 const DEFAULT_AUTH_WINDOW_MS = 30000;
 const DEFAULT_CONNECT_TIMEOUT_MS = 5000;
+const DEFAULT_TASK_LOCK_TTL_MS = 60000;
+const DEFAULT_P2P_TOPICS = {
+  discovery: 'sorotask.keeper.discovery.v1',
+  taskLocks: 'sorotask.keeper.task-locks.v1',
+  bids: 'sorotask.keeper.bids.v1',
+};
 
 function parsePeerList(value) {
   if (!value) {
@@ -163,6 +169,53 @@ function assignTasksByRendezvous(taskIds, selfNode, peers = []) {
   };
 }
 
+async function createDefaultLibp2pNode(options = {}) {
+  try {
+    const [
+      { createLibp2p },
+      { tcp },
+      { webSockets },
+      { noise },
+      { yamux },
+      { bootstrap },
+      { gossipsub },
+    ] = await Promise.all([
+      import('libp2p'),
+      import('@libp2p/tcp'),
+      import('@libp2p/websockets'),
+      import('@chainsafe/libp2p-noise'),
+      import('@chainsafe/libp2p-yamux'),
+      import('@libp2p/bootstrap'),
+      import('@chainsafe/libp2p-gossipsub'),
+    ]);
+
+    const listenPort = Number.isFinite(options.listenPort) ? options.listenPort : 0;
+    const listenHost = options.listenHost || '0.0.0.0';
+    const bootstrapPeers = parsePeerList(options.bootstrapPeers);
+
+    return createLibp2p({
+      addresses: {
+        listen: [`/ip4/${listenHost}/tcp/${listenPort}`],
+      },
+      transports: [tcp(), webSockets()],
+      connectionEncrypters: [noise()],
+      streamMuxers: [yamux()],
+      peerDiscovery: bootstrapPeers.length > 0 ? [bootstrap({ list: bootstrapPeers })] : [],
+      services: {
+        pubsub: gossipsub({
+          allowPublishToZeroTopicPeers: true,
+        }),
+      },
+    });
+  } catch (error) {
+    const wrapped = new Error(
+      `Unable to initialize libp2p transport. Install libp2p, @libp2p/tcp, @libp2p/websockets, @chainsafe/libp2p-noise, @chainsafe/libp2p-yamux, @libp2p/bootstrap, and @chainsafe/libp2p-gossipsub or provide libp2pNodeFactory. ${error.message}`,
+    );
+    wrapped.cause = error;
+    throw wrapped;
+  }
+}
+
 class KeeperP2PNetwork extends EventEmitter {
   constructor(options = {}) {
     super();
@@ -178,14 +231,29 @@ class KeeperP2PNetwork extends EventEmitter {
     this.stalePeerMs = options.stalePeerMs || DEFAULT_STALE_PEER_MS;
     this.authWindowMs = options.authWindowMs || DEFAULT_AUTH_WINDOW_MS;
     this.connectTimeoutMs = options.connectTimeoutMs || DEFAULT_CONNECT_TIMEOUT_MS;
+    this.transport = options.transport || 'socketio';
+    this.taskLockTtlMs = options.taskLockTtlMs || DEFAULT_TASK_LOCK_TTL_MS;
+    this.topics = {
+      ...DEFAULT_P2P_TOPICS,
+      ...(options.topics || {}),
+    };
     this.loadProvider = options.loadProvider || (() => ({}));
+    this.libp2pNode = options.libp2pNode || null;
+    this.libp2pNodeFactory = options.libp2pNodeFactory || (
+      (options.transport === 'libp2p' || options.transport === 'hybrid')
+        ? createDefaultLibp2pNode
+        : null
+    );
     this.logger = options.logger || createLogger('p2p');
 
     this.httpServer = null;
     this.io = null;
+    this.libp2pStarted = false;
+    this.libp2pMessageListenerRegistered = false;
     this.started = false;
     this.peers = new Map();
     this.sockets = new Map();
+    this.taskLocks = new Map();
     this.seenNonces = new Set();
     this.heartbeatTimer = null;
     this.pruneTimer = null;
@@ -201,6 +269,45 @@ class KeeperP2PNetwork extends EventEmitter {
       throw new Error('P2P_SHARED_SECRET is required when P2P networking is enabled');
     }
 
+    if (this.shouldStartSocketTransport()) {
+      await this.startSocketTransport();
+    }
+
+    if (this.shouldStartLibp2pTransport()) {
+      await this.startLibp2pTransport();
+    }
+
+    this.started = true;
+    if (this.shouldStartSocketTransport()) {
+      this.bootstrapPeers.forEach((peerUrl) => this.connect(peerUrl));
+    }
+    this.heartbeatTimer = setInterval(() => this.broadcastHeartbeat(), this.heartbeatIntervalMs);
+    this.pruneTimer = setInterval(() => this.pruneStalePeers(), Math.min(this.stalePeerMs, 10000));
+    if (typeof this.heartbeatTimer.unref === 'function') {
+      this.heartbeatTimer.unref();
+    }
+    if (typeof this.pruneTimer.unref === 'function') {
+      this.pruneTimer.unref();
+    }
+    this.logger.info('P2P keeper network started', {
+      nodeId: this.nodeId,
+      publicUrl: this.publicUrl,
+      bootstrapPeers: this.bootstrapPeers.length,
+    });
+    return this.getStateSnapshot();
+  }
+
+  shouldStartSocketTransport() {
+    return this.transport === 'socketio' || this.transport === 'hybrid';
+  }
+
+  shouldStartLibp2pTransport() {
+    return this.transport === 'libp2p'
+      || this.transport === 'hybrid'
+      || Boolean(this.libp2pNode || this.libp2pNodeFactory);
+  }
+
+  async startSocketTransport() {
     this.httpServer = http.createServer();
     this.io = new SocketIOServer(this.httpServer, {
       cors: { origin: '*' },
@@ -226,23 +333,54 @@ class KeeperP2PNetwork extends EventEmitter {
       this.httpServer.once('listening', onListening);
       this.httpServer.listen(this.listenPort, this.listenHost);
     });
+  }
 
-    this.started = true;
-    this.bootstrapPeers.forEach((peerUrl) => this.connect(peerUrl));
-    this.heartbeatTimer = setInterval(() => this.broadcastHeartbeat(), this.heartbeatIntervalMs);
-    this.pruneTimer = setInterval(() => this.pruneStalePeers(), Math.min(this.stalePeerMs, 10000));
-    if (typeof this.heartbeatTimer.unref === 'function') {
-      this.heartbeatTimer.unref();
+  async startLibp2pTransport() {
+    if (!this.libp2pNode && this.libp2pNodeFactory) {
+      this.libp2pNode = await this.libp2pNodeFactory({
+        nodeId: this.nodeId,
+        listenHost: this.listenHost,
+        listenPort: this.listenPort,
+        bootstrapPeers: this.bootstrapPeers,
+        topics: this.topics,
+      });
     }
-    if (typeof this.pruneTimer.unref === 'function') {
-      this.pruneTimer.unref();
+
+    if (!this.libp2pNode) {
+      if (this.transport === 'libp2p') {
+        throw new Error('P2P libp2p transport requested but no libp2p node factory was provided');
+      }
+      return;
     }
-    this.logger.info('P2P keeper network started', {
-      nodeId: this.nodeId,
-      publicUrl: this.publicUrl,
-      bootstrapPeers: this.bootstrapPeers.length,
-    });
-    return this.getStateSnapshot();
+
+    if (typeof this.libp2pNode.start === 'function') {
+      await this.libp2pNode.start();
+    }
+
+    this.subscribeLibp2pTopic(this.topics.discovery);
+    this.subscribeLibp2pTopic(this.topics.taskLocks);
+    this.subscribeLibp2pTopic(this.topics.bids);
+    this.libp2pStarted = true;
+    this.broadcastLibp2pDiscovery();
+  }
+
+  subscribeLibp2pTopic(topic) {
+    const pubsub = this.libp2pNode && this.libp2pNode.services && this.libp2pNode.services.pubsub;
+    if (!pubsub || typeof pubsub.subscribe !== 'function') {
+      return;
+    }
+
+    pubsub.subscribe(topic);
+    if (this.libp2pMessageListenerRegistered) {
+      return;
+    }
+
+    if (typeof pubsub.addEventListener === 'function') {
+      pubsub.addEventListener('message', (event) => this.handleLibp2pMessage(event));
+    } else if (typeof pubsub.on === 'function') {
+      pubsub.on('message', (message) => this.handleLibp2pMessage(message));
+    }
+    this.libp2pMessageListenerRegistered = true;
   }
 
   registerSocketHandlers(socket, metadata = {}) {
@@ -278,6 +416,7 @@ class KeeperP2PNetwork extends EventEmitter {
     socket.on('keeper:hello:ack', (envelope) => this.handleEnvelope(socket, envelope));
     socket.on('keeper:heartbeat', (envelope) => this.handleEnvelope(socket, envelope));
     socket.on('keeper:peers', (envelope) => this.handleEnvelope(socket, envelope));
+    socket.on('keeper:task-lock', (envelope) => this.handleTaskLockEnvelope(envelope));
     // Issue #841: receive incoming fee bids from peer keepers
     socket.on('keeper:bid', (envelope) => {
       const verification = this.verify(envelope);
@@ -356,6 +495,78 @@ class KeeperP2PNetwork extends EventEmitter {
         .filter((peerUrl) => peerUrl !== this.publicUrl)
         .forEach((peerUrl) => this.connect(peerUrl));
     }
+  }
+
+  handleLibp2pMessage(event) {
+    const detail = event.detail || event;
+    const topic = detail.topic;
+    const data = detail.data || detail;
+    let envelope;
+
+    try {
+      const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+      envelope = JSON.parse(buffer.toString('utf8'));
+    } catch (error) {
+      this.logger.warn('Rejected malformed libp2p pubsub message', { error: error.message });
+      return;
+    }
+
+    if (topic === this.topics.taskLocks) {
+      this.handleTaskLockEnvelope(envelope);
+      return;
+    }
+    if (topic === this.topics.bids) {
+      const verification = this.verify(envelope);
+      if (verification.ok) {
+        this._recordBid(envelope);
+        this.emit('bid:received', { nodeId: envelope.nodeId, payload: envelope.payload });
+      }
+      return;
+    }
+    this.handleDiscoveryEnvelope(envelope);
+  }
+
+  handleDiscoveryEnvelope(envelope) {
+    const verification = this.verify(envelope);
+    if (!verification.ok) {
+      this.logger.warn('Rejected invalid discovery envelope', { reason: verification.reason });
+      this.emit('security:rejected', { reason: verification.reason });
+      return;
+    }
+
+    const payload = envelope.payload || {};
+    this.upsertPeer(envelope.nodeId, {
+      url: payload.url || null,
+      load: payload.load || {},
+      state: payload.state || {},
+      direction: 'libp2p',
+      peerId: payload.peerId || null,
+    });
+  }
+
+  handleTaskLockEnvelope(envelope) {
+    const verification = this.verify(envelope);
+    if (!verification.ok) {
+      this.logger.warn('Rejected invalid task lock envelope', { reason: verification.reason });
+      this.emit('security:rejected', { reason: verification.reason });
+      return;
+    }
+
+    const payload = envelope.payload || {};
+    if (payload.taskId == null) {
+      return;
+    }
+
+    const lock = {
+      taskId: String(payload.taskId),
+      nodeId: envelope.nodeId,
+      claimedAt: Number(payload.claimedAt) || envelope.timestamp,
+      expiresAt: Number(payload.expiresAt) || Date.now() + this.taskLockTtlMs,
+      correlationId: payload.correlationId || null,
+    };
+
+    this.taskLocks.set(lock.taskId, lock);
+    this.emit('task-lock:claimed', lock);
   }
 
   rejectSocket(socket, reason) {
@@ -450,14 +661,39 @@ class KeeperP2PNetwork extends EventEmitter {
       state: this.getLocalState(),
     });
 
+    this.publishEnvelope(this.topics.discovery, 'keeper:heartbeat', heartbeat);
+  }
+
+  broadcastLibp2pDiscovery() {
+    const envelope = this.sign('peer_discovery', {
+      url: this.publicUrl,
+      load: this.getLocalLoad(),
+      state: this.getLocalState(),
+    });
+    this.publishLibp2p(this.topics.discovery, envelope);
+  }
+
+  publishEnvelope(topic, socketEvent, envelope) {
+    this.publishLibp2p(topic, envelope);
     if (this.io) {
-      this.io.emit('keeper:heartbeat', heartbeat);
+      this.io.emit(socketEvent, envelope);
     }
     this.sockets.forEach((socket) => {
       if (socket.connected) {
-        socket.emit('keeper:heartbeat', heartbeat);
+        socket.emit(socketEvent, envelope);
       }
     });
+  }
+
+  publishLibp2p(topic, envelope) {
+    const pubsub = this.libp2pNode && this.libp2pNode.services && this.libp2pNode.services.pubsub;
+    if (!this.libp2pStarted || !pubsub || typeof pubsub.publish !== 'function') {
+      return false;
+    }
+
+    const encoded = Buffer.from(JSON.stringify(envelope));
+    pubsub.publish(topic, encoded);
+    return true;
   }
 
   pruneStalePeers(now = Date.now()) {
@@ -476,19 +712,32 @@ class KeeperP2PNetwork extends EventEmitter {
       }
       this.sockets.delete(nodeId);
       this.peers.delete(nodeId);
+      this.clearTaskLocksForPeer(nodeId);
       this.emit('peer:stale', peer);
       this.logger.warn('Pruned stale P2P peer', { nodeId });
     });
 
     // Also prune expired bid auction entries (Issue #841)
     this.pruneExpiredBids(now);
+    this.pruneExpiredTaskLocks(now);
 
     return stale;
   }
 
   selectOwnedTasks(taskIds) {
+    this.pruneExpiredTaskLocks();
+    const activeLocks = this.getActiveTaskLocks();
+    const remoteLockedTaskIds = [];
+    const unlockedTaskIds = (taskIds || []).filter((taskId) => {
+      const lock = activeLocks[String(taskId)];
+      if (lock && lock.nodeId !== this.nodeId) {
+        remoteLockedTaskIds.push(taskId);
+        return false;
+      }
+      return true;
+    });
     const selection = assignTasksByRendezvous(
-      taskIds,
+      unlockedTaskIds,
       {
         nodeId: this.nodeId,
         url: this.publicUrl,
@@ -496,11 +745,16 @@ class KeeperP2PNetwork extends EventEmitter {
       },
       this.getHealthyPeers(),
     );
+    remoteLockedTaskIds.forEach((taskId) => {
+      selection.skippedTaskIds.push(taskId);
+      selection.owners[taskId] = activeLocks[String(taskId)].nodeId;
+    });
 
     return {
       shardIndex: 0,
       shardCount: selection.nodes.length || 1,
       shardLabel: `p2p:${this.nodeId}`,
+      activeLocks,
       ...selection,
     };
   }
@@ -515,6 +769,9 @@ class KeeperP2PNetwork extends EventEmitter {
       healthy: this.isHealthy(),
       peerCount: this.peers.size,
       healthyPeerCount: peers.length,
+      libp2pStarted: this.libp2pStarted,
+      transport: this.transport,
+      taskLockCount: this.taskLocks.size,
       peers: peers.map((peer) => ({
         nodeId: peer.nodeId,
         url: peer.url,
@@ -542,23 +799,73 @@ class KeeperP2PNetwork extends EventEmitter {
       await new Promise((resolve) => this.httpServer.close(resolve));
       this.httpServer = null;
     }
+    if (this.libp2pNode && typeof this.libp2pNode.stop === 'function') {
+      await this.libp2pNode.stop();
+    }
 
+    this.libp2pStarted = false;
+    this.libp2pMessageListenerRegistered = false;
     this.started = false;
     this.logger.info('P2P keeper network stopped', { nodeId: this.nodeId });
   }
 
   broadcastTaskClaimIntent(taskId) {
-    // Integrate @libp2p gossipsub protocol into keeper node runtime.
-    // Broadcast task claim intent messages over P2P topic before executing.
-    const intent = this.sign('task_claim_intent', { taskId });
-    if (this.io) {
-      this.io.emit('gossipsub:claim', intent);
+    return this.broadcastTaskLock(taskId);
+  }
+
+  broadcastTaskLock(taskId, metadata = {}) {
+    if (!this.enabled || !this.started) {
+      return null;
     }
-    this.sockets.forEach((socket) => {
-      if (socket.connected) {
-        socket.emit('gossipsub:claim', intent);
+
+    const now = Date.now();
+    const intent = this.sign('task_lock_claimed', {
+      taskId: String(taskId),
+      claimedAt: now,
+      expiresAt: now + this.taskLockTtlMs,
+      correlationId: metadata.correlationId || null,
+    });
+
+    this.handleTaskLockEnvelope(intent);
+    this.publishEnvelope(this.topics.taskLocks, 'keeper:task-lock', intent);
+    return intent;
+  }
+
+  getActiveTaskLocks(now = Date.now()) {
+    this.pruneExpiredTaskLocks(now);
+    const locks = {};
+    this.taskLocks.forEach((lock, taskId) => {
+      locks[taskId] = { ...lock };
+    });
+    return locks;
+  }
+
+  clearTaskLocksForPeer(nodeId) {
+    const released = [];
+    this.taskLocks.forEach((lock, taskId) => {
+      if (lock.nodeId === nodeId) {
+        released.push(taskId);
+        this.taskLocks.delete(taskId);
       }
     });
+    if (released.length > 0) {
+      this.emit('tasks:reassign', { nodeId, taskIds: released });
+    }
+    return released;
+  }
+
+  pruneExpiredTaskLocks(now = Date.now()) {
+    const expired = [];
+    this.taskLocks.forEach((lock, taskId) => {
+      if (lock.expiresAt <= now) {
+        expired.push(taskId);
+        this.taskLocks.delete(taskId);
+      }
+    });
+    if (expired.length > 0) {
+      this.emit('tasks:reassign', { nodeId: null, taskIds: expired });
+    }
+    return expired;
   }
 
   resolveExecutionConflicts(taskId, peersClaims) {
@@ -609,13 +916,10 @@ class KeeperP2PNetwork extends EventEmitter {
     this._recordBid(bid);
 
     if (this.io) {
-      this.io.emit('keeper:bid', bid);
+      this.publishEnvelope(this.topics.bids, 'keeper:bid', bid);
+    } else {
+      this.publishLibp2p(this.topics.bids, bid);
     }
-    this.sockets.forEach((socket) => {
-      if (socket.connected) {
-        socket.emit('keeper:bid', bid);
-      }
-    });
 
     this.logger.debug('Bid broadcast', {
       taskId,
@@ -731,6 +1035,7 @@ module.exports = {
   KeeperP2PNetwork,
   KeeperBidAuction,
   assignTasksByRendezvous,
+  createDefaultLibp2pNode,
   createSignedEnvelope,
   parsePeerList,
   verifySignedEnvelope,


### PR DESCRIPTION
Closes #816

## Summary
- start the keeper P2P network during keeper startup
- add optional libp2p/gossipsub transport support with signed discovery, task-lock, and bid topics
- broadcast task lock claims before enqueueing due tasks
- skip remotely locked tasks and release locks for reassignment when peers go stale or locks expire
- add P2P transport/task-lock config, docs, and tests



## Testing
- npm test -- --runTestsByPath __tests__/p2pNetwork.test.js --coverage=false
- npx eslint src/p2pNetwork.js src/config.js ../keeper/index.js __tests__/p2pNetwork.test.js